### PR TITLE
getSession fix: return actual capabilities

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -7,6 +7,7 @@ import { fs } from 'appium-support';
 import { path as unicodeIMEPath } from 'appium-android-ime';
 import { path as settingsApkPath } from 'io.appium.settings';
 import { path as unlockApkPath } from 'appium-unlock';
+import Bootstrap from 'appium-android-bootstrap';
 
 const REMOTE_TEMP_PATH = "/data/local/tmp";
 const REMOTE_INSTALL_TIMEOUT = 90000; // milliseconds
@@ -363,6 +364,8 @@ helpers.getChromePkg = function (browser) {
   }
   return {pkg, activity: act};
 };
+
+helpers.bootstrap = Bootstrap;
 
 export default helpers;
 export { CHROME_BROWSERS };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,7 +1,6 @@
 import { BaseDriver, DeviceSettings } from 'appium-base-driver';
 import ADB from 'appium-adb';
 import Chromedriver from 'appium-chromedriver';
-import Bootstrap from 'appium-android-bootstrap';
 import desiredConstraints from './desired-caps';
 import commands from './commands/index';
 import { setupNewChromedriver } from './commands/context';
@@ -156,7 +155,7 @@ class AndroidDriver extends BaseDriver {
       await this.initAUT();
     }
     // start UiAutomator
-    this.bootstrap = new Bootstrap(DEVICE_PORT, this.opts.websocket);
+    this.bootstrap = new helpers.bootstrap(DEVICE_PORT, this.opts.websocket);
     await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers);
     // handling unexpected shutdown
     this.bootstrap.onUnexpectedShutdown.catch(async (err) => {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -55,9 +55,20 @@ class AndroidDriver extends BaseDriver {
     // if creating a session fails at any point, we teardown everything we
     // set up before throwing the error.
     try {
-
       let sessionId;
       [sessionId] = await super.createSession(caps);
+
+      let serverDetails = {platform: 'LINUX',
+                           webStorageEnabled: false,
+                           takesScreenshot: true,
+                           javascriptEnabled: true,
+                           databaseEnabled: false,
+                           networkConnectionEnabled: true,
+                           locationContextEnabled: false,
+                           warnings: {},
+                           desired: this.caps};
+
+      this.caps = Object.assign(serverDetails, this.caps);
 
       // assigning defaults
       let defaultOpts = {action: "android.intent.action.MAIN",
@@ -130,6 +141,11 @@ class AndroidDriver extends BaseDriver {
     log.info(`Starting Android session`);
     // set up the device to run on (real or emulator, etc)
     this.defaultIME = await helpers.initDevice(this.adb, this.opts);
+
+    // set actual device name & platform version
+    this.caps.deviceName = this.adb.curDeviceId;
+    this.caps.platformVersion = await this.adb.getPlatformVersion();
+
     // Set CompressedLayoutHierarchy on the device based on current settings object
     if (this.opts.ignoreUnimportantViews) {
       await this.settings.update({ignoreUnimportantViews: this.opts.ignoreUnimportantViews});

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -94,4 +94,12 @@ describe('createSession', function () {
     caps.appActivity = '.ApiDemos';
     await driver.createSession(caps).should.eventually.be.rejectedWith(/Could not find/);
   });
+  it('should get updated capabilities', async () => {
+    let caps = Object.assign({}, defaultCaps);
+    caps.appPackage = 'io.appium.android.apis';
+    caps.appActivity = '.view.SplitTouchView';
+    await driver.createSession(caps);
+    let serverCaps = await driver.getSession();
+    serverCaps.takesScreenshot.should.exist;
+  });
 });


### PR DESCRIPTION
## getSession():

With this change we return the same as 1.4.

### 1.4 returns:
![image](https://cloud.githubusercontent.com/assets/4726068/11821341/da21f980-a31d-11e5-8121-86e748439ffd.png)

### 1.5 was returning:
![image](https://cloud.githubusercontent.com/assets/4726068/11821347/e79dc544-a31d-11e5-88b5-9459822d4e59.png)

@imurchie 
