### PR TITLE
Add driver version to logs

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -10,6 +10,7 @@ import _ from 'lodash';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
 import { fs, tempDir } from 'appium-support';
 import { retryInterval } from 'asyncbox';
+import { version } from '../../package.json'; // eslint-disable-line import/no-unresolved
 
 
 const APP_EXTENSION = '.apk';
@@ -31,6 +32,9 @@ const NO_PROXY = [
 class AndroidDriver extends BaseDriver {
   constructor (opts = {}, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
+
+    log.debug(`AndroidDriver version: ${version}`);
+
     this.locatorStrategies = [
       'xpath',
       'id',


### PR DESCRIPTION
Make it easier to tell what people are running when they provide logs.