### PR TITLE
Make sure we have an options object on touch action

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -200,7 +200,7 @@ helpers.parseTouch = async function (gestures, multi) {
   }
 
   let touchStateObjects = await asyncmap(gestures, async (gesture) => {
-    let options = gesture.options;
+    let options = gesture.options || {};
     if (_.contains(['press', 'moveTo', 'tap', 'longPress'], gesture.action)) {
       options.offset = false;
       let elementId = gesture.options.element;


### PR DESCRIPTION
Some clients do not send an `options` property, particularly for the `release` action. This then fails when we hit the processing of the states.

Fixes https://github.com/appium/appium/issues/7181