### PR TITLE
Added instrumentation tests commands

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -202,6 +202,48 @@ commands.getScreenshot = async function () {
   return b64data;
 };
 
+commands.instrumentationClassTest = async function (testClass, packageName) {
+  log.info('Running instrumentation testcase');
+  try {
+    let testsRunner = 'android.support.test.runner.AndroidJUnitRunner';
+    let testsPackageName = packageName + '.test';
+
+    await this.adb.forceStop(testsPackageName);
+    await this.adb.clear(packageName);
+
+    return await this.adb.shell(['am', 'instrument', '-w -r -e debug false -e class',
+      testClass, testsPackageName + '/' + testsRunner]);
+  } catch (e) {
+    log.errorAndThrow(`Error running instrumentation tests. Original error: ${e.message}`);
+  }
+};
+
+commands.instrumentationPackageTest = async function (packageName) {
+  log.info('Running package instrumentation tests');
+  try {
+    let testsRunner = "android.support.test.runner.AndroidJUnitRunner";
+    let testsPackageName = packageName + ".test";
+
+    await this.adb.forceStop(testsPackageName);
+    await this.adb.clear(packageName);
+
+    return await this.adb.shell(['am', 'instrument', '-w -r -e debug false ',
+      testsPackageName + '/' + testsRunner]);
+  } catch (e) {
+    log.errorAndThrow(`Error running instrumentation tests. Original error: ${e.message}`);
+  }
+};
+
+commands.instrumentationInstallTest = async function (apkPath) {
+  log.info('Installing apk without activity');
+  try {
+    return await this.adb.shell(['pm', 'install', '-r', apkPath]);
+  } catch (e) {
+    log.errorAndThrow(`Error installing apk without activity. Original error: ${e.message}`);
+  }
+};
+
+
 
 Object.assign(extensions, commands, helpers);
 export { commands, helpers };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "mobile",
     "mobile testing"
   ],
-  "version": "1.10.30",
+  "version": "1.10.31",
   "author": "appium",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
I am want to use Appium as infrastructure for running instrumentation tests on multiple devices or emulators by Selenium Grid. This new approach require new routes.

For running instrumentation test in apk
instrumentationClassTest(testClass, packageName)

For running all instrumentation tests in apk
instrumentationPackageTest(packageName)

For installing apk without activity (apk with test)
instrumentationInstallTest(apkPath)