### PR TITLE
installApkRemotely to parse correct capabilities from opts

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -254,17 +254,17 @@ helpers.reinstallRemoteApk = async function (adb, localApkPath, pkg,
 };
 
 helpers.installApkRemotely = async function (adb, opts) {
-  let {localApkPath, pkg, fastReset, androidInstallTimeout} = opts;
+  let {app, appPackage, fastReset, androidInstallTimeout} = opts;
 
-  let apkMd5 = await fs.md5(localApkPath);
-  let remotePath = await helpers.getRemoteApkPath(apkMd5, localApkPath);
+  let apkMd5 = await fs.md5(app);
+  let remotePath = await helpers.getRemoteApkPath(apkMd5, app);
   let remoteApkExists = await adb.fileExists(remotePath);
   logger.debug("Checking if app is installed");
-  let installed = await adb.isAppInstalled(pkg);
+  let installed = await adb.isAppInstalled(appPackage);
 
   if (installed && remoteApkExists && fastReset) {
     logger.info("Apk is already on remote and installed, resetting");
-    await helpers.resetApp(adb, localApkPath, pkg, fastReset, androidInstallTimeout);
+    await helpers.resetApp(adb, app, appPackage, fastReset, androidInstallTimeout);
   } else if (!installed || (!remoteApkExists && fastReset)) {
     if (!installed) {
       logger.info("Apk is not yet installed");
@@ -277,14 +277,14 @@ helpers.installApkRemotely = async function (adb, opts) {
     await helpers.removeRemoteApks(adb, [apkMd5]);
     if (!remoteApkExists) {
       // push from local to remote
-      logger.info(`Pushing ${pkg} to device. Will wait up to ${androidInstallTimeout} ` +
+      logger.info(`Pushing ${appPackage} to device. Will wait up to ${androidInstallTimeout} ` +
                   `milliseconds before aborting`);
-      await adb.push(localApkPath, remotePath, {timeout: androidInstallTimeout});
+      await adb.push(app, remotePath, {timeout: androidInstallTimeout});
     }
 
     // Next, install from the remote path. This can be flakey. If it doesn't
     // work, clear out any cached apks, re-push from local, and try again
-    await helpers.reinstallRemoteApk(adb, localApkPath, pkg, remotePath, androidInstallTimeout);
+    await helpers.reinstallRemoteApk(adb, app, appPackage, remotePath, androidInstallTimeout);
   }
 };
 

--- a/test/functional/android-helper-e2e-specs.js
+++ b/test/functional/android-helper-e2e-specs.js
@@ -5,8 +5,8 @@ import sampleApps from 'sample-apps';
 import ADB from 'appium-adb';
 
 let opts = {
-  localApkPath : sampleApps('ApiDemos-debug'),
-  pkg : 'io.appium.android.apis',
+  app : sampleApps('ApiDemos-debug'),
+  appPackage : 'io.appium.android.apis',
   androidInstallTimeout : 90000
 };
 
@@ -18,10 +18,10 @@ describe('android-helpers e2e', () => {
     it('installs an apk by pushing it to the device then installing it from within', async function () {
       this.timeout(15000);
       var adb = await ADB.createADB();
-      await adb.uninstallApk(opts.pkg);
-      await adb.isAppInstalled(opts.pkg).should.eventually.be.false;
+      await adb.uninstallApk(opts.appPackage);
+      await adb.isAppInstalled(opts.appPackage).should.eventually.be.false;
       await helpers.installApkRemotely(adb, opts);
-      await adb.isAppInstalled(opts.pkg).should.eventually.be.true;
+      await adb.isAppInstalled(opts.appPackage).should.eventually.be.true;
     });
   });
   describe('ensureDeviceLocale', () => {

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -10,7 +10,8 @@ let driver;
 let defaultCaps = {
   app: sampleApps('ApiDemos-debug'),
   deviceName: 'Android',
-  platformName: 'Android'
+  platformName: 'Android',
+  androidInstallTimeout: '90000'
 };
 
 describe('createSession', function () {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -308,14 +308,15 @@ describe('Android Helpers', () => {
     });
   }));
   describe('installApkRemotely', withMocks({adb, fs, helpers}, (mocks) => {
+    //use mock appium capabilities for this test
     const opts = {
-      localApkPath : 'local',
-      pkg : 'pkg',
+      app : 'local',
+      appPackage : 'pkg',
       fastReset : true,
       androidInstallTimeout : 90000
     };
     it('should reset app if already installed', async () => {
-      mocks.fs.expects('md5').withExactArgs(opts.localApkPath).returns('apkmd5');
+      mocks.fs.expects('md5').withExactArgs(opts.app).returns('apkmd5');
       mocks.helpers.expects('getRemoteApkPath').returns(false);
       mocks.adb.expects('fileExists').returns(true);
       mocks.adb.expects('isAppInstalled').returns(true);
@@ -326,7 +327,7 @@ describe('Android Helpers', () => {
       mocks.helpers.verify();
     });
     it.skip('should push and reinstall apk when apk is not installed', async () => {
-      mocks.fs.expects('md5').withExactArgs(opts.localApkPath).returns('apkmd5');
+      mocks.fs.expects('md5').withExactArgs(opts.app).returns('apkmd5');
       mocks.helpers.expects('getRemoteApkPath').returns(true);
       mocks.adb.expects('fileExists').returns(true);
       mocks.adb.expects('isAppInstalled').returns(true);


### PR DESCRIPTION
Per my previous PR I tested the new release within Appium and I found that my original change is **defective**
ref: #161 

The opts values for localApkPath and pkg parsed in android-helpers.js : line 257 are referred incorrectly.

The tests for this PR passed, but when using official capability arguments passed from appium the appium-android-driver will fail.

I have updated use of variables localApkPath and pkg to their respective capabilities: app and appPackage.