### PR TITLE
Enable mock locations for appium settings app

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -335,6 +335,14 @@ helpers.initUnicodeKeyboard = async function (adb) {
   return defaultIME;
 };
 
+helpers.setMockLocationApp = async function (adb, app) {
+  if (parseInt(await adb.getApiLevel(), 10) < 23) {
+    await adb.shell(['settings', 'put', 'secure', 'mock_location', '1']);
+  } else {
+    await adb.shell(['appops', 'set', app, 'android:mock_location', 'allow']);
+  }
+};
+
 helpers.pushSettingsApp = async function (adb) {
   logger.debug("Pushing settings apk to device...");
   await adb.install(settingsApkPath, false);
@@ -419,6 +427,7 @@ helpers.initDevice = async function (adb, opts) {
   }
   await helpers.pushSettingsApp(adb);
   await helpers.pushUnlock(adb);
+  await helpers.setMockLocationApp(adb, 'io.appium.settings');
   return defaultIME;
 };
 

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -383,6 +383,22 @@ describe('Android Helpers', () => {
       mocks.adb.verify();
     });
   }));
+  describe('setMockLocationApp', withMocks({adb}, (mocks) => {
+    it('should enable mock location for api level below 23', async () => {
+      mocks.adb.expects('getApiLevel').returns(Promise.resolve("18"));
+      mocks.adb.expects('shell').withExactArgs(['settings', 'put', 'secure', 'mock_location', '1']).once()
+        .returns('');
+      await helpers.setMockLocationApp(adb, 'io.appium.settings');
+      mocks.adb.verify();
+    });
+    it('should enable mock location for api level 23 and above', async () => {
+      mocks.adb.expects('getApiLevel').returns(Promise.resolve("23"));
+      mocks.adb.expects('shell').withExactArgs(['appops', 'set', 'io.appium.settings', 'android:mock_location', 'allow']).once()
+        .returns('');
+      await helpers.setMockLocationApp(adb, 'io.appium.settings');
+      mocks.adb.verify();
+    });
+  }));
   describe('pushUnlock', withMocks({adb}, (mocks) => {
     it('should install unlockApp', async () => {
       mocks.adb.expects('install').withExactArgs(unlockApkPath, false).once()


### PR DESCRIPTION
* Enable mock location for all apps below Android 6 and set io.appium.settings as the mock location app on Android 6 and above to fix the mock location issue

This PR fixes the issue below
https://github.com/appium/appium/issues/7647