### PR TITLE
Add device information commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If more than one of these capabilities are given, the driver will only use first
 | `getCurrentActivity`       |
 | `getCurrentContext`        |
 | `getDeviceTime`            |
+| `getDisplayDensity`        |
 | `getLocationInView`        |
 | `getLog`                   |
 | `getLogTypes`              |
@@ -89,12 +90,14 @@ If more than one of these capabilities are given, the driver will only use first
 | `getScreenshot`            |
 | `getSize`                  |
 | `getStrings`               |
+| `getSystemBars`            |
 | `getText`                  |
 | `getWindowSize`            |
 | `hideKeyboard`             |
 | `installApp`               |
 | `isAppInstalled`           |
 | `isIMEActivated`           |
+| `isKeyboardShown`          |
 | `isLocked`                 |
 | `isWebContext`             |
 | `keyevent`                 |

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -46,6 +46,11 @@ commands.back = function () {
   return this.bootstrap.sendAction('pressBack');
 };
 
+commands.isKeyboardShown = async function () {
+  let keyboardInfo = await this.adb.isSoftKeyboardPresent();
+  return keyboardInfo.isKeyboardShown;
+};
+
 commands.hideKeyboard = async function () {
   let {isKeyboardShown, canCloseKeyboard} = await this.adb.isSoftKeyboardPresent();
   if (!isKeyboardShown) {
@@ -216,6 +221,112 @@ commands.closeApp = async function () {
   await this.adb.forceStop(this.opts.appPackage);
 };
 
+commands.getDisplayDensity = async function () {
+  // first try the property for devices
+  let out = await this.adb.shell(['getprop', 'ro.sf.lcd_density']);
+  if (out) {
+    let val = parseInt(out, 10);
+    // if the value is NaN, try getting the emulator property
+    if (!isNaN(val)) {
+      return val;
+    }
+    log.debug(`Parsed density value was NaN: "${out}"`);
+  }
+  // fallback to trying property for emulators
+  out = await this.adb.shell(['getprop', 'qemu.sf.lcd_density']);
+  if (out) {
+    let val = parseInt(out, 10);
+    if (!isNaN(val)) {
+      return val;
+    }
+    log.debug(`Parsed density value was NaN: "${out}"`);
+  }
+  // couldn't get anything, so error out
+  log.errorAndThrow('Failed to get display density property.');
+};
+
+/**
+ * Parses the given window manager Surface string to get info.
+ * @param line: To parse. This is assumed to be valid.
+ * @return: Visibility and bounds of the Surface.
+ */
+function parseSurfaceLine (line) {
+  // the surface bounds are in the format:
+  // "rect=(0.0,1184.0) 768.0 x 96.0"
+  //       ^ location   ^ size
+  // cut out the stuff before the 'rect' and then split the numbers apart
+  let bounds = line.split('rect=')[1]
+  .replace(/[\(\), x]+/g, ' ')
+  .trim()
+  .split(' ');
+
+  return {
+    visible: (line.indexOf('shown=true') !== -1),
+    x: parseFloat(bounds[0]),
+    y: parseFloat(bounds[1]),
+    width: parseFloat(bounds[2]),
+    height: parseFloat(bounds[3])
+  };
+}
+
+/**
+ * Extracts status and navigation bar information from the window manager output.
+ * @param lines: Output from dumpsys command
+ * @return: Visibility and bounds info of status and navigation bar
+ */
+function parseWindows (lines) {
+  let atStatusBar = false;
+  let atNavBar = false;
+  let statusBar;
+  let navigationBar;
+  // the window manager output looks like:
+  // Window #1 ... WindowID
+  //   A bunch of properties
+  // Window #2 ... WindowID
+  //   A bunch of properties
+  lines.split('\n').forEach((line) => {
+    // the start of a new window section
+    if (line.indexOf('  Window #') !== -1) {
+      // determine which section we're in
+      // only one will be true
+      atStatusBar = (line.indexOf('StatusBar') !== -1);
+      atNavBar = (line.indexOf('NavigationBar') !== -1);
+      // don't need anything else. move to next line
+      return;
+    }
+    // once we're in a window section, look for the surface data line
+    if (line.indexOf('      Surface:') === -1) {
+      return;
+    }
+    if (atStatusBar) {
+      statusBar = parseSurfaceLine(line);
+      atStatusBar = false;
+    } else if (atNavBar) {
+      navigationBar = parseSurfaceLine(line);
+      atNavBar = false;
+    }
+  });
+
+  if (!statusBar) {
+    log.errorAndThrow('Failed to parse status bar information.');
+  }
+  if (!navigationBar) {
+    log.errorAndThrow('Failed to parse navigation bar information.');
+  }
+
+  return {statusBar, navigationBar};
+}
+
+commands.getSystemBars = async function () {
+  let out = await this.adb.shell(['dumpsys', 'window', 'windows']);
+  if (!out) {
+    log.errorAndThrow('Did not get window manager output.');
+  }
+  return parseWindows(out);
+};
+
 Object.assign(extensions, commands, helpers);
 export { commands, helpers };
 export default extensions;
+// for unit tests
+export { parseWindows, parseSurfaceLine };

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -1,12 +1,14 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import AndroidDriver from '../../..';
+import { parseSurfaceLine, parseWindows } from '../../../lib/commands/general';
 import helpers from '../../../lib/android-helpers';
 import { withMocks } from 'appium-test-support';
 
 let driver;
 chai.should();
 chai.use(chaiAsPromised);
+let expect = chai.expect;
 
 describe('General', () => {
   describe('hideKeyboard', () => {
@@ -18,6 +20,20 @@ describe('General', () => {
     });
     it('should throw an error if there is no selector', () => {
       driver.findElOrEls('xpath', null, false, 'some context').should.be.rejected;
+    });
+  });
+  describe('isKeyboardShown', () => {
+    it('should return true if the keyboard is shown', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.isSoftKeyboardPresent = () => { return { isKeyboardShown: true, canCloseKeyboard: true }; };
+      (await driver.isKeyboardShown()).should.equal(true);
+    });
+    it('should return false if the keyboard is not shown', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.isSoftKeyboardPresent = () => { return { isKeyboardShown: false, canCloseKeyboard: true }; };
+      (await driver.isKeyboardShown()).should.equal(false);
     });
   });
   describe('Install App', () => {
@@ -81,4 +97,123 @@ describe('General', () => {
       strings.test.should.equal('en_value');
     });
   }));
+  describe('getDisplayDensity', () => {
+    it('should return the display density of a device', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.shell = () => { return '123'; };
+      (await driver.getDisplayDensity()).should.equal(123);
+    });
+    it('should return the display density of an emulator', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.shell = (cmd) => {
+        let joinedCmd = cmd.join(' ');
+        if (joinedCmd.indexOf('ro.sf') !== -1) {
+          // device property look up
+          return '';
+        } else if (joinedCmd.indexOf('qemu.sf') !== -1) {
+          // emulator property look up
+          return '456';
+        }
+        return '';
+      };
+      (await driver.getDisplayDensity()).should.equal(456);
+    });
+    it('should throw an error if the display density property can\'t be found', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.shell = () => { return ''; };
+      await driver.getDisplayDensity().should.be.rejectedWith(/Failed to get display density property/);
+    });
+    it('should throw and error if the display density is not a number', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.shell = () => { return 'abc'; };
+      await driver.getDisplayDensity().should.be.rejectedWith(/Failed to get display density property/);
+    });
+  });
+  describe('parseSurfaceLine', () => {
+    it('should return visible true if the surface is visible', async () => {
+      parseSurfaceLine('shown=true rect=1 1 1 1').should.be.eql({
+        visible: true,
+        x: 1,
+        y: 1,
+        width: 1,
+        height: 1
+      });
+    });
+    it('should return visible false if the surface is not visible', async () => {
+      parseSurfaceLine('shown=false rect=1 1 1 1').should.be.eql({
+        visible: false,
+        x: 1,
+        y: 1,
+        width: 1,
+        height: 1
+      });
+    });
+    it('should return the parsed surface bounds', async () => {
+      parseSurfaceLine('shown=true rect=(1.0,2.0) 3.0 x 4.0').should.be.eql({
+        visible: true,
+        x: 1,
+        y: 2,
+        width: 3,
+        height: 4
+      });
+    });
+  });
+
+  // these are used for both parseWindows and getSystemBars tests
+  let validWindowOutput = [
+    '  Window #1 Derp',
+    '    stuff',
+    '      Surface: derp shown=false lalalala rect=(9.0,8.0) 7.0 x 6.0',
+    '    more stuff',
+    '  Window #2 StatusBar',
+    '    blah blah blah',
+    '      Surface: blah blah shown=true blah blah rect=(1.0,2.0) 3.0 x 4.0',
+    '    blah blah blah',
+    '  Window #3 NavigationBar',
+    '    womp womp',
+    '      Surface: blah blah shown=false womp womp rect=(5.0,6.0) 50.0 x 60.0',
+    '    qwerty asd zxc'
+  ].join('\n');
+  let validSystemBars = {
+    statusBar: {visible: true, x: 1, y: 2, width: 3, height: 4},
+    navigationBar: {visible: false, x: 5, y: 6, width: 50, height: 60}
+  };
+
+  describe('parseWindows', () => {
+    it('should throw an error if the status bar info wasn\'t found', async () => {
+      expect(() => { parseWindows(''); })
+        .to.throw(Error, /Failed to parse status bar information./);
+    });
+    it('should throw an error if the navigation bar info wasn\'t found', async () => {
+      let windowOutput = [
+        '  Window #1 StatusBar',
+        '    blah blah blah',
+        '      Surface: blah blah shown=true blah blah rect=(1.0,2.0) 3.0 x 4.0',
+        '    blah blah blah'
+      ].join('\n');
+      expect(() => { parseWindows(windowOutput); })
+        .to.throw(Error, /Failed to parse navigation bar information./);
+    });
+    it('should return status and navigation bar info when both are given', async () => {
+      parseWindows(validWindowOutput).should.be.eql(validSystemBars);
+    });
+  });
+  describe('getSystemBars', () => {
+    it('should throw an error if there\'s no window manager output', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.shell = () => { return ''; };
+      await driver.getSystemBars().should.be.rejectedWith(/Did not get window manager output./);
+    });
+    it('should return the parsed system bar info', async () => {
+      driver = new AndroidDriver();
+      driver.adb = {};
+      driver.adb.shell = () => { return validWindowOutput; };
+      (await driver.getSystemBars()).should.be.eql(validSystemBars);
+    });
+  });
 });


### PR DESCRIPTION
- Get display density
- Get visibility and bounds of status bar and navigation bars
- Check if soft keyboard is present

I think this will also require updates in other packages to expose the commands/endpoints to users.

Since the commands aren't exposed by default, I tested by replacing the internals of `hideKeyboard` before moving the logic to their own commands. Tested on emulators and a device.