### PR TITLE
Set default androidInstallTimeout

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -79,7 +79,8 @@ class AndroidDriver extends BaseDriver {
         tmpDir: await tempDir.staticDir(),
         fullReset: false,
         autoLaunch: true,
-        adbPort: DEFAULT_ADB_PORT
+        adbPort: DEFAULT_ADB_PORT,
+        androidInstallTimeout: 90000
       };
       _.defaults(this.opts, defaultOpts);
       if (!this.opts.javaVersion) {


### PR DESCRIPTION
A default value for this timeout is set within android-helpers.js and also exists downstream in android-adb if the cap is not provided. 
If the cap is not provided this message...
`
logger.info(`Pushing ${appPackage} to device. Will wait up to ${androidInstallTimeout} ` +
                  `milliseconds before aborting`);
`
...will print a timeout value of 'undefined' yet still continue with the correct default value of 90000

This PR will fix the misleading message provided to the upstream appium consumer.

Apologizes for the stacked PRs around this single change