### PR TITLE
Keep track of ignoreUnexpectedShutdown in Bootstrap

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -162,7 +162,6 @@ helpers.doKey = async function (key) {
 };
 
 helpers.wrapBootstrapDisconnect = async function (wrapped) {
-  log.debug('Ignoring bootstrap disconnect while operation completes');
   this.bootstrap.ignoreUnexpectedShutdown = true;
   try {
     await wrapped();
@@ -170,7 +169,6 @@ helpers.wrapBootstrapDisconnect = async function (wrapped) {
     await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers, this.acceptSslCerts);
   } finally {
     this.bootstrap.ignoreUnexpectedShutdown = false;
-    log.debug('Operation complete. Re-watching for bootstrap disconnect');
   }
 };
 

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -163,13 +163,13 @@ helpers.doKey = async function (key) {
 
 helpers.wrapBootstrapDisconnect = async function (wrapped) {
   log.debug('Ignoring bootstrap disconnect while operation completes');
-  this.ignoreUnexpectedShutdown = true;
+  this.bootstrap.ignoreUnexpectedShutdown = true;
   try {
     await wrapped();
     await this.adb.restart();
     await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers, this.acceptSslCerts);
   } finally {
-    this.ignoreUnexpectedShutdown = false;
+    this.bootstrap.ignoreUnexpectedShutdown = false;
     log.debug('Operation complete. Re-watching for bootstrap disconnect');
   }
 };

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -43,7 +43,6 @@ class AndroidDriver extends BaseDriver {
                                        this.onSettingsUpdate.bind(this));
     this.chromedriver = null;
     this.apkStrings = {};
-    this.ignoreUnexpectedShutdown = false;
     this.acceptSslCerts = !!opts.acceptSslCerts;
   }
 
@@ -162,7 +161,7 @@ class AndroidDriver extends BaseDriver {
     await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers);
     // handling unexpected shutdown
     this.bootstrap.onUnexpectedShutdown.catch(async (err) => {
-      if (!this.ignoreUnexpectedShutdown) {
+      if (!this.bootstrap.ignoreUnexpectedShutdown) {
         await this.startUnexpectedShutdown(err);
       }
     });


### PR DESCRIPTION
This way Bootstrap can access `ignoreUnexpectedShutdown` when it errors on Windows.

cc) @imurchie 