### PR TITLE
Move startAUT method so that it is accessible to Selendroid

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -174,6 +174,20 @@ commands.reset = async function () {
   return await this.startAUT();
 };
 
+commands.startAUT = async function () {
+  await this.adb.startApp({
+    pkg: this.opts.appPackage,
+    activity: this.opts.appActivity,
+    action: this.opts.intentAction,
+    category: this.opts.intentCategory,
+    flags: this.opts.intentFlags,
+    waitPkg: this.opts.appWaitPackage,
+    waitActivity: this.opts.appWaitActivity,
+    optionalIntentArguments: this.opts.optionalIntentArguments,
+    stopApp: this.opts.stopAppOnReset || !this.opts.dontStopAppOnReset,
+  });
+};
+
 // we override setUrl to take an android URI which can be used for deep-linking
 // inside an app, similar to starting an intent
 commands.setUrl = async function (uri) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -214,20 +214,6 @@ class AndroidDriver extends BaseDriver {
         this.opts.language, this.adb, this.opts);
   }
 
-  async startAUT () {
-    await this.adb.startApp({
-      pkg: this.opts.appPackage,
-      activity: this.opts.appActivity,
-      action: this.opts.intentAction,
-      category: this.opts.intentCategory,
-      flags: this.opts.intentFlags,
-      waitPkg: this.opts.appWaitPackage,
-      waitActivity: this.opts.appWaitActivity,
-      optionalIntentArguments: this.opts.optionalIntentArguments,
-      stopApp: this.opts.stopAppOnReset || !this.opts.dontStopAppOnReset,
-    });
-  }
-
   async startChromeSession () {
     log.info("Starting a chrome-based browser session");
     let opts = _.cloneDeep(this.opts);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "appium-adb": "^2.5.0",
     "appium-android-bootstrap": "^2.6.0",
     "appium-android-ime": "^2.0.0",
-    "appium-base-driver": "^1.3.0",
+    "appium-base-driver": "^1.4.1",
     "appium-chromedriver": "^2.8.0",
     "appium-express": "^1.2.0",
     "appium-logger": "^2.1.0",
@@ -63,6 +63,6 @@
     "sample-apps": "2.0.3",
     "sinon": "^1.16.1",
     "xmldom": "^0.1.19",
-    "xpath": "0.0.9"
+    "xpath": "0.0.22"
   }
 }


### PR DESCRIPTION
The selendroid driver only pulls methods from `commands`, not those in the `driver` itself.