### PR TITLE
kill emulator at start of session if -wipe-data required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 build
 *.log
 .DS_Store
+.idea/
+*.iml

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -49,8 +49,13 @@ helpers.prepareEmulator = async function (adb, opts) {
   let avdName = avd.replace('@', '');
   let runningAVD = await adb.getRunningAVD(avdName);
   if (runningAVD !== null) {
-    logger.debug("Not launching AVD because it is already running.");
-    return;
+    if (avdArgs && avdArgs.toLowerCase().indexOf("-wipe-data") > -1) {
+      logger.debug(`Killing '${avdName}' because it needs to be wiped at start.`);
+      await adb.killEmulator(avdName);
+    } else {
+      logger.debug("Not launching AVD because it is already running.");
+      return;
+    }
   }
   await adb.launchAVD(avd, avdArgs, language, locale, avdLaunchTimeout,
                       avdReadyTimeout);


### PR DESCRIPTION
If the avd is defined and in avdArgs the -wipe-data argument is set, this update will close emulator before test to wipe its data.

This Pull Request depends on [adding killEmulator function to kill specific emulator with AVD name.](https://github.com/appium/appium-adb/pull/165), to kill emulator.
