### PR TITLE
Defaulting findElorEls to single element

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -8,7 +8,7 @@ let commands = {}, helpers = {}, extensions = {};
 // selector: the actual selector for finding an element
 // mult: multiple elements or just one?
 // context: finding an element from the root context? or starting from another element
-helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
+helpers.findElOrEls = async function (strategy, selector, mult = false, context = '') {
   // throws error if not valid, uses this.locatorStrategies
   this.validateLocatorStrategy(strategy);
 

--- a/test/functional/api-demos/attribute-e2e-specs.js
+++ b/test/functional/api-demos/attribute-e2e-specs.js
@@ -18,7 +18,7 @@ describe('apidemo - attributes', function () {
   before(async () => {
     driver = new AndroidDriver();
     await driver.createSession(defaultCaps);
-    let animation = await driver.findElOrEls('accessibility id', 'Animation', false);
+    let animation = await driver.findElOrEls('accessibility id', 'Animation');
     animationEl = animation.ELEMENT;
   });
   after(async () => {

--- a/test/functional/api-demos/find/by-accessibility-id-e2e-specs.js
+++ b/test/functional/api-demos/find/by-accessibility-id-e2e-specs.js
@@ -22,7 +22,7 @@ describe('Find - accessibility ID', function(){
     await driver.deleteSession();
   });
   it('should find an element by name', async () => {
-    await driver.findElOrEls('accessibility id', 'Animation', false).should.eventually.exist;
+    await driver.findElOrEls('accessibility id', 'Animation').should.eventually.exist;
   });
   it('should return an array of one element if the `multi` param is true', async () => {
     // TODO: this returns an object instead of an array. Investigate.
@@ -30,6 +30,6 @@ describe('Find - accessibility ID', function(){
     //         .should.eventually.have.length(1);
   });
   it('should find an element with a content-desc property containing an apostrophe', async () => {
-    await driver.findElOrEls('accessibility id', "Access'ibility", false).should.eventually.exist;
+    await driver.findElOrEls('accessibility id', "Access'ibility").should.eventually.exist;
   });
 });

--- a/test/functional/api-demos/find/by-uiautomator-e2e-specs.js
+++ b/test/functional/api-demos/find/by-uiautomator-e2e-specs.js
@@ -52,12 +52,12 @@ describe('Find - uiautomator', function () {
       .should.eventually.have.length.at.least(10);
   });
   it('should find an element with an int argument', async () => {
-    let el = await driver.findElOrEls('-android uiautomator', 'new UiSelector().index(0)', false);
+    let el = await driver.findElOrEls('-android uiautomator', 'new UiSelector().index(0)');
     await driver.getName(el.ELEMENT).should.eventually.equal('android.widget.FrameLayout');
   });
   it('should find an element with a string argument', async () => {
     await driver
-      .findElOrEls('-android uiautomator', 'new UiSelector().description("Animation")', false)
+      .findElOrEls('-android uiautomator', 'new UiSelector().description("Animation")')
       .should.eventually.exist;
   });
   it('should find an element with an overloaded method argument', async () => {
@@ -69,7 +69,7 @@ describe('Find - uiautomator', function () {
       .should.eventually.have.length.at.least(10);
   });
   it('should find an element with a long chain of methods', async () => {
-    let el = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true).className(android.widget.TextView).index(1)', false);
+    let el = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true).className(android.widget.TextView).index(1)');
     await driver.getText(el.ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find an element with recursive UiSelectors', async () => {
@@ -110,22 +110,22 @@ describe('Find - uiautomator', function () {
   });
   it('should scroll to, and return elements using UiScrollable', async () => {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0))';
-    let el = await driver.findElOrEls('-android uiautomator', selector, false);
+    let el = await driver.findElOrEls('-android uiautomator', selector);
     await driver.getText(el.ELEMENT).should.eventually.equal('Views');
   });
   it('should allow chaining UiScrollable methods', async () => {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).setMaxSearchSwipes(10).scrollIntoView(new UiSelector().text("Views").instance(0))';
-    let el = await driver.findElOrEls('-android uiautomator', selector, false);
+    let el = await driver.findElOrEls('-android uiautomator', selector);
     await driver.getText(el.ELEMENT).should.eventually.equal('Views');
   });
   it('should allow UiScrollable scrollIntoView', async () => {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0));';
-    let el = await driver.findElOrEls('-android uiautomator', selector, false);
+    let el = await driver.findElOrEls('-android uiautomator', selector);
     await driver.getText(el.ELEMENT).should.eventually.equal('Views');
   });
   it('should error reasonably if a UiScrollable does not return a UiObject', async () => {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).setMaxSearchSwipes(10)';
-    await driver.findElOrEls('-android uiautomator', selector, false)
+    await driver.findElOrEls('-android uiautomator', selector)
       .should.eventually.be.rejectedWith(/resource could not be found/);
   });
 }); 

--- a/test/functional/api-demos/find/by-xpath-e2e-specs.js
+++ b/test/functional/api-demos/find/by-xpath-e2e-specs.js
@@ -24,17 +24,17 @@ describe('Find - xpath', function () {
     await driver.deleteSession();
   });
   it('should throw when matching nothing', async () => {
-    await driver.findElOrEls('xpath', '//whatthat', false).should.eventually.be.rejectedWith(/could not be located/);
+    await driver.findElOrEls('xpath', '//whatthat').should.eventually.be.rejectedWith(/could not be located/);
   });
   it('should throw with status 7 for hierarchy root', async () => {
-    await driver.findElOrEls('xpath', '/*', false).should.eventually.be.rejectedWith(/could not be located/);
+    await driver.findElOrEls('xpath', '/*').should.eventually.be.rejectedWith(/could not be located/);
   });
   it('should find element by type', async () => {
-    let el = await driver.findElOrEls('xpath', `//${atv}`, false);
+    let el = await driver.findElOrEls('xpath', `//${atv}`);
     await driver.getText(el.ELEMENT).should.eventually.equal('API Demos');
   });
   it('should find element by text', async () => {
-    let el = await driver.findElOrEls('xpath', `//${atv}[@text='Accessibility']`, false);
+    let el = await driver.findElOrEls('xpath', `//${atv}[@text='Accessibility']`);
     await driver.getText(el.ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find exactly one element via elementsByXPath', async () => {
@@ -43,11 +43,11 @@ describe('Find - xpath', function () {
     await driver.getText(el[0].ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find element by partial text', async () => {
-    let el = await driver.findElOrEls('xpath', `//${atv}[contains(@text, 'Accessibility')]`, false);
+    let el = await driver.findElOrEls('xpath', `//${atv}[contains(@text, 'Accessibility')]`);
     await driver.getText(el.ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find the last element', async () => {
-    let el = await driver.findElOrEls('xpath', `(//${atv})[last()]`, false);
+    let el = await driver.findElOrEls('xpath', `(//${atv})[last()]`);
     let text = await driver.getText(el.ELEMENT);
     ["OS", "Text", "Views", "Preference"].should.include(text);
   });
@@ -60,7 +60,7 @@ describe('Find - xpath', function () {
   //});
 
   it('should find element by index and embedded desc', async () => {
-    let el = await driver.findElOrEls('xpath', `//${f}//${atv}[5]`, false);
+    let el = await driver.findElOrEls('xpath', `//${f}//${atv}[5]`);
     await driver.getText(el.ELEMENT).should.eventually.equal('Content');
   });
   it('should find all elements', async () => {

--- a/test/functional/api-demos/find/find-basic-e2e-specs.js
+++ b/test/functional/api-demos/find/find-basic-e2e-specs.js
@@ -29,11 +29,11 @@ describe('Find - basic', function () {
     await driver.deleteSession();
   });
   it('should find a single element by content-description', async () => {
-    let el = await driver.findElOrEls('accessibility id', 'Animation', false);
+    let el = await driver.findElOrEls('accessibility id', 'Animation');
     await driver.getText(el.ELEMENT).should.eventually.equal('Animation');
   });
   it('should find an element by class name', async () => {
-    let el = await driver.findElOrEls('class name', 'android.widget.TextView', false);
+    let el = await driver.findElOrEls('class name', 'android.widget.TextView');
     await driver.getText(el.ELEMENT).should.eventually.equal('API Demos');
   });
   it('should find multiple elements by class name', async () => {
@@ -41,7 +41,7 @@ describe('Find - basic', function () {
       .should.eventually.have.length.at.least(10);
   });
   it('should not find an element that doesnt exist', async () => {
-    await driver.findElOrEls('class name', 'blargimarg', false)
+    await driver.findElOrEls('class name', 'blargimarg')
       .should.be.rejectedWith(/could not be located/);
   });
   it('should not find multiple elements that doesnt exist', async () => {
@@ -52,11 +52,11 @@ describe('Find - basic', function () {
     await driver.findElOrEls('class name', '', true).should.be.rejectedWith(/selector/);
   });
   it('should find a single element by string id @skip-android-all', async () => {
-    let el = await driver.findElOrEls('id', 'activity_sample_code', false);
+    let el = await driver.findElOrEls('id', 'activity_sample_code');
     await driver.getText(el.ELEMENT).should.eventually.equal('API Demos');
   });
   it('should find a single element by resource-id', async () => {
-    await driver.findElOrEls('id', `android:id/${singleResourceId}`, false)
+    await driver.findElOrEls('id', `android:id/${singleResourceId}`)
       .should.eventually.exist;
   });
   it('should find multiple elements by resource-id', async () => {
@@ -68,7 +68,7 @@ describe('Find - basic', function () {
       .should.eventually.have.length(1);
   });
   it('should find a single element by resource-id with implicit package', async () => {
-    await driver.findElOrEls('id', singleResourceId, false)
+    await driver.findElOrEls('id', singleResourceId)
       .should.eventually.exist;
   });
   it('should find a single element by resource-id with implicit package', async () => {

--- a/test/functional/api-demos/find/from-el-e2e-specs.js
+++ b/test/functional/api-demos/find/from-el-e2e-specs.js
@@ -24,17 +24,17 @@ describe('Find - from element', function () {
     await driver.deleteSession();
   });
   it('should find a single element by tag name', async () => {
-    let el = await driver.findElOrEls('class name', alv, false);
+    let el = await driver.findElOrEls('class name', alv);
     let innerEl = await driver.findElOrEls('class name', atv, false, el.ELEMENT);
     await driver.getText(innerEl.ELEMENT).should.eventually.equal("Access'ibility");
   });
   it('should find multiple elements by tag name', async () => {
-    let el = await driver.findElOrEls('class name', alv, false);
+    let el = await driver.findElOrEls('class name', alv);
     let innerEl = await driver.findElOrEls('class name', atv, true, el.ELEMENT);
     await driver.getText(innerEl[0].ELEMENT).should.eventually.have.length.above(10);
   });
   it('should not find an element that doesnt exist', async () => {
-    let el = await driver.findElOrEls('class name', alv, false);
+    let el = await driver.findElOrEls('class name', alv);
     await driver.findElOrEls('class name', 'blargimarg', false, el.ELEMENT)
       .should.be.rejectedWith(/could not be located/);
   });

--- a/test/functional/api-demos/find/invalid-strategy-e2e-specs.js
+++ b/test/functional/api-demos/find/invalid-strategy-e2e-specs.js
@@ -22,7 +22,7 @@ describe('Find - invalid strategy', function () {
     await driver.deleteSession();
   });
   it('should not accept -ios uiautomation locator strategy', async () => {
-    await driver.findElOrEls('-ios uiautomation', '.elements()', false)
+    await driver.findElOrEls('-ios uiautomation', '.elements()')
       .should.eventually.be.rejectedWith(/not supported/);
   });
 });

--- a/test/functional/api-demos/notifications-e2e-specs.js
+++ b/test/functional/api-demos/notifications-e2e-specs.js
@@ -24,7 +24,7 @@ describe('apidemo - notifications', function () {
     await driver.deleteSession();
   });
   it('should open the notification shade @skip-ci', async () => {
-    let el = await driver.findElOrEls('accessibility id', ':-|', false);
+    let el = await driver.findElOrEls('accessibility id', ':-|');
     await driver.click(el.ELEMENT);
     await driver.openNotifications();
     await B.delay(500);

--- a/test/functional/api-demos/touch/drag-e2e-specs.js
+++ b/test/functional/api-demos/touch/drag-e2e-specs.js
@@ -24,28 +24,28 @@ describe('apidemo - touch', function () {
   });
   describe('drag', function () {
     it('should drag by element', async () => {
-      let dot3 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_3', false);
-      let dot2 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_2', false);
+      let dot3 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_3');
+      let dot2 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_2');
       let gestures = [
         {options: {element: dot3.ELEMENT}},
         {options: {element: dot2.ELEMENT}}
       ];
       await driver.doTouchDrag(gestures);
-      let results = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_result_text', false);
+      let results = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_result_text');
       await driver.getText(results.ELEMENT).should.eventually.include('Dropped');
     });
     it('should drag by element with an offset', async () => {
       // reset
       await driver.startActivity('io.appium.android.apis', '.view.DragAndDropDemo');
 
-      let dot3 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_3', false);
-      let dot2 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_2', false);
+      let dot3 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_3');
+      let dot2 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_2');
       let gestures = [
         {options: {element: dot3.ELEMENT, x: 5, y: 5}},
         {options: {element: dot2.ELEMENT, x: 5, y: 5}}
       ];
       await driver.doTouchDrag(gestures);
-      let results = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_result_text', false);
+      let results = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_result_text');
       await driver.getText(results.ELEMENT).should.eventually.include('Dropped');
     });
   }); 


### PR DESCRIPTION
@imurchie on second thoughts, I think the benefit from defaulting to false (i.e. requesting a single element) will be outweighed by potential confusion for the user.

The old API had `elementByClassName` and `elementsByClassName`. If these are removed, it might make sense to train the user from the beginning to specify single or multiple elements.

I'd be curious to get your thoughts.