### PR TITLE
Replace constant REMOTE_INSTALL_TIMEOUT with androidInstallTimeout capability

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -215,7 +215,7 @@ helpers.getRemoteApkPath = function (localApkMd5) {
   return remotePath;
 };
 
-helpers.resetApp = async function (adb, localApkPath, pkg, fastReset) {
+helpers.resetApp = async function (adb, localApkPath, pkg, fastReset, androidInstallTimeout = REMOTE_INSTALL_TIMEOUT) {
   if (fastReset) {
     logger.debug("Running fast reset (stop and clear)");
     await adb.stopAndClear(pkg);
@@ -226,12 +226,12 @@ helpers.resetApp = async function (adb, localApkPath, pkg, fastReset) {
     if (!await adb.fileExists(remotePath)) {
       throw new Error("Can't run slow reset without a remote apk!");
     }
-    await helpers.reinstallRemoteApk(adb, localApkPath, pkg, remotePath);
+    await helpers.reinstallRemoteApk(adb, localApkPath, pkg, remotePath, androidInstallTimeout);
   }
 };
 
 helpers.reinstallRemoteApk = async function (adb, localApkPath, pkg,
-                                             remotePath, tries = 2) {
+                                             remotePath, androidInstallTimeout, tries = 2) {
   await retry(tries, async () => {
     try {
       // first do an uninstall of the package to make sure it's not there
@@ -240,7 +240,7 @@ helpers.reinstallRemoteApk = async function (adb, localApkPath, pkg,
       logger.warn("Uninstalling remote APK failed, maybe it wasn't installed");
     }
     try {
-      await adb.installFromDevicePath(remotePath, {timeout: 90000});
+      await adb.installFromDevicePath(remotePath, {timeout: androidInstallTimeout});
     } catch (e) {
       logger.warn("Installing remote APK failed, going to uninstall and try " +
                   "again");
@@ -253,8 +253,8 @@ helpers.reinstallRemoteApk = async function (adb, localApkPath, pkg,
   });
 };
 
-helpers.installApkRemotely = async function (adb, localApkPath, pkg, fastReset) {
-  let installTimeout = REMOTE_INSTALL_TIMEOUT;
+helpers.installApkRemotely = async function (adb, opts) {
+  let {localApkPath, pkg, fastReset, androidInstallTimeout} = opts;
 
   let apkMd5 = await fs.md5(localApkPath);
   let remotePath = await helpers.getRemoteApkPath(apkMd5, localApkPath);
@@ -264,7 +264,7 @@ helpers.installApkRemotely = async function (adb, localApkPath, pkg, fastReset) 
 
   if (installed && remoteApkExists && fastReset) {
     logger.info("Apk is already on remote and installed, resetting");
-    await helpers.resetApp(adb, localApkPath, pkg, fastReset);
+    await helpers.resetApp(adb, localApkPath, pkg, fastReset, androidInstallTimeout);
   } else if (!installed || (!remoteApkExists && fastReset)) {
     if (!installed) {
       logger.info("Apk is not yet installed");
@@ -277,14 +277,14 @@ helpers.installApkRemotely = async function (adb, localApkPath, pkg, fastReset) 
     await helpers.removeRemoteApks(adb, [apkMd5]);
     if (!remoteApkExists) {
       // push from local to remote
-      logger.info(`Pushing ${pkg} to device. Will wait up to ${installTimeout} ` +
+      logger.info(`Pushing ${pkg} to device. Will wait up to ${androidInstallTimeout} ` +
                   `milliseconds before aborting`);
-      await adb.push(localApkPath, remotePath, {timeout: installTimeout});
+      await adb.push(localApkPath, remotePath, {timeout: androidInstallTimeout});
     }
 
     // Next, install from the remote path. This can be flakey. If it doesn't
     // work, clear out any cached apks, re-push from local, and try again
-    await helpers.reinstallRemoteApk(adb, localApkPath, pkg, remotePath);
+    await helpers.reinstallRemoteApk(adb, localApkPath, pkg, remotePath, androidInstallTimeout);
   }
 };
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -31,6 +31,9 @@ let commonCapConstraints = {
   androidDeviceSocket: {
     isString: true
   },
+  androidInstallTimeout: {
+    isNumber: true
+  },
   adbPort: {
     isNumber: true
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -233,7 +233,7 @@ class AndroidDriver extends BaseDriver {
       log.debug('No app capability. Assuming it is already on the device');
       return;
     }
-    await helpers.installApkRemotely(this.adb, this.opts.app, this.opts.appPackage, this.opts.fastReset);
+    await helpers.installApkRemotely(this.adb, this.opts);
     this.apkStrings[this.opts.language] = await helpers.pushStrings(
         this.opts.language, this.adb, this.opts);
   }

--- a/test/functional/android-helper-e2e-specs.js
+++ b/test/functional/android-helper-e2e-specs.js
@@ -4,8 +4,11 @@ import helpers from '../../lib/android-helpers';
 import sampleApps from 'sample-apps';
 import ADB from 'appium-adb';
 
-let apiDemos = sampleApps('ApiDemos-debug');
-let appPackage = 'io.appium.android.apis';
+let opts = {
+  localApkPath : sampleApps('ApiDemos-debug'),
+  pkg : 'io.appium.android.apis',
+  androidInstallTimeout : 90000
+};
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -15,10 +18,10 @@ describe('android-helpers e2e', () => {
     it('installs an apk by pushing it to the device then installing it from within', async function () {
       this.timeout(15000);
       var adb = await ADB.createADB();
-      await adb.uninstallApk(appPackage);
-      await adb.isAppInstalled(appPackage).should.eventually.be.false;
-      await helpers.installApkRemotely(adb, apiDemos, appPackage);
-      await adb.isAppInstalled(appPackage).should.eventually.be.true;
+      await adb.uninstallApk(opts.pkg);
+      await adb.isAppInstalled(opts.pkg).should.eventually.be.false;
+      await helpers.installApkRemotely(adb, opts);
+      await adb.isAppInstalled(opts.pkg).should.eventually.be.true;
     });
   });
   describe('ensureDeviceLocale', () => {


### PR DESCRIPTION
Proposed change in android driver to address appium issue of adb install timeout value hardcoded.
ref: https://github.com/appium/appium-adb/issues/147

My proposal to fix is to add a new capability to appium "--adb-install-timeout"

This PR has updated and passed tests
