### PR TITLE
flexible appPackage, autoWebview logic, Context fix

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -39,7 +39,6 @@ class AndroidDriver extends BaseDriver {
       '-android uiautomator'
     ];
     this.desiredCapConstraints = desiredConstraints;
-    this.curContext = this.defaultContextName();
     this.sessionChromedrivers = {};
     this.jwpProxyActive = false;
     this.jwpProxyAvoid = NO_PROXY;
@@ -72,6 +71,8 @@ class AndroidDriver extends BaseDriver {
       if (!this.opts.javaVersion) {
         this.opts.javaVersion = await helpers.getJavaVersion();
       }
+      
+      this.curContext = this.defaultContextName();
 
       if (this.isChromeSession) {
         log.info("We're going to run a Chrome-based session");

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -84,6 +84,12 @@ class AndroidDriver extends BaseDriver {
       // set up an instance of ADB
       this.adb = await ADB.createADB({javaVersion: this.opts.javaVersion});
 
+      if (this.helpers.isPackageOrBundle(this.opts.app)){
+        // user provided package instead of app for 'app' capability, massage options
+        this.opts.appPackage = this.opts.app;
+        this.opts.app = null;
+      }
+
       if (this.opts.app) {
         // find and copy, or download and unzip an app url or path
         this.opts.app = await this.helpers.configureApp(this.opts.app, APP_EXTENSION);
@@ -106,8 +112,8 @@ class AndroidDriver extends BaseDriver {
   }
 
   get appOnDevice () {
-    return !this.opts.app &&
-           this.helpers.isPackageOrBundle(this.opts.appPackage);
+    return this.helpers.isPackageOrBundle(this.opts.app) || (!this.opts.app &&
+           this.helpers.isPackageOrBundle(this.opts.appPackage));
   }
 
   get isChromeSession () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -159,6 +159,11 @@ class AndroidDriver extends BaseDriver {
         await this.startAUT();
       }
     }
+    if (this.opts.autoWebview) {
+      log.info('Setting auto webview');
+      let viewName = this.defaultWebviewName();
+      await this.setContext(viewName);
+    }
   }
 
   async initAUT () {

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -57,7 +57,7 @@ describe('createSession', function () {
     caps.app = 'foo.apk';
     caps.appPackage = 'io.appium.android.apis';
     caps.appActivity = '.view.SplitTouchView';
-    await driver.createSession(caps).should.eventually.be.rejectedWith(/Could not find app/);
+    await driver.createSession(caps).should.eventually.be.rejectedWith(/Could not find/);
   });
   it('should be able to start session without launching or installing app', async () => {
     let caps = Object.assign({}, defaultCaps);
@@ -92,6 +92,6 @@ describe('createSession', function () {
     caps.app = '';
     caps.appPackage = 'sipa.diordna.muippa.oi';
     caps.appActivity = '.ApiDemos';
-    await driver.createSession(caps).should.eventually.be.rejectedWith(/Could not find package/);
+    await driver.createSession(caps).should.eventually.be.rejectedWith(/Could not find/);
   });
 });

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -39,7 +39,7 @@ describe('driver', () => {
       sandbox.restore();
     });
     it('should get java version if none is provided', async () => {
-      await driver.createSession({platformName: 'Android', deviceName: 'device', app: 'some.apk'});
+      await driver.createSession({platformName: 'Android', deviceName: 'device', app: '/path/to/some.apk'});
       driver.opts.javaVersion.should.exist;
     });
     it('should get browser package details if browserName is provided', async () => {
@@ -48,11 +48,15 @@ describe('driver', () => {
       helpers.getChromePkg.calledOnce.should.be.true;
     });
     it('should check an app is present', async () => {
-      await driver.createSession({platformName: 'Android', deviceName: 'device', app: 'some.apk'});
+      await driver.createSession({platformName: 'Android', deviceName: 'device', app: '/path/to/some.apk'});
       driver.checkAppPresent.calledOnce.should.be.true;
     });
     it('should check a package is present', async () => {
       await driver.createSession({platformName: 'Android', deviceName: 'device', appPackage: 'some.app.package'});
+      driver.checkPackagePresent.calledOnce.should.be.true;
+    });
+    it('should accept a package via the app capability', async () => {
+      await driver.createSession({platformName: 'Android', deviceName: 'device', app: 'some.app.package'});
       driver.checkPackagePresent.calledOnce.should.be.true;
     });
     it('should delete a session on failure', async () => {
@@ -119,7 +123,7 @@ describe('driver', () => {
     });
     it('should not throw an error if caps contain an app, package or valid browser', () => {
       expect(() => {
-        driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', app: 'some.apk'});
+        driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', app: '/path/to/some.apk'});
       }).to.not.throw(Error);
       expect(() => {
         driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', browserName: 'Chrome'});
@@ -130,7 +134,7 @@ describe('driver', () => {
     });
     it('should throw an error if caps contain both an app and browser', () => {
       expect(() => {
-        driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', app: 'some.apk', browserName: 'Chrome'});
+        driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', app: '/path/to/some.apk', browserName: 'Chrome'});
       }).to.throw(/should not include both/);
     });
   });


### PR DESCRIPTION
- appPackage: Backward compatibility - our docs don't suggest that we support this feature but we do in current Appium and our existing e2e tests rely on it.

- autoWebview logic

- context fix: with the additional autoWebview logic, some tests were failing from context related issues, moving the `curContext` to createSession() resolves the issues.
