### PR TITLE
Auto-select devices based on platform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ await driver.setOrientation('LANDSCAPE');
 console.log(await driver.getOrientation()); // -> 'LANDSCAPE'
 ```
 
+### Specifying and selecting devices/emulators
+The driver will attempt to connect to a device/emulator based on these properties in the `desiredCapabilities` object:
+
+1. `avd`: Launch or connect to the emulator with the given name.
+1. `udid`: Connect to the device with the given UDID.
+1. `platformVersion`: Connect to the first device or active emulator whose OS begins with the desired OS. This means `platformVersion: 5` will take the first `5x` device from the output of `adb devices` if there are multiple available.
+
+If none of these capabilities are given, the driver will connect to the first device or active emulator returned from the output of `adb devices`.
+
+If more than one of these capabilities are given, the driver will only use first the capability in the order above. That is, `avd` takes priority over `udid`, which takes priority over `platformVersion`.
+
 ## Commands
 |          Command           |
 |----------------------------|

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -107,24 +107,63 @@ helpers.getDeviceInfoFromCaps = async function (opts = {}) {
   let udid = opts.udid;
   let emPort = null;
 
+  // a specific avd name was given. try to initialize with that
   if (opts.avd) {
     await helpers.prepareEmulator(adb, opts);
     udid = adb.curDeviceId;
     emPort = adb.emulatorPort;
   } else {
+    // no avd given. lets try whatever's plugged in devices/emulators
     logger.info("Retrieving device list");
     let devices = await adb.getDevicesWithRetry();
+
+    // udid was given, lets try to init with that device
     if (udid) {
       if (!_.contains(_.pluck(devices, 'udid'), udid)) {
         logger.errorAndThrow(`Device ${udid} was not in the list ` +
                              `of connected devices`);
       }
       emPort = adb.getPortFromEmulatorString(udid);
+    } else if (!!opts.platformVersion) {
+      // a platform version was given. lets try to find a device with the same os
+      logger.info(`Looking for a device with Android ${opts.platformVersion}`);
+
+      // in case we fail to find something, give the user a useful log that has
+      // the device udids and os versions so they know what's available
+      let availDevicesStr = [];
+
+      // first try started devices/emulators
+      for (let device of devices) {
+        // direct adb calls to the specific device
+        await adb.setDeviceId(device.udid);
+        let deviceOS = await adb.getPlatformVersion();
+
+        // build up our info string of available devices as we iterate
+        availDevicesStr.push(`${device.udid} (${deviceOS})`);
+
+        // we do a begins with check for implied wildcard matching
+        // eg: 4 matches 4.1, 4.0, 4.1.3-samsung, etc
+        if (deviceOS.indexOf(opts.platformVersion) === 0) {
+          udid = device.udid;
+          break;
+        }
+      }
+
+      // we couldn't find anything! quit
+      if (!udid) {
+        logger.errorAndThrow(`Unable to find an active device or emulator ` +
+                             `with OS ${opts.platformVersion}. The following ` +
+                             `are available: ` + availDevicesStr.join(', '));
+      }
+
+      emPort = adb.getPortFromEmulatorString(udid);
     } else {
+      // a udid was not given, grab the first device we see
       udid = devices[0].udid;
       emPort = adb.getPortFromEmulatorString(udid);
     }
   }
+
   logger.info(`Using device: ${udid}`);
   return {udid, emPort};
 };


### PR DESCRIPTION
Here's a draft implementation for appium/appium#6473.

Tested with an Android 6.0 device and a 4.0 emulator running.

Spun up an Appium instance from the Java client with PLATFORM_VERSION = 4 and got the emulator. 6 got my phone. 5 got nothing and the server returned an error response and remained online.

Let me know what you think. Once we have quorum I'll add tests.