### PR TITLE
Make sure dontStopAppOnReset cap is respected

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,8 +1,9 @@
 import _ from 'lodash';
 import androidHelpers from '../android-helpers';
-import { fs } from 'appium-support';
+import { fs, util } from 'appium-support';
 import B from 'bluebird';
 import log from '../logger';
+
 
 let commands = {}, helpers = {}, extensions = {};
 
@@ -155,6 +156,13 @@ commands.startActivity = async function (appPackage, appActivity,
                                          intentFlags, optionalIntentArguments,
                                          dontStopAppOnReset) {
   log.debug(`Starting package '${appPackage}' and activity '${appActivity}'`);
+
+  // dontStopAppOnReset is both an argument here, and a desired capability
+  // if the argument is set, use it, otherwise use the cap
+  if (!util.hasValue(dontStopAppOnReset)) {
+    dontStopAppOnReset = !!this.opts.dontStopAppOnReset;
+  }
+
   await this.adb.startApp({
     pkg: appPackage,
     activity: appActivity,


### PR DESCRIPTION
We have a capability `dontStopAppOnReset` and also, for `startActivity`, a parameter. If the latter is explicitly set it should be used, otherwise the default should be the capability.

Fixes https://github.com/appium/appium/issues/5361