### PR TITLE
Honor reset without the app capability

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -171,7 +171,7 @@ class AndroidDriver extends BaseDriver {
     // unlock the device
     await helpers.unlock(this.adb);
     // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
-    if (!this.appOnDevice && this.opts.autoLaunch) {
+    if (this.opts.autoLaunch) {
       // set up app under test
       await this.initAUT();
     }
@@ -225,13 +225,19 @@ class AndroidDriver extends BaseDriver {
     let launchInfo = await helpers.getLaunchInfo(this.adb, this.opts);
     Object.assign(this.opts, launchInfo);
     Object.assign(this.caps, launchInfo);
-    if (!this.opts.skipUninstall) {
-      await this.adb.uninstallApk(this.opts.appPackage);
-    }
     // install app
     if (!this.opts.app) {
+      if (this.opts.fullReset) {
+        log.errorAndThrow('Full reset requires an app capability, use fastReset if app is not provided');
+      }
       log.debug('No app capability. Assuming it is already on the device');
+      if (this.opts.fastReset) {
+        await helpers.resetApp(this.adb, this.opts.app, this.opts.appPackage, this.opts.fastReset);
+      }
       return;
+    }
+    if (!this.opts.skipUninstall) {
+      await this.adb.uninstallApk(this.opts.appPackage);
     }
     await helpers.installApkRemotely(this.adb, this.opts);
     this.apkStrings[this.opts.language] = await helpers.pushStrings(

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -26,6 +26,31 @@ describe('General', () => {
       await driver.installApp('non/existent/app.apk').should.be.rejectedWith(/Could not find/);
     });
   });
+  describe('Run installed App', withMocks({helpers}, (mocks) => {
+    it('should throw error if run with full reset', async () => {
+      driver = new AndroidDriver();
+      driver.opts = {appPackage: "app.package", appActivity: "act", fullReset: true};
+      driver.caps = {};
+      await driver.initAUT().should.be.rejectedWith(/Full reset requires an app capability/);
+    });
+    it('should reset if run with fast reset', async () => {
+      driver = new AndroidDriver();
+      driver.opts = {appPackage: "app.package", appActivity: "act", fullReset: false, fastReset: true};
+      driver.caps = {};
+      driver.adb = "mock_adb";
+      mocks.helpers.expects("resetApp").withExactArgs("mock_adb", undefined, "app.package", true);
+      await driver.initAUT();
+      mocks.helpers.verify();
+    });
+    it('should keep data if run without reset', async () => {
+      driver = new AndroidDriver();
+      driver.opts = {appPackage: "app.package", appActivity: "act", fullReset: false, fastReset: false};
+      driver.caps = {};
+      mocks.helpers.expects("resetApp").never();
+      await driver.initAUT();
+      mocks.helpers.verify();
+    });
+  }));
   describe('getStrings', withMocks({helpers}, (mocks) => {
     it('should return app strings', async () => {
       driver = new AndroidDriver();


### PR DESCRIPTION
Fixes #157: Don't ignore reset capability when appActivity/appPackage are used instead of app.