### PR TITLE
Fixes #171, removes unused state.touch parameters

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -253,7 +253,7 @@ helpers.parseTouch = async function (gestures, multi) {
   let prevPos = null,
       time = 0;
   for (let state of touchStateObjects) {
-    if (_.isUndefined(state.options.x) && _.isUndefined(state.options.y)) {
+    if (_.isUndefined(state.options.x) && _.isUndefined(state.options.y) && prevPos !== null) {
       // this happens with wait
       state.options.x = prevPos.x;
       state.options.y = prevPos.y;
@@ -264,7 +264,8 @@ helpers.parseTouch = async function (gestures, multi) {
       state.options.y += prevPos.y;
     }
     delete state.options.offset;
-    prevPos = state.options;
+    if (!_.isUndefined(state.options.x) && !_.isUndefined(state.options.y))
+      prevPos = state.options;
 
     if (multi) {
       var timeOffset = state.timeOffset;
@@ -272,7 +273,11 @@ helpers.parseTouch = async function (gestures, multi) {
       state.time = androidHelpers.truncateDecimals(time, 3);
 
       // multi gestures require 'touch' rather than 'options'
-      state.touch = state.options;
+      if (!_.isUndefined(state.options.x) && !_.isUndefined(state.options.y))
+        state.touch = {
+          x: state.options.x,
+          y: state.options.y
+        };
       delete state.options;
     }
     delete state.timeOffset;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "adm-zip": "^0.4.7",
     "appium-adb": "^2.5.0",
-    "appium-android-bootstrap": "^2.6.0",
+    "appium-android-bootstrap": "^2.7.5",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^2.0.0",
     "appium-chromedriver": "^2.9.0",

--- a/test/unit/commands/touch-specs.js
+++ b/test/unit/commands/touch-specs.js
@@ -150,4 +150,21 @@ describe('Touch', () => {
       tests(4.4, 1);
     });
   }));
+
+  describe('parseTouch', () => {
+    it('should handle actions starting with wait', async () => {
+      let actions = [{action: 'wait', options: {ms: 500}},
+                     {action: 'tap', options: {x: 100, y: 101}}];
+
+      let touchStateObject = await driver.parseTouch(actions, true);
+      touchStateObject.should.eql([{
+        action: 'wait',
+        time: 0.5,
+      }, {
+        action: 'tap',
+        touch: {x: 100, y: 101},
+        time: 0.505,
+      }]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #171.

#171 is now crashing on android bootstrap when it receives the first wait without a position. I'll fix appium-android-bootstrap to accept them.

Please don't merge yet, I'll report back when this is fully functional. Let me know if you have any commentaries about this PR.