### PR TITLE
Fix remote apk path in Windows

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -124,7 +124,7 @@ helpers.getLaunchInfo = async function (adb, opts) {
 };
 
 helpers.getRemoteApkPath = function (localApkMd5) {
-  let remotePath = path.resolve(REMOTE_TEMP_PATH, `${localApkMd5}.apk`);
+  let remotePath = `${REMOTE_TEMP_PATH}/${localApkMd5}.apk`;
   logger.info(`Remote apk path is ${remotePath}`);
   return remotePath;
 };

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -4,7 +4,6 @@ import helpers from '../../lib/android-helpers';
 import ADB from 'appium-adb';
 import { withMocks } from 'appium-test-support';
 import * as teen_process from 'teen_process';
-import path from 'path';
 import { fs } from 'appium-support';
 import { path as settingsApkPath } from 'io.appium.settings';
 import { path as unlockApkPath } from 'appium-unlock';
@@ -142,8 +141,7 @@ describe('Android Helpers', () => {
   }));
   describe('getRemoteApkPath', () => {
     it('should return remote path', () => {
-      helpers.getRemoteApkPath('foo').should.equal(path.resolve(REMOTE_TEMP_PATH,
-        'foo.apk'));
+      helpers.getRemoteApkPath('foo').should.equal(`${REMOTE_TEMP_PATH}/foo.apk`);
     });
   });
   describe('resetApp', withMocks({adb, fs, helpers}, (mocks) => {


### PR DESCRIPTION
In Windows, Appium 1.5 fails when copying the apk file to the Android device:
```  
[MJSONWP] Encountered internal error running command: Error: Error executing adb
Exec. Original error: Command 'D:\\android-sdk\\platform-tools\\adb.exe -s 09e146d60bdbdad8 push C:\\Users\\username\\AppData\\Local\\Temp\\20151030-3012-1k0ss0d\\appium-app.apk C:\\data\\local\\tmp\\bb9dc6b4d478edb5ffbf6dbe1e650f72.apk' exited with code 1{"stdout":"","stderr":"failed to copy 'C:\\Users\\username\\AppData\\Local\\Temp\\20151030-3012-1k0ss0d\\appium-app.apk' to 'C:\\data\\local\\tmp\\bb9dc6b4d478edb5ffbf6dbe1e650f72.apk': Read-only file system\r\n","code":1}
```
The remote apk path should not be created with path.resolve, it's always an Android path.
