### PR TITLE
Fix ensureDeviceLocale to work with API 23

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -55,22 +55,39 @@ helpers.prepareEmulator = async function (adb, opts) {
                       avdReadyTimeout);
 };
 
-helpers.ensureDeviceLocale = async function (adb, language, locale) {
+helpers.ensureDeviceLocale = async function (adb, language, country) {
   let haveLanguage = language && typeof language === "string";
-  let haveCountry = locale && typeof locale === "string";
+  let haveCountry = country && typeof country === "string";
   if (!haveLanguage && !haveCountry) {
     return;
   }
-  let curLanguage = await adb.getDeviceLanguage();
-  let country = await adb.getDeviceCountry();
   let changed = false;
-  if (haveLanguage && language !== curLanguage) {
-    await adb.setDeviceLanguage(language);
-    changed = true;
-  }
-  if (haveCountry && locale !== country) {
-    await adb.setDeviceCountry(locale);
-    changed = true;
+  if (await adb.getApiLevel() < 23)
+  {
+    let curLanguage = await adb.getDeviceLanguage();
+    let curCountry = await adb.getDeviceCountry();
+    if (haveLanguage && language !== curLanguage) {
+      await adb.setDeviceLanguage(language);
+      changed = true;
+    }
+    if (haveCountry && country !== curCountry) {
+      await adb.setDeviceCountry(country);
+      changed = true;
+    }
+  } else { //API >= 23
+    let curLocale = await adb.getDeviceLocale();
+    let locale;
+    if (!haveCountry) {
+      locale = language.toLowerCase();
+    } else if (!haveLanguage) {
+      locale = country;
+    } else {
+      locale = language.toLowerCase() + "-" + country.toUpperCase();
+    }
+    if (locale !== curLocale) {
+      await adb.setDeviceLocale(locale);
+      changed = true;
+    }
   }
   if (changed) {
     await adb.reboot();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "adm-zip": "^0.4.7",
-    "appium-adb": "^2.4.2",
+    "appium-adb": "^2.5.0",
     "appium-android-bootstrap": "^2.5.2",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^1.3.0",

--- a/test/functional/android-helper-e2e-specs.js
+++ b/test/functional/android-helper-e2e-specs.js
@@ -21,4 +21,14 @@ describe('android-helpers e2e', () => {
       await adb.isAppInstalled(appPackage).should.eventually.be.true;
     });
   });
+  describe('ensureDeviceLocale', () => {
+    it('should set device language and country', async function () {
+      var adb = await ADB.createADB();
+      await helpers.ensureDeviceLocale(adb, 'fr', 'FR');
+      await adb.getDeviceLanguage().should.eventually.equal('fr');
+      await adb.getDeviceCountry().should.eventually.equal('FR');
+      // cleanup
+      await helpers.ensureDeviceLocale(adb, 'en', 'US');
+    });
+  });
 });

--- a/test/functional/commands/general-e2e-specs.js
+++ b/test/functional/commands/general-e2e-specs.js
@@ -13,61 +13,82 @@ let defaultCaps = {
   platformName: 'Android'
 };
 
-describe('startActivity', function () {
-  before(async () => {
-    driver = new AndroidDriver();
-    await driver.createSession(defaultCaps);
+describe('general', function () {
+  describe('startActivity', function () {
+    before(async () => {
+      driver = new AndroidDriver();
+      await driver.createSession(defaultCaps);
+    });
+    after(async () => {
+      await driver.deleteSession();
+    });
+
+    it('should launch a new package and activity', async () => {
+      let {appPackage, appActivity} = await driver.adb.getFocusedPackageAndActivity();
+      appPackage.should.equal('io.appium.android.apis');
+      appActivity.should.equal('.ApiDemos');
+
+      let startAppPackage = 'io.appium.android.apis';
+      let startAppActivity = '.view.SplitTouchView';
+
+      await driver.startActivity(startAppPackage, startAppActivity);
+
+      let {appPackage: newAppPackage, appActivity: newAppActivity} = await driver.adb.getFocusedPackageAndActivity();
+      newAppPackage.should.equal(startAppPackage);
+      newAppActivity.should.equal(startAppActivity);
+    });
+    it('should be able to launch activity with custom intent parameter category', async () => {
+      let startAppPackage = 'io.appium.android.apis';
+      let startAppActivity = 'io.appium.android.apis.app.HelloWorld';
+      let startIntentCategory = 'appium.android.intent.category.SAMPLE_CODE';
+
+      await driver.startActivity(startAppPackage, startAppActivity, undefined, undefined, startIntentCategory);
+
+      let {appActivity} = await driver.adb.getFocusedPackageAndActivity();
+      appActivity.should.include('HelloWorld');
+    });
+    it('should be able to launch activity with dontStopAppOnReset = true', async () => {
+      let startAppPackage = 'io.appium.android.apis';
+      let startAppActivity = '.os.MorseCode';
+      await driver.startActivity(startAppPackage, startAppActivity,
+                                 startAppPackage, startAppActivity,
+                                 undefined, undefined,
+                                 undefined, undefined,
+                                 true);
+      let {appPackage, appActivity} = await driver.adb.getFocusedPackageAndActivity();
+      appPackage.should.equal(startAppPackage);
+      appActivity.should.equal(startAppActivity);
+    });
+    it('should be able to launch activity with dontStopAppOnReset = false', async () => {
+      let startAppPackage = 'io.appium.android.apis';
+      let startAppActivity = '.os.MorseCode';
+      await driver.startActivity(startAppPackage, startAppActivity,
+                                 startAppPackage, startAppActivity,
+                                 undefined, undefined,
+                                 undefined, undefined,
+                                 false);
+      let {appPackage, appActivity} = await driver.adb.getFocusedPackageAndActivity();
+      appPackage.should.equal(startAppPackage);
+      appActivity.should.equal(startAppActivity);
+    });
   });
-  after(async () => {
-    await driver.deleteSession();
-  });
+  describe('getStrings', function () {
+    before(async () => {
+      driver = new AndroidDriver();
+      let contactCaps = Object.assign({}, defaultCaps, {app: sampleApps('ContactManager')});
+      await driver.createSession(contactCaps);
+    });
+    after(async () => {
+      await driver.deleteSession();
+    });
 
-  it('should launch a new package and activity', async () => {
-    let {appPackage, appActivity} = await driver.adb.getFocusedPackageAndActivity();
-    appPackage.should.equal('io.appium.android.apis');
-    appActivity.should.equal('.ApiDemos');
-
-    let startAppPackage = 'io.appium.android.apis';
-    let startAppActivity = '.view.SplitTouchView';
-
-    await driver.startActivity(startAppPackage, startAppActivity);
-
-    let {appPackage: newAppPackage, appActivity: newAppActivity} = await driver.adb.getFocusedPackageAndActivity();
-    newAppPackage.should.equal(startAppPackage);
-    newAppActivity.should.equal(startAppActivity);
-  });
-  it('should be able to launch activity with custom intent parameter category', async () => {
-    let startAppPackage = 'io.appium.android.apis';
-    let startAppActivity = 'io.appium.android.apis.app.HelloWorld';
-    let startIntentCategory = 'appium.android.intent.category.SAMPLE_CODE';
-
-    await driver.startActivity(startAppPackage, startAppActivity, undefined, undefined, startIntentCategory);
-
-    let {appActivity} = await driver.adb.getFocusedPackageAndActivity();
-    appActivity.should.include('HelloWorld');
-  });
-  it('should be able to launch activity with dontStopAppOnReset = true', async () => {
-    let startAppPackage = 'io.appium.android.apis';
-    let startAppActivity = '.os.MorseCode';
-    await driver.startActivity(startAppPackage, startAppActivity,
-                               startAppPackage, startAppActivity,
-                               undefined, undefined,
-                               undefined, undefined,
-                               true);
-    let {appPackage, appActivity} = await driver.adb.getFocusedPackageAndActivity();
-    appPackage.should.equal(startAppPackage);
-    appActivity.should.equal(startAppActivity);
-  });
-  it('should be able to launch activity with dontStopAppOnReset = false', async () => {
-    let startAppPackage = 'io.appium.android.apis';
-    let startAppActivity = '.os.MorseCode';
-    await driver.startActivity(startAppPackage, startAppActivity,
-                               startAppPackage, startAppActivity,
-                               undefined, undefined,
-                               undefined, undefined,
-                               false);
-    let {appPackage, appActivity} = await driver.adb.getFocusedPackageAndActivity();
-    appPackage.should.equal(startAppPackage);
-    appActivity.should.equal(startAppActivity);
+    it('should return app strings', async () => {
+      let strings = await driver.getStrings('en');
+      strings.save.should.equal('Save');
+    });
+    it('should return app strings for the device language', async () => {
+      let strings = await driver.getStrings();
+      strings.save.should.equal('Save');
+    });
   });
 });

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -64,30 +64,63 @@ describe('Android Helpers', () => {
     });
   }));
   describe('ensureDeviceLocale', withMocks({adb}, (mocks) => {
-    it('should return if language and locale are not passed', async () => {
+    it('should return if language and country are not passed', async () => {
       mocks.adb.expects('getDeviceLanguage').never();
       mocks.adb.expects('getDeviceCountry').never();
+      mocks.adb.expects('getDeviceLocale').never();
       mocks.adb.expects('setDeviceLanguage').never();
       mocks.adb.expects('setDeviceCountry').never();
+      mocks.adb.expects('setDeviceLocale').never();
       mocks.adb.expects('reboot').never();
       await helpers.ensureDeviceLocale(adb);
       mocks.adb.verify();
     });
-    it('should not set language and locale if it does not change', async () => {
+    it('should not set language and country if it does not change when API < 23', async () => {
+      mocks.adb.expects('getApiLevel').returns("18");
       mocks.adb.expects('getDeviceLanguage').returns('en');
       mocks.adb.expects('getDeviceCountry').returns('us');
+      mocks.adb.expects('getDeviceLocale').never();
       mocks.adb.expects('setDeviceLanguage').never();
       mocks.adb.expects('setDeviceCountry').never();
+      mocks.adb.expects('setDeviceLocale').never();
       mocks.adb.expects('reboot').never();
       await helpers.ensureDeviceLocale(adb, 'en', 'us');
       mocks.adb.verify();
     });
-    it('should set language and locale if they are different', async () => {
+    it('should set language and country if they are different when API < 23', async () => {
+      mocks.adb.expects('getApiLevel').returns("18");
       mocks.adb.expects('getDeviceLanguage').returns('fr');
       mocks.adb.expects('getDeviceCountry').returns('FR');
+      mocks.adb.expects('getDeviceLocale').never();
       mocks.adb.expects('setDeviceLanguage').withExactArgs('en')
         .returns("");
       mocks.adb.expects('setDeviceCountry').withExactArgs('us')
+        .returns("");
+      mocks.adb.expects('setDeviceLocale').never();
+      mocks.adb.expects('reboot').returns(null);
+      await helpers.ensureDeviceLocale(adb, 'en', 'us');
+      mocks.adb.verify();
+    });
+    it('should not set locale if it does not change when API = 23', async () => {
+      mocks.adb.expects('getApiLevel').returns("23");
+      mocks.adb.expects('getDeviceLanguage').never();
+      mocks.adb.expects('getDeviceCountry').never();
+      mocks.adb.expects('getDeviceLocale').returns('en-US');
+      mocks.adb.expects('setDeviceLanguage').never();
+      mocks.adb.expects('setDeviceCountry').never();
+      mocks.adb.expects('setDeviceLocale').never();
+      mocks.adb.expects('reboot').never();
+      await helpers.ensureDeviceLocale(adb, 'en', 'us');
+      mocks.adb.verify();
+    });
+    it('should set locale if it is different when API = 23', async () => {
+      mocks.adb.expects('getApiLevel').returns("23");
+      mocks.adb.expects('getDeviceLanguage').never();
+      mocks.adb.expects('getDeviceCountry').never();
+      mocks.adb.expects('getDeviceLocale').returns('fr-FR');
+      mocks.adb.expects('setDeviceLanguage').never();
+      mocks.adb.expects('setDeviceCountry').never();
+      mocks.adb.expects('setDeviceLocale').withExactArgs('en-US')
         .returns("");
       mocks.adb.expects('reboot').returns(null);
       await helpers.ensureDeviceLocale(adb, 'en', 'us');

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -1,6 +1,8 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import AndroidDriver from '../../..';
+import helpers from '../../../lib/android-helpers';
+import { withMocks } from 'appium-test-support';
 
 let driver;
 chai.should();
@@ -24,4 +26,34 @@ describe('General', () => {
       await driver.installApp('non/existent/app.apk').should.be.rejectedWith(/Could not find/);
     });
   });
+  describe('getStrings', withMocks({helpers}, (mocks) => {
+    it('should return app strings', async () => {
+      driver = new AndroidDriver();
+      driver.bootstrap = {};
+      driver.bootstrap.sendAction = function(){ return ''; };
+      mocks.helpers.expects("pushStrings")
+          .returns({'test': 'en_value'});
+      let strings = await driver.getStrings('en');
+      strings.test.should.equal('en_value');
+      mocks.helpers.verify();
+    });
+    it('should return cached app strings for the specified language', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.getDeviceLanguage = function(){ return 'en'; };
+      driver.apkStrings.en = {'test': 'en_value'};
+      driver.apkStrings.fr = {'test': 'fr_value'};
+      let strings = await driver.getStrings('fr');
+      strings.test.should.equal('fr_value');
+    });
+    it('should return cached app strings for the device language', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.getDeviceLanguage = function(){ return 'en'; };
+      driver.apkStrings.en = {'test': 'en_value'};
+      driver.apkStrings.fr = {'test': 'fr_value'};
+      let strings = await driver.getStrings();
+      strings.test.should.equal('en_value');
+    });
+  }));
 });


### PR DESCRIPTION
Android 6.0 (API 23) uses 'persist.sys.locale' instead of 'persist.sys.language' and 'persist.sys.country' properties to store device language settings.
I have modified ensureDeviceLocale method to use setDeviceLanguage/Country or setDeviceLocale, depending on the API level.

This PR requires the new methods added in this appium-adb PR: https://github.com/appium/appium-adb/pull/143
