### PR TITLE
ensure we shut down logcat regardless of whether bootstrap was active

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -298,6 +298,7 @@ class AndroidDriver extends BaseDriver {
     log.debug("Shutting down Android driver");
     await super.deleteSession();
     if (this.bootstrap) {
+      // certain cleanup we only care to do if the bootstrap was ever run
       await this.stopChromedriverProxies();
       if (this.opts.unicodeKeyboard && this.opts.resetKeyboard && this.defaultIME) {
         log.debug(`Resetting IME to ${this.defaultIME}`);
@@ -306,17 +307,19 @@ class AndroidDriver extends BaseDriver {
       if (!this.isChromeSession) {
         await this.adb.forceStop(this.opts.appPackage);
       }
-      await this.adb.forceStop('io.appium.unlock');
       await this.adb.goToHome();
       if (this.opts.fullReset && !this.opts.skipUninstall && !this.appOnDevice) {
         await this.adb.uninstallApk(this.opts.appPackage);
       }
-      await this.adb.stopLogcat();
       await this.bootstrap.shutdown();
       this.bootstrap = null;
     } else {
-      log.warn("Cannot shut down Android driver; it has already shut down");
+      log.debug("Called deleteSession but bootstrap wasn't active");
     }
+    // some cleanup we want to do regardless, in case we are shutting down
+    // mid-startup
+    await this.adb.forceStop('io.appium.unlock');
+    await this.adb.stopLogcat();
   }
 
   validateDesiredCaps (caps) {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -112,7 +112,7 @@ describe('driver', () => {
       sandbox.stub(driver.adb, 'uninstallApk');
       sandbox.stub(driver.adb, 'stopLogcat');
       sandbox.stub(driver.bootstrap, 'shutdown');
-      sandbox.spy(log, 'warn');
+      sandbox.spy(log, 'debug');
     });
     afterEach(() => {
       sandbox.restore();
@@ -120,8 +120,9 @@ describe('driver', () => {
     it('should not do anything if Android Driver has already shut down', async () => {
       driver.bootstrap = null;
       await driver.deleteSession();
-      log.warn.calledOnce.should.be.true;
+      log.debug.calledTwice.should.be.true;
       driver.stopChromedriverProxies.called.should.be.false;
+      driver.adb.stopLogcat.called.should.be.true;
     });
     it('should reset keyboard to default IME', async () => {
       driver.opts.unicodeKeyboard = true;


### PR DESCRIPTION
this ensures we don't leave procs hanging if we fail mid-start-session
fix appium/appium#6753

cc @imurchie 