### PR TITLE
add chromeAndroidProcess support

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -220,6 +220,9 @@ async function setupNewChromedriver (opts, curDeviceId, adbPort) {
   if (opts.chromeAndroidActivity) {
     caps.chromeOptions.androidActivity = opts.chromeAndroidActivity;
   }
+  if (opts.chromeAndroidProcess) {
+    caps.chromeOptions.androidProcess = opts.chromeAndroidProcess;
+  }
   if (opts.enablePerformanceLogging) {
     caps.loggingPrefs = {performance: 'ALL'};
   }


### PR DESCRIPTION
try to support wechat webview automation
detail https://testerhome.com/topics/6954

a demo for weixin (wechat) testcase
already passed by local testing

```scala
  test("test weixin h5") {
    val capability = new DesiredCapabilities()
    capability.setCapability("app", "")
    capability.setCapability("appPackage", "com.tencent.mm")
    capability.setCapability("appActivity", ".ui.LauncherUI")
    capability.setCapability("deviceName", "emulator-5554")
    capability.setCapability("fastReset", "false")
    capability.setCapability("fullReset", "false")
    capability.setCapability("noReset", "true")
    capability.setCapability("resetKeyboard", "true")
    capability.setCapability("automationName", "appium")
    capability.setCapability("platformName", "android")
    capability.setCapability("chromeAndroidProcess", "com.tencent.mm:tools")

    val url = "http://127.0.0.1:4723/wd/hub"
    val driver = new AndroidDriver[WebElement](new URL(url), capability)
    driver.findElementByXPath("//*[@text='我']").click
    driver.findElementByXPath("//*[@text='收藏']").click
    driver.findElementByXPath("//*[contains(@text, '美团外卖')]").click
    println(driver.getPageSource)
    println(driver.getContextHandles)
    driver.context("WEBVIEW_com.tencent.mm:tools")
    println(driver.getPageSource)
  }

```