### PR TITLE
Instantiate this.adb earlier, so it is not missing in certain steps

### DIFF
--- a/ANDROID_HOME_OLD
+++ b/ANDROID_HOME_OLD
@@ -1,0 +1,1 @@
+/Users/isaac/code/adt-bundle/sdk

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -79,6 +79,9 @@ class AndroidDriver extends BaseDriver {
         log.info(`Chrome-type package and activity are ${pkg} and ${activity}`);
       }
 
+      // set up an instance of ADB
+      this.adb = await ADB.createADB();
+
       if (this.opts.app) {
         // find and copy, or download and unzip an app url or path
         this.opts.app = await this.helpers.configureApp(this.opts.app, APP_EXTENSION);
@@ -117,8 +120,6 @@ class AndroidDriver extends BaseDriver {
 
   async startAndroidSession () {
     log.info(`Starting Android session`);
-    // set up an instance of ADB
-    this.adb = await ADB.createADB();
     // set up the device to run on (real or emulator, etc)
     this.defaultIME = await helpers.initDevice(this.adb, this.opts);
     // Set CompressedLayoutHierarchy on the device based on current settings object

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -32,19 +32,21 @@ describe('driver', () => {
       sandbox.stub(driver, 'checkAppPresent');
       sandbox.stub(driver, 'checkPackagePresent');
       sandbox.stub(driver, 'startAndroidSession');
+      sandbox.stub(ADB, 'createADB');
     });
     afterEach(() => {
+
       sandbox.restore();
     });
-    it('should get java version if non is provided', async () => {
+    it('should get java version if none is provided', async () => {
       await driver.createSession({platformName: 'Android', deviceName: 'device', app: 'some.apk'});
       driver.opts.javaVersion.should.exist;
     });
     it('should get browser package details if browserName is provided', async () => {
-      sandbox.spy(helpers, 'getChromePkg');      
+      sandbox.spy(helpers, 'getChromePkg');
       await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'Chrome'});
       helpers.getChromePkg.calledOnce.should.be.true;
-    });    
+    });
     it('should check an app is present', async () => {
       await driver.createSession({platformName: 'Android', deviceName: 'device', app: 'some.apk'});
       driver.checkAppPresent.calledOnce.should.be.true;


### PR DESCRIPTION
Otherwise in the mobile web flow we get:

```
error: [MJSONWP] Encountered internal error running command: TypeError: Cannot read property 'shell' of undefined
    at AndroidDriver.checkPackagePresent$ (lib/driver.js:219:25)
    at tryCatch (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:294:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:167:17)
    at new Promise (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.promise.js:182:7)
    at AsyncIterator.enqueue (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:166:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:192:12)
    at AndroidDriver.checkPackagePresent (lib/driver.js:217:29)
    at AndroidDriver.createSession$ (lib/driver.js:91:20)
    at tryCatch (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:294:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at run (/Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.promise.js:89:39)
    at /Users/isaac/code/appium-repos/appium/node_modules/appium-android-driver/node_modules/babel-runtime/node_modules/core-js/library/modules/es6.promise.js:100:28
    at doNTCallback0 (node.js:407:9)
    at process._tickCallback (node.js:336:13)
```