### PR TITLE
Allow way to pass chromeAndroidPackage

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -214,6 +214,9 @@ async function setupNewChromedriver (opts, curDeviceId, adbPort) {
   if (opts.chromeUseRunningApp) {
     caps.chromeOptions.androidUseRunningApp = opts.chromeUseRunningApp;
   }
+  if (opts.chromeAndroidPackage) {
+    caps.chromeOptions.androidPackage = opts.chromeAndroidPackage;
+  }
   if (opts.chromeAndroidActivity) {
     caps.chromeOptions.androidActivity = opts.chromeAndroidActivity;
   }


### PR DESCRIPTION
This is useful when you are launching an app from another app.
Fixes https://github.com/appium/appium/issues/7194