### PR TITLE
Pass acceptSslCerts to bootstrap on start

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -178,7 +178,7 @@ helpers.wrapBootstrapDisconnect = async function (wrapped) {
   try {
     await wrapped();
     await this.adb.restart();
-    await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers, this.acceptSslCerts);
+    await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers, this.opts.acceptSslCerts);
   } finally {
     this.bootstrap.ignoreUnexpectedShutdown = false;
   }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -50,7 +50,6 @@ class AndroidDriver extends BaseDriver {
                                        this.onSettingsUpdate.bind(this));
     this.chromedriver = null;
     this.apkStrings = {};
-    this.acceptSslCerts = !!opts.acceptSslCerts;
     this.bootstrapPort = opts.bootstrapPort || DEVICE_PORT;
   }
 
@@ -215,7 +214,7 @@ class AndroidDriver extends BaseDriver {
     }
     // start UiAutomator
     this.bootstrap = new helpers.bootstrap(this.adb, this.bootstrapPort, this.opts.websocket);
-    await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers);
+    await this.bootstrap.start(this.opts.appPackage, this.opts.disableAndroidWatchers, this.opts.acceptSslCerts);
     // handling unexpected shutdown
     this.bootstrap.onUnexpectedShutdown.catch(async (err) => {
       if (!this.bootstrap.ignoreUnexpectedShutdown) {


### PR DESCRIPTION
## Proposed changes

Fix ```acceptSslCerts``` capability for android browser

PR for https://github.com/appium/appium/issues/7326

Linked PR: https://github.com/appium/appium/pull/7325

## Details

Android driver must pass ```this.acceptSslCerts``` as third argument of ```this.bootstrap.start```