### PR TITLE
Fix reboot bug

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -364,11 +364,6 @@ class AndroidDriver extends BaseDriver {
         await this.adb.uninstallApk(this.opts.appPackage);
       }
       await this.bootstrap.shutdown();
-      if (this.opts.reboot) {
-        let avdName = this.opts.avd.replace('@', '');
-        log.debug(`closing emulator '${avdName}'`);
-        this.adb.killEmulator(avdName);
-      }
       this.bootstrap = null;
     } else {
       log.debug("Called deleteSession but bootstrap wasn't active");
@@ -377,7 +372,11 @@ class AndroidDriver extends BaseDriver {
     // mid-startup
     await this.adb.forceStop('io.appium.unlock');
     await this.adb.stopLogcat();
-
+    if (this.opts.reboot) {
+      let avdName = this.opts.avd.replace('@', '');
+      log.debug(`closing emulator '${avdName}'`);
+      await this.adb.killEmulator(avdName);
+    }
     if (this.opts.clearSystemFiles) {
       if (this.opts.appIsTemp) {
         log.debug(`Temporary copy of app was made: deleting '${this.opts.app}'`);


### PR DESCRIPTION
When starting the appium server with the reboot option added from appium 1.6, sometimes get the following error.

```
[MJSONWP] Encountered internal error running command: Error: Error executing adbExec. Original error: 'Command '/usr/local/opt/android-sdk/platform-tools/adb -P 5037 -s emulator-5554 shell am force-stop io.appium.unlock' exited with code 1'; Stderr: 'error: device 'emulator-5554' not found'; Code: '1'
```
I think The above error occurs when `this.adb.killEmulator` completes earlier than `this.adb.forceStop ('io.appium.unlock')`,
So fix `this.adb.killEmulator` to be executed after `this.adb.forceStop ('io.appium.unlock')`.