### PR TITLE
Remove restrictions on browserName and combining with app capability for Grid

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -1,5 +1,3 @@
-import { CHROME_BROWSERS } from './android-helpers';
-
 let commonCapConstraints = {
   platformName: {
     isString: true,
@@ -106,8 +104,7 @@ let commonCapConstraints = {
 
 let uiautomatorCapConstraints = {
   browserName: {
-    isString: true,
-    inclusion: CHROME_BROWSERS
+    isString: true
   },
   enablePerformanceLogging: {
     isBoolean: true

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -317,10 +317,11 @@ class AndroidDriver extends BaseDriver {
       let msg = 'The desired capabilities must include either an app, package or browser';
       log.errorAndThrow(msg);
     }
-    // make sure that the capabilities don't have both `app` and `browser`
+    // warn if the capabilities have both `app` and `browser, although this
+    // is common with selenium grid
     if (caps.browserName && caps.app) {
-      let msg = 'The desired capabilities should not include both an app and a browser';
-      log.errorAndThrow(msg);
+      let msg = 'The desired capabilities should generally not include both an app and a browser';
+      log.warn(msg);
     }
   }
 

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -47,11 +47,6 @@ describe('createSession', function () {
     caps.app = '';
     await driver.createSession(caps).should.eventually.be.rejectedWith(/include/);
   });
-  it('should error out if both an app and a browser is defined', async () => {
-    let caps = Object.assign({}, defaultCaps);
-    caps.browserName = 'Chrome';
-    await driver.createSession(caps).should.eventually.be.rejectedWith(/both/);
-  });
   it('should error out for invalid app path', async () => {
     let caps = Object.assign({}, defaultCaps);
     caps.app = 'foo.apk';

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -244,7 +244,7 @@ describe('driver', () => {
       }).to.throw(/must include/);
       expect(() => {
         driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', browserName: 'Netscape Navigator'});
-      }).to.throw(/Netscape Navigator/);
+      }).to.throw(/must include/);
     });
     it('should not throw an error if caps contain an app, package or valid browser', () => {
       expect(() => {
@@ -257,15 +257,15 @@ describe('driver', () => {
         driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', appPackage: 'some.app.package'});
       }).to.not.throw(/must include/);
     });
-    it('should not be sentivie to platform name casing', () => {
+    it('should not be sensitive to platform name casing', () => {
       expect(() => {
         driver.validateDesiredCaps({platformName: 'AnDrOiD', deviceName: 'device', app: '/path/to/some.apk'});
       }).to.not.throw(Error);
     });
-    it('should throw an error if caps contain both an app and browser', () => {
+    it('should not throw an error if caps contain both an app and browser, for grid compatibility', () => {
       expect(() => {
-        driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', app: '/path/to/some.apk', browserName: 'Chrome'});
-      }).to.throw(/should not include both/);
+        driver.validateDesiredCaps({platformName: 'Android', deviceName: 'device', app: '/path/to/some.apk', browserName: 'iPhone'});
+      }).to.not.throw(Error);
     });
   });
   describe('proxying', () => {


### PR DESCRIPTION
This is the android implementation of appium/appium-ios-driver#127, which has already been merged.

#19 looks to have added these particular restrictions. `browserName` needs to be open since that's how the Selenium Grid matches nodes. See appium/appium-ios-driver#127 for more details.

This PR also had to remove the specific check for providing `browserName` and `app` together, which was not necessary for the iOS PR. I'm not positive what the rationale for this was, I'm assuming to try and catch mistakenly providing both. However providing both still prefers `app` with a custom `browserName` (which is necessary for the Grid). Another alternative would be to check if this server is being run as a Grid node, to do this conditionally. Perhaps @jlipps can comment since he added these changes?

I've left `CHROME_BROWSERS` in `android-helpers.js` since it appears to be used by other things.

I've tested these changes with Appium v1.5 locally and with Selenium Grid 2.52.0.