### PR TITLE
add test to check if java version parsing works for openjdk

### DIFF
--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -26,6 +26,9 @@ describe('Android Helpers', () => {
     it('should return null if it cannot parse java verstion', () => {
       should.not.exist(helpers.parseJavaVersion('foo bar'));
     });
+    it('parses OpenJDK versioning', function () {
+      helpers.parseJavaVersion('openjdk version 1.8').should.be.equal('1.8');
+    });
   });
 
   describe('getJavaVersion', withMocks({teen_process}, (mocks) => {


### PR DESCRIPTION
Original PR: appium/appium#5532
Helper method is already fully ported.

@imurchie is this test even valid anymore?