### PR TITLE
Move context switch out to its own method, for subclasses

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -48,12 +48,17 @@ commands.setContext = async function (name) {
     return;
   }
 
-  // Otherwise, we have some options when it comes to webviews. If we want a
+  await this.switchContext(name);
+  this.curContext = name;
+};
+
+helpers.switchContext = async function (name) {
+  // We have some options when it comes to webviews. If we want a
   // Chromedriver webview, we can only control one at a time.
-  if (isChromedriverContext(name)) {
+  if (this.isChromedriverContext(name)) {
     // start proxying commands directly to chromedriver
     await this.startChromedriverProxy(name);
-  } else if (isChromedriverContext(this.curContext)) {
+  } else if (this.isChromedriverContext(this.curContext)) {
     // if we're moving to a non-chromedriver webview, and our current context
     // _is_ a chromedriver webview, if caps recreateChromeDriverSessions is set
     // to true then kill chromedriver session using stopChromedriverProxies or
@@ -67,7 +72,6 @@ commands.setContext = async function (name) {
   } else {
     throw new Error(`Didn't know how to handle switching to context '${name}'`);
   }
-  this.curContext = name;
 };
 
 
@@ -167,14 +171,14 @@ helpers.stopChromedriverProxies = async function () {
   }
 };
 
+helpers.isChromedriverContext = function (viewName) {
+  return viewName.indexOf(WEBVIEW_WIN) !== -1 || viewName === CHROMIUM_WIN;
+};
+
 
 /* --------------------------
  * Internal library functions
  * -------------------------- */
-
-function isChromedriverContext (viewName) {
-  return viewName.indexOf(WEBVIEW_WIN) !== -1 || viewName === CHROMIUM_WIN;
-}
 
 async function setupExistingChromedriver (chromedriver) {
   // check the status by sending a simple window-based command to ChromeDriver

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,5 @@
 import log from './logger';
-import { server as baseServer } from 'appium-express';
+import { default as baseServer } from 'appium-express';
 import { routeConfiguringFunction } from 'mobile-json-wire-protocol';
 import AndroidDriver from './driver';
 

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "appium-android-bootstrap": "^2.2.2",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^1.0.2",
-    "appium-chromedriver": "^2.3.7",
+    "appium-chromedriver": "^2.5.0",
     "appium-express": "^1.0.0",
     "appium-logger": "^2.0.0",
-    "appium-support": "^2.0.6",
+    "appium-support": "^2.0.7",
     "appium-unlock": "0.0.1",
     "asyncbox": "^2.0.4",
     "babel-runtime": "=5.8.24",
@@ -45,7 +45,7 @@
     "lodash": "^3.10.0",
     "mobile-json-wire-protocol": "^1.0.2",
     "source-map-support": "^0.3.1",
-    "teen_process": "^1.2.2",
+    "teen_process": "^1.4.0",
     "temp": "^0.8.3"
   },
   "scripts": {


### PR DESCRIPTION
Move actual switching logic out, so a subclass can override. Needed for Selendroid to work.