### PR TITLE
adding fingerprint command

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -165,6 +165,10 @@ commands.pullFolder = async function (remotePath) {
   });
 };
 
+commands.fingerprint = async function (fingerprintId) {
+  await this.adb.fingerprint(fingerprintId);
+};
+
 commands.getScreenshot = async function () {
   let localFile = temp.path({prefix: 'appium', suffix: '.png'});
   let pngDir = this.opts.androidScreenshotPath || '/data/local/tmp/';


### PR DESCRIPTION
making fingerprint function accessible from driver. required for proxying it with base_driver.