### PR TITLE
getLocationInView/getLocation mapping

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -54,8 +54,12 @@ commands.click = async function (elementId) {
   return await this.bootstrap.sendAction("element:click", {elementId});
 };
 
-commands.getLocationInView = async function (elementId) {
+commands.getLocation = async function (elementId) {
   return await this.bootstrap.sendAction("element:getLocation", {elementId});
+};
+
+commands.getLocationInView = async function (elementId) {
+  return await this.getLocation(elementId);
 };
 
 commands.getSize = async function (elementId) {

--- a/test/functional/commands/attribute-e2e-specs.js
+++ b/test/functional/commands/attribute-e2e-specs.js
@@ -49,7 +49,12 @@ describe('apidemo - attributes', function () {
   it('should be able to find displayed attribute through normal func', async () => {
     await driver.elementDisplayed(animationEl).should.eventually.become(true);
   });
-  it('should be able to get element location', async () => {
+  it('should be able to get element location using getLocation', async () => {
+    let location = await driver.getLocation(animationEl);
+    location.x.should.be.at.least(0);
+    location.y.should.be.at.least(0);
+  });
+  it('should be able to get element location using getLocationInView', async () => {
     let location = await driver.getLocationInView(animationEl);
     location.x.should.be.at.least(0);
     location.y.should.be.at.least(0);


### PR DESCRIPTION
- Replaced getLocationInView with getLocation.
- Mapped getLocationInView to getLocation.

(these changes are consistent with iOS driver - https://github.com/appium/appium-ios-driver/blob/c84609bb7e50c20fbd602e080d1536d762568313/lib/commands/general.js#L58-L60)

Resolves confusion such as https://github.com/appium/appium/issues/5960