### PR TITLE
setting the mock location on the device and android emulator.

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -76,13 +76,10 @@ commands.toggleFlightMode = async function () {
   });
 };
 
-commands.setGeoLocation = async function (location) {
-  /*
-   * TODO: Implement isRealDevice(). This method fails on
-   * real devices, it should throw a NotYetImplementedError
-   */
-  let cmd = `geo fix ${location.longitude} ${location.latitude}`;
-  return await this.adb.sendTelnetCommand(cmd);
+commands.setGeoLocation = async function (location) {    
+   let cmd = ['am', 'startservice', '-e', 'longitude', location.longitude,
+              '-e', 'latitude', location.latitude, 'io.appium.settings/.LocationService'];
+   return await this.adb.shell(cmd);
 };
 
 commands.toggleLocationServices = async function () {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "asyncbox": "^2.0.4",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.32",
-    "io.appium.settings": "^2.0.0",
+    "io.appium.settings": "^2.1.0",
     "lodash": "^3.10.0",
     "mobile-json-wire-protocol": "^1.2.0",
     "source-map-support": "^0.3.1",

--- a/test/functional/commands/geo-location-e2e-specs.js
+++ b/test/functional/commands/geo-location-e2e-specs.js
@@ -1,0 +1,53 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { retryInterval } from 'asyncbox';
+import { AndroidDriver } from '../../../..';
+import sampleApps from 'sample-apps';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+let driver;
+let caps = {
+  app: sampleApps('gpsDemo-debug'),
+  deviceName: 'Android',
+  platformName: 'Android'
+};
+
+describe.skip("geo-location", function () {
+  before(async () => {
+    driver = new AndroidDriver();
+    await driver.createSession(caps);
+  });
+  after(async () => {
+    await driver.deleteSession();
+  });
+
+  it('should set geo location @skip-ci', async () => {
+    let getText = async () => {
+      let els = await driver.findElOrEls('class name', 'android.widget.TextView', true);
+      return await driver.getText(els[1].ELEMENT);
+    };
+
+    let latitude = '27.17';
+    let longitude = '78.04';
+
+    let text = await getText();
+    text.should.not.include(`Latitude: ${latitude}`);
+    text.should.not.include(`Longitude: ${longitude}`);
+
+    await driver.setGeoLocation({latitude, longitude});
+
+    // wait for the text to change
+    await retryInterval(6, 1000, async () => {
+      if (await getText() === 'GPS Tutorial') {
+        throw new Error('Location not set yet. Retry.');
+      }
+    });
+
+    text = await getText();
+    text.should.include(`Latitude: ${latitude}`);
+    text.should.include(`Longitude: ${longitude}`);
+  });
+});


### PR DESCRIPTION
#### Fix: ####
The code fix addresses the issue [https://github.com/appium/appium/issues/4309] on **appium 1.5** to set the Location on the Android Devices and Android Emulators.It is linked with the [appium/io.appium.settings#6] .This feature will work once the settings apk is published to npm.

#### Commit summary: ####

set Location uses Android Service (in the settings apk )is invoked in the case of device.
Need to enable **Allow mock locations** option in the Developer Options in Device/Emulator