### PR TITLE
Rotate screenshot when device is not upright

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -4,6 +4,8 @@ import { fs, mkdirp } from 'appium-support';
 import AdmZip from 'adm-zip';
 import path from 'path';
 import log from '../logger';
+import B from 'bluebird';
+import jimp from 'jimp';
 
 const swipeStepsPerSec = 28;
 const dragStepsPerSec = 40;
@@ -167,8 +169,18 @@ commands.getScreenshot = async function () {
     await fs.unlink(localFile);
   }
   await this.adb.pull(png, localFile);
-  let data = await fs.readFile(localFile);
-  let b64data = new Buffer(data).toString('base64');
+  let image = await jimp.read(localFile);
+  if (await this.adb.getApiLevel() < 23) {
+    // Android bug 8433742 - rotate screenshot if screen is rotated
+    let screenOrientation = await this.adb.getScreenOrientation();
+    try {
+      image = await image.rotate(-90 * screenOrientation);
+    } catch (err) {
+      log.warn(`Could not rotate screenshot due to error: ${err}`);
+    }
+  }
+  let b64data = (await B.promisify(image.getBuffer).call(image, jimp.MIME_PNG))
+                .toString('base64');
   await fs.unlink(localFile);
   return b64data;
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.32",
     "io.appium.settings": "^2.1.0",
+    "jimp": "^0.2.24",
     "lodash": "^3.10.0",
     "source-map-support": "^0.3.1",
     "teen_process": "^1.4.0",


### PR DESCRIPTION
Fixes https://github.com/appium/appium/issues/3158.

Added [jimp](https://www.npmjs.com/package/jimp) as a dependency. I chose this library because it has no external/native dependencies and was simple to setup with npm.

Let me know if adding this dependency is fine and I will work a bit more on the code (mainly checking if I can easily optimize the read/rotate/write/re-read flow).