### PR TITLE
Allow no metastate to be sent for key code

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -17,11 +17,11 @@ commands.keyevent = async function (keycode, metastate = null) {
   return await this.pressKeyCode(keycode, metastate);
 };
 
-commands.pressKeyCode = async function (keycode, metastate) {
+commands.pressKeyCode = async function (keycode, metastate = null) {
   return await this.bootstrap.sendAction("pressKeyCode", {keycode, metastate});
 };
 
-commands.longPressKeyCode = async function (keycode, metastate) {
+commands.longPressKeyCode = async function (keycode, metastate = null) {
   return await this.bootstrap.sendAction("longPressKeyCode", {keycode, metastate});
 };
 

--- a/test/functional/commands/actions-e2e-specs.js
+++ b/test/functional/commands/actions-e2e-specs.js
@@ -13,10 +13,12 @@ let caps = {
   app: sampleApps('ApiDemos-debug'),
   deviceName: 'Android',
   platformName: 'Android',
+  appPackage: 'io.appium.android.apis',
   appActivity: '.view.TextFields'
 };
 
-describe('replaceValue', function () {
+
+describe('actions', () => {
   before(async () => {
     driver = new AndroidDriver();
     await driver.createSession(caps);
@@ -25,13 +27,34 @@ describe('replaceValue', function () {
     await driver.deleteSession();
   });
 
-  it('should replace existing value in a text field', async () => {
-    let el = _.last(await driver.findElOrEls('class name', 'android.widget.EditText', true));
-    el.should.exist;
-    await driver.setValue('original value', el.ELEMENT);
-    await driver.getText(el.ELEMENT).should.eventually.equal('original value');
+  describe('replaceValue', function () {
+    it('should replace existing value in a text field', async () => {
+      let el = _.last(await driver.findElOrEls('class name', 'android.widget.EditText', true));
+      el.should.exist;
+      await driver.setValue('original value', el.ELEMENT);
+      await driver.getText(el.ELEMENT).should.eventually.equal('original value');
 
-    await driver.replaceValue('replaced value', el.ELEMENT);
-    await driver.getText(el.ELEMENT).should.eventually.equal('replaced value');
+      await driver.replaceValue('replaced value', el.ELEMENT);
+      await driver.getText(el.ELEMENT).should.eventually.equal('replaced value');
+    });
+  });
+
+  describe('key codes', function () {
+    beforeEach(async () => {
+      await driver.startActivity(caps.appPackage, caps.appActivity);
+    });
+
+    it('should press key code 3 without metastate', async () => {
+      await driver.pressKeyCode(3).should.not.be.rejected;
+    });
+    it('should press key code 3 with metastate', async () => {
+      await driver.pressKeyCode(3, 193).should.not.be.rejected;
+    });
+    it('should long press key code 3 without metastate', async () => {
+      await driver.longPressKeyCode(3).should.not.be.rejected;
+    });
+    it('should long press key code 3 with metastate', async () => {
+      await driver.longPressKeyCode(3, 193).should.not.be.rejected;
+    });
   });
 });


### PR DESCRIPTION
When no metastate is sent in, in some cases (notably, the `HOME` key, `3`) the call would fail. So default to `null` rather than passing the `undefined` in.

Resolves https://github.com/appium/appium/issues/6112