### PR TITLE
throw real error instead of deleteSession error

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -143,7 +143,11 @@ class AndroidDriver extends BaseDriver {
       await this.startAndroidSession(this.opts);
       return [sessionId, this.caps];
     } catch (e) {
-      await this.deleteSession();
+      // ignoring delete session exception if any and throw the real error
+      // that happened while creating the session.
+      try {
+        await this.deleteSession();
+      } catch (ign) {}
       throw e;
     }
   }


### PR DESCRIPTION
If `createSession` throws exception it will try to delete session before throwing the exception. In case `deleteSession` throws another exception, appium will return `deleteSession`s exception instead of real error. If you are using grid ( + jenkins) you will see `deleteSession` error instead of the real reason.