### PR TITLE
Unlock before pushing the app to device and wait to check if screen is unlocked

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import path from 'path';
 import { exec } from 'teen_process';
-import { retry, retryInterval } from 'asyncbox';
+import { retry, retryInterval, sleep } from 'asyncbox';
 import logger from './logger';
 import { fs } from 'appium-support';
 import { path as unicodeIMEPath } from 'appium-android-ime';
@@ -340,6 +340,7 @@ helpers.unlock = async function (adb) {
       category: "android.intent.category.LAUNCHER",
       flags: "0x10200000"
     });
+    await sleep(1000); 
     if (!await adb.isScreenLocked()) {
       logger.debug("Screen unlocked successfully");
     } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -158,6 +158,9 @@ class AndroidDriver extends BaseDriver {
     if (this.opts.ignoreUnimportantViews) {
       await this.settings.update({ignoreUnimportantViews: this.opts.ignoreUnimportantViews});
     }
+    // Let's try to unlock before installing the app
+    // unlock the device
+    await helpers.unlock(this.adb);
     // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
     if (!this.appOnDevice && this.opts.autoLaunch) {
       // set up app under test
@@ -172,8 +175,6 @@ class AndroidDriver extends BaseDriver {
         await this.startUnexpectedShutdown(err);
       }
     });
-    // unlock the device
-    await helpers.unlock(this.adb);
     if (this.isChromeSession) {
       // start a chromedriver session and proxy to it
       await this.startChromeSession();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "appium-express": "^1.2.0",
     "appium-logger": "^2.1.0",
     "appium-support": "^2.0.9",
-    "appium-unlock": "0.0.1",
+    "appium-unlock": "^0.0.2",
     "asyncbox": "^2.0.4",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.32",


### PR DESCRIPTION
Unlocking before pushing the app to device so that we can fail the job if it failed to unlock before installing.
I also added one second after unlock runs to actually check if the screen is unlocked cause it was failing this check when the case was that the unlock app was running and then coming back to the lock screen for some reason. 
With the changes here on the verification of the unlock screen + the changes to send to background the unlock app I was getting no false positives.