### PR TITLE
Further de-flaking unlock

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import path from 'path';
 import { exec } from 'teen_process';
-import { retry, retryInterval, sleep } from 'asyncbox';
+import { retry, retryInterval } from 'asyncbox';
 import logger from './logger';
 import { fs } from 'appium-support';
 import { path as unicodeIMEPath } from 'appium-android-ime';
@@ -373,19 +373,30 @@ helpers.unlock = async function (adb) {
 
   await retryInterval(10, 1000, async () => {
     logger.debug("Screen is locked, trying to unlock");
-    await adb.startApp({
+
+    // first manually stop the unlock activity
+    await adb.forceStop('io.appium.unlock');
+
+    // then start the app twice, as once is flakey
+    let startOpts = {
       pkg: "io.appium.unlock",
       activity: ".Unlock",
       action: "android.intent.action.MAIN",
       category: "android.intent.category.LAUNCHER",
-      flags: "0x10200000"
+      flags: "0x10200000",
+      stopApp: false
+    };
+    await adb.startApp(startOpts);
+    await adb.startApp(startOpts);
+
+    // check if it worked, twice
+    await retryInterval(2, 1000, async () => {
+      if (!await adb.isScreenLocked()) {
+        logger.debug("Screen unlocked successfully");
+      } else {
+        throw new Error("Screen did not unlock successfully, retrying");
+      }
     });
-    await sleep(1000);
-    if (!await adb.isScreenLocked()) {
-      logger.debug("Screen unlocked successfully");
-    } else {
-      throw new Error("Screen did not unlock successfully, retrying");
-    }
   });
 };
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -297,6 +297,7 @@ class AndroidDriver extends BaseDriver {
       if (!this.isChromeSession) {
         await this.adb.forceStop(this.opts.appPackage);
       }
+      await this.adb.forceStop('io.appium.unlock');
       await this.adb.goToHome();
       if (this.opts.fullReset && !this.opts.skipUninstall && !this.appOnDevice) {
         await this.adb.uninstallApk(this.opts.appPackage);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "appium-chromedriver": "^2.9.0",
     "appium-logger": "^2.1.0",
     "appium-support": "^2.0.9",
-    "appium-unlock": "^0.0.2",
+    "appium-unlock": "^0.1.0",
     "asyncbox": "^2.0.4",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.32",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -391,7 +391,8 @@ describe('Android Helpers', () => {
     it('should start unlock app', async () => {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
       mocks.adb.expects('isScreenLocked').returns(false);
-      mocks.adb.expects('startApp').once().returns('');
+      mocks.adb.expects('forceStop').once().returns('');
+      mocks.adb.expects('startApp').twice().returns('');
       await helpers.unlock(adb);
       mocks.adb.verify();
     });

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -132,6 +132,11 @@ describe('driver', () => {
     });
     it('should force stop non-Chrome sessions', async () => {
       await driver.deleteSession();
+      driver.adb.forceStop.calledTwice.should.be.true;
+    });
+    it('should force stop unlocker in Chrome sessions', async () => {
+      driver.opts.browserName = 'Chrome';
+      await driver.deleteSession();
       driver.adb.forceStop.calledOnce.should.be.true;
     });
     it('should uninstall APK if required', async () => {


### PR DESCRIPTION
Through the research of @nghiadhd, it seems that there is a way to make unlocking Android devices less flakey. Essentially (1) manually stop the unlock helper, (2) start the unlock helper twice in succession. Locally the app unlocks consistently with this.

See https://github.com/appium/appium-android-driver/issues/146