### PR TITLE
Make sure ignoreUnimportantViews cap gets passed through

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -166,10 +166,6 @@ class AndroidDriver extends BaseDriver {
     this.caps.deviceName = this.adb.curDeviceId;
     this.caps.platformVersion = await this.adb.getPlatformVersion();
 
-    // Set CompressedLayoutHierarchy on the device based on current settings object
-    if (this.opts.ignoreUnimportantViews) {
-      await this.settings.update({ignoreUnimportantViews: this.opts.ignoreUnimportantViews});
-    }
     // Let's try to unlock before installing the app
     // unlock the device
     await helpers.unlock(this.adb);
@@ -187,6 +183,13 @@ class AndroidDriver extends BaseDriver {
         await this.startUnexpectedShutdown(err);
       }
     });
+
+    // Set CompressedLayoutHierarchy on the device based on current settings object
+    // this has to happen _after_ bootstrap is initialized
+    if (this.opts.ignoreUnimportantViews) {
+      await this.settings.update({ignoreUnimportantViews: this.opts.ignoreUnimportantViews});
+    }
+
     if (this.isChromeSession) {
       // start a chromedriver session and proxy to it
       await this.startChromeSession();

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -233,6 +233,13 @@ describe('driver', () => {
       driver.defaultWebviewName.calledOnce.should.be.false;
       driver.setContext.calledOnce.should.be.false;
     });
+    it('should set ignoreUnimportantViews cap', async () => {
+      driver.opts.ignoreUnimportantViews = true;
+
+      await driver.startAndroidSession();
+      driver.settings.update.calledOnce.should.be.true;
+      driver.settings.update.firstCall.args[0].ignoreUnimportantViews.should.be.true;
+    });
   });
   describe('validateDesiredCaps', () => {
     before(() => {


### PR DESCRIPTION
If we try to set the cap before initializing bootstrap then we get an error when trying to call a method on undefined.