### PR TITLE
Use new bootstrap constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 *.log
+.DS_Store

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -159,7 +159,7 @@ class AndroidDriver extends BaseDriver {
       await this.initAUT();
     }
     // start UiAutomator
-    this.bootstrap = new helpers.bootstrap(DEVICE_PORT, this.opts.websocket);
+    this.bootstrap = new helpers.bootstrap(this.adb, DEVICE_PORT, this.opts.websocket);
     await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers);
     // handling unexpected shutdown
     this.bootstrap.onUnexpectedShutdown.catch(async (err) => {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "adm-zip": "^0.4.7",
     "appium-adb": "^2.2.0",
-    "appium-android-bootstrap": "^2.2.3",
+    "appium-android-bootstrap": "^2.3.0",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^1.0.2",
     "appium-chromedriver": "^2.6.0",

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -89,7 +89,7 @@ describe('driver', () => {
     beforeEach(async () => {
       driver = new AndroidDriver();
       driver.adb = new ADB();
-      driver.bootstrap = new helpers.bootstrap();
+      driver.bootstrap = new helpers.bootstrap(driver.adb);
       sandbox.stub(driver, 'stopChromedriverProxies');
       sandbox.stub(driver.adb, 'setIME');
       sandbox.stub(driver.adb, 'forceStop');
@@ -129,7 +129,7 @@ describe('driver', () => {
     beforeEach(async () => {
       driver = new AndroidDriver();
       driver.adb = new ADB();
-      driver.bootstrap = new helpers.bootstrap();
+      driver.bootstrap = new helpers.bootstrap(driver.adb);
       driver.settings = { update: function () {} };
       driver.caps = {};
 


### PR DESCRIPTION
Pass `adb` instance to Bootstrap, so environment for interacting with the device is the same throughout the chain.