### PR TITLE
Add device name to session information

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -162,8 +162,9 @@ class AndroidDriver extends BaseDriver {
     // set up the device to run on (real or emulator, etc)
     this.defaultIME = await helpers.initDevice(this.adb, this.opts);
 
-    // set actual device name & platform version
+    // set actual device name, udid & platform version
     this.caps.deviceName = this.adb.curDeviceId;
+    this.caps.deviceUDID = this.opts.udid;
     this.caps.platformVersion = await this.adb.getPlatformVersion();
 
     // Let's try to unlock before installing the app
@@ -218,7 +219,8 @@ class AndroidDriver extends BaseDriver {
 
 
   async initAUT () {
-    // populate appPackage, appActivity, appWaitPackage, appWaitActivity
+    // populate appPackage, appActivity, appWaitPackage, appWaitActivity,
+    // and the device being used
     // in the opts and caps (so it gets back to the user on session creation)
     let launchInfo = await helpers.getLaunchInfo(this.adb, this.opts);
     Object.assign(this.opts, launchInfo);

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -97,6 +97,18 @@ describe('createSession', function () {
     let serverCaps = await driver.getSession();
     serverCaps.takesScreenshot.should.exist;
   });
+  it('should get device name and udid in session details', async () => {
+    let caps = Object.assign({}, defaultCaps);
+    caps.appPackage = 'io.appium.android.apis';
+    caps.appActivity = '.view.SplitTouchView';
+    let session = await driver.createSession(caps);
+    session[1].deviceName.should.exist;
+    session[1].deviceUDID.should.exist;
+
+    let serverCaps = await driver.getSession();
+    serverCaps.deviceName.should.exist;
+    serverCaps.deviceUDID.should.exist;
+  });
 });
 
 describe('close', function () {


### PR DESCRIPTION
It is possible that you might want to know what the device name is that is actually running a test (see https://github.com/appium/appium/issues/6550), so add that to the caps/opts so they can be retrieved through `getSession`.