### PR TITLE
Add clearSystemFiles cap to delete generated app files

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -109,6 +109,9 @@ let commonCapConstraints = {
   androidScreenshotPath: {
     isString: true
   },
+  clearSystemFiles: {
+    isBoolean: true
+  },
 };
 
 let uiautomatorCapConstraints = {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -131,6 +131,7 @@ class AndroidDriver extends BaseDriver {
       if (this.opts.app) {
         // find and copy, or download and unzip an app url or path
         this.opts.app = await this.helpers.configureApp(this.opts.app, APP_EXTENSION);
+        this.opts.appIsTemp = caps.app !== this.opts.app; // did we make a temporary copy?
         await this.checkAppPresent();
       } else if (this.appOnDevice) {
         // the app isn't an actual app file but rather something we want to
@@ -357,6 +358,21 @@ class AndroidDriver extends BaseDriver {
     // mid-startup
     await this.adb.forceStop('io.appium.unlock');
     await this.adb.stopLogcat();
+
+    if (this.opts.clearSystemFiles) {
+      if (this.opts.appIsTemp) {
+        log.debug(`Temporary copy of app was made: deleting '${this.opts.app}'`);
+        try {
+          await fs.rimraf(this.opts.app);
+        } catch (err) {
+          log.warn(`Unable to delete temporary app: ${err.message}`);
+        }
+      } else {
+        log.debug('App was not copied, so not deleting');
+      }
+    } else {
+      log.debug('Not cleaning generated files. Add `clearSystemFiles` capability if wanted.');
+    }
   }
 
   validateDesiredCaps (caps) {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -120,7 +120,7 @@ describe('driver', () => {
     it('should not do anything if Android Driver has already shut down', async () => {
       driver.bootstrap = null;
       await driver.deleteSession();
-      log.debug.calledTwice.should.be.true;
+      log.debug.callCount.should.eql(3);
       driver.stopChromedriverProxies.called.should.be.false;
       driver.adb.stopLogcat.called.should.be.true;
     });


### PR DESCRIPTION
First pass, just deletes any copy of the app that was made.