### PR TITLE
support reboot parameter for android

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -107,6 +107,11 @@ class AndroidDriver extends BaseDriver {
         this.jwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);
       }
 
+      if (this.opts.reboot) {
+        this.setAvdFromCapabilities(caps);
+        this.addWipeDataToAvdArgs();
+      }
+
       // get device udid for this session
       let {udid, emPort} = await helpers.getDeviceInfoFromCaps(this.opts);
       this.opts.udid = udid;
@@ -140,6 +145,29 @@ class AndroidDriver extends BaseDriver {
     } catch (e) {
       await this.deleteSession();
       throw e;
+    }
+  }
+
+  setAvdFromCapabilities (caps) {
+    if (this.opts.avd) {
+      log.info('avd name defined, ignoring device name and platform version');
+    } else {
+      if (!caps.deviceName) {
+        log.errorAndThrow('avd or deviceName should be specified when reboot option is enables');
+      }
+      if (!caps.platformVersion) {
+        log.errorAndThrow('avd or platformVersion should be specified when reboot option is enabled');
+      }
+      let avdDevice = caps.deviceName.replace(/[^a-zA-Z0-9_.]/g, "-");
+      this.opts.avd = `${avdDevice}__${caps.platformVersion}`;
+    }
+  }
+
+  addWipeDataToAvdArgs () {
+    if (!this.opts.avdArgs) {
+      this.opts.avdArgs = '-wipe-data';
+    } else  if (this.opts.avdArgs.toLowerCase().indexOf("-wipe-data") === -1) {
+      this.opts.avdArgs += ' -wipe-data';
     }
   }
 
@@ -312,6 +340,11 @@ class AndroidDriver extends BaseDriver {
         await this.adb.uninstallApk(this.opts.appPackage);
       }
       await this.bootstrap.shutdown();
+      if (this.opts.reboot) {
+        let avdName = this.opts.avd.replace('@', '');
+        log.debug(`closing emulator '${avdName}'`);
+        this.adb.killEmulator(avdName);
+      }
       this.bootstrap = null;
     } else {
       log.debug("Called deleteSession but bootstrap wasn't active");


### PR DESCRIPTION
If reboot option activated (will link pull request for that soon), it will always wipe data of emulator on start, and close emulator at the end.
It also use device name and platform version to create avd name, if it is not defined.

Android emulator sometimes get stuck if it is started for a long time without activity, and will not respond to any adb command, even if we kill adb-server, this update will kill emulator after session and wipe it on start to reduce the risk of this problem on production. the issue was already created about it. #167 