### PR TITLE
Add cap to not proxy web screenshot

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -98,7 +98,10 @@ let commonCapConstraints = {
   },
   autoLaunch: {
     isBoolean: true
-  }
+  },
+  nativeWebScreenshot: {
+    isBoolean: true
+  },
 };
 
 let uiautomatorCapConstraints = {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -41,7 +41,7 @@ class AndroidDriver extends BaseDriver {
     this.desiredCapConstraints = desiredConstraints;
     this.sessionChromedrivers = {};
     this.jwpProxyActive = false;
-    this.jwpProxyAvoid = NO_PROXY;
+    this.jwpProxyAvoid = _.clone(NO_PROXY);
     this.settings = new DeviceSettings({ignoreUnimportantViews: false},
                                        this.onSettingsUpdate.bind(this));
     this.chromedriver = null;
@@ -100,6 +100,10 @@ class AndroidDriver extends BaseDriver {
         this.opts.appPackage = pkg;
         this.opts.appActivity = activity;
         log.info(`Chrome-type package and activity are ${pkg} and ${activity}`);
+      }
+
+      if (this.opts.nativeWebScreenshot) {
+        this.jwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);
       }
 
       // get device udid for this session

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -91,6 +91,14 @@ describe('driver', () => {
       await driver.createSession({platformName: 'Android', deviceName: 'device', appPackage: 'some.app.package', adbPort: 1111});
       driver.adb.adbPort.should.equal(1111);
     });
+    it('should proxy screenshot if nativeWebScreenshot is off', async () => {
+      await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: false});
+      driver.getProxyAvoidList().should.have.length(8);
+    });
+    it('should not proxy screenshot if nativeWebScreenshot is on', async () => {
+      await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: true});
+      driver.getProxyAvoidList().should.have.length(9);
+    });
   });
   describe('deleteSession', () => {
     beforeEach(async () => {


### PR DESCRIPTION
Add `nativeWebScreenshot` desired capability that, when set, adds screenshot path to the proxy avoid list, so native screenshot is done.

Android driver portion of https://github.com/appium/appium/issues/6425