### PR TITLE
Passing the appWaitDurationParam to appium-adb startApp method

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -187,6 +187,7 @@ commands.startAUT = async function () {
     flags: this.opts.intentFlags,
     waitPkg: this.opts.appWaitPackage,
     waitActivity: this.opts.appWaitActivity,
+    waitDuration: this.opts.appWaitDuration,
     optionalIntentArguments: this.opts.optionalIntentArguments,
     stopApp: this.opts.stopAppOnReset || !this.opts.dontStopAppOnReset,
   });

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -19,6 +19,9 @@ let commonCapConstraints = {
   appWaitPackage: {
     isString: true
   },
+  appWaitDuration: {
+    isNumber: true
+  },
   deviceReadyTimeout: {
     isNumber: true
   },

--- a/test/functional/driver-e2e-specs.js
+++ b/test/functional/driver-e2e-specs.js
@@ -110,6 +110,12 @@ describe('createSession', function () {
     serverCaps.deviceName.should.exist;
     serverCaps.deviceUDID.should.exist;
   });
+  it('should error out for activity that fails to load after app wait activity timeout', async () => {
+    let caps = Object.assign({}, defaultCaps);
+    caps.appWaitActivity = 'non.existent.activity';
+    caps.appWaitDuration = 1000; // 1 second
+    await driver.createSession(caps).should.eventually.be.rejectedWith(/never started/);
+  });
 });
 
 describe('close', function () {


### PR DESCRIPTION
This is required for appium/appium#780