### PR TITLE
Launch AVD before getting devices

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -106,17 +106,23 @@ helpers.getDeviceInfoFromCaps = async function (opts = {}) {
   let udid = opts.udid;
   let emPort = null;
 
-  logger.info("Retrieving device list");
-  let devices = await adb.getDevicesWithRetry();
-  if (udid) {
-    if (!_.contains(_.pluck(devices, 'udid'), udid)) {
-      logger.errorAndThrow(`Device ${udid} was not in the list ` +
-                           `of connected devices`);
-    }
-    emPort = adb.getPortFromEmulatorString(udid);
+  if (opts.avd) {
+    await helpers.prepareEmulator(adb, opts);
+    udid = adb.curDeviceId;
+    emPort = adb.emulatorPort;
   } else {
-    udid = devices[0].udid;
-    emPort = adb.getPortFromEmulatorString(udid);
+    logger.info("Retrieving device list");
+    let devices = await adb.getDevicesWithRetry();
+    if (udid) {
+      if (!_.contains(_.pluck(devices, 'udid'), udid)) {
+        logger.errorAndThrow(`Device ${udid} was not in the list ` +
+                             `of connected devices`);
+      }
+      emPort = adb.getPortFromEmulatorString(udid);
+    } else {
+      udid = devices[0].udid;
+      emPort = adb.getPortFromEmulatorString(udid);
+    }
   }
   logger.info(`Using device: ${udid}`);
   return {udid, emPort};
@@ -343,10 +349,6 @@ helpers.unlock = async function (adb) {
 };
 
 helpers.initDevice = async function (adb, opts) {
-  if (opts.avd) {
-    await helpers.prepareEmulator(adb, opts);
-  }
-
   await adb.waitForDevice();
 
   await helpers.ensureDeviceLocale(adb, opts.language, opts.locale);

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -140,7 +140,12 @@ describe('Android Helpers', () => {
           },
           getPortFromEmulatorString: () => {
             return 1234;
-          }
+          },
+          getRunningAVD: () => {
+            return {'udid': 'emulator-1234', 'port': 1234};
+          },
+          curDeviceId: 'emulator-1234',
+          emulatorPort: 1234
         };
       });
     });
@@ -167,6 +172,14 @@ describe('Android Helpers', () => {
     });
     it('should get first deviceId and emPort by default', async () => {
       let {udid, emPort} = await helpers.getDeviceInfoFromCaps();
+      udid.should.equal('emulator-1234');
+      emPort.should.equal(1234);
+    });
+    it('should get deviceId and emPort when avd is present', async () => {
+      let caps = {
+        avd: 'AVD_NAME'
+      };
+      let {udid, emPort} = await helpers.getDeviceInfoFromCaps(caps);
       udid.should.equal('emulator-1234');
       emPort.should.equal(1234);
     });


### PR DESCRIPTION
In Appium 1.5, getDeviceInfoFromCaps() fails when avd capability is configured and no device is connected.
I have moved prepareEmulator call from initDevice to getDeviceInfoFromCaps to ensure that the emulator is up before trying to access it.

This PR and https://github.com/appium/appium-adb/pull/145 fix the issue https://github.com/appium/appium/issues/6233