### PR TITLE
Fix getScreenshot on Windows

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -161,8 +161,8 @@ commands.pullFolder = async function (remotePath) {
 
 commands.getScreenshot = async function () {
   let localFile = temp.path({prefix: 'appium', suffix: '.png'});
-  let png_dir = this.opts.androidScreenshotPath || '/data/local/tmp/';
-  const png = path.resolve(png_dir, 'screenshot.png');
+  let pngDir = this.opts.androidScreenshotPath || '/data/local/tmp/';
+  const png = path.posix.resolve(pngDir, 'screenshot.png');
   let cmd =  ['/system/bin/rm', `${png};`, '/system/bin/screencap', '-p', png];
   await this.adb.shell(cmd);
   if (await fs.exists(localFile)) {


### PR DESCRIPTION
getScreenshot was broken on Windows, eg. at [this log](https://gist.github.com/tiagoshibata/040e6145250d9b36616977500c0ba4d0). Using `path.resolve` at Windows prepended the drive letter to the root of the path.

Relevant lines:

```
[debug] [ADB] Running C:\adb\platform-tools\adb.exe with args: ["-P",5037,"-s","T099706ZXD","shell","/system/bin/rm","C:\\data\\local\\tmp\\screenshot.png;","/system/bin/screencap","-p","C:\\data\\local\\tmp\\screenshot.png"]
[debug] [ADB] Running C:\adb\platform-tools\adb.exe with args: ["-P",5037,"-s","T099706ZXD","pull","C:\\data\\local\\tmp\\screenshot.png","C:\\Users\\DEWOTT\\AppData\\Local\\Temp\\appium116619-5360-196dkbl.lq6fbyy14i.png"]
[debug] [ADB] Running C:\adb\platform-tools\adb.exe with args: ["-P",5037,"-s","T099706ZXD","pull","C:\\data\\local\\tmp\\screenshot.png","C:\\Users\\DEWOTT\\AppData\\Local\\Temp\\appium116619-5360-196dkbl.lq6fbyy14i.png"]
[MJSONWP] Encountered internal error running command: Error: Error executing adbExec. Original error: Command 'C\:\\adb\\platform-tools\\adb.exe -P 5037 -s T099706ZXD pull C\:\\data\\local\\tmp\\screenshot.png C\:\\Users\\DEWOTT\\AppData\\Local\\Temp\\appium116619-5360-196dkbl.lq6fbyy14i.png' exited with code 1{"stdout":"","stderr":"remote object 'C:\\data\\local\\tmp\\screenshot.png' does not exist\r\n","code":1}
```