### PR TITLE
Add Android 7 WebView Browser Tester support

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -15,7 +15,7 @@ const REMOTE_TEMP_PATH = "/data/local/tmp";
 const REMOTE_INSTALL_TIMEOUT = 90000; // milliseconds
 const CHROME_BROWSERS = ["Chrome", "Chromium", "Chromebeta", "Browser",
                          "chrome", "chromium", "chromebeta", "browser",
-                         "chromium-browser"];
+                         "chromium-browser", "chromium-webview"];
 
 let helpers = {};
 
@@ -497,6 +497,9 @@ helpers.getChromePkg = function (browser) {
   } else if (browser === "chromium-browser") {
     pkg = "org.chromium.chrome";
     activity = "com.google.android.apps.chrome.Main";
+  } else if (browser === "chromium-webview") {
+    pkg = "org.chromium.webview_shell";
+    activity = "org.chromium.webview_shell.WebViewBrowserActivity";
   } else {
     pkg = "com.android.chrome";
     activity = "com.google.android.apps.chrome.Main";

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -302,7 +302,8 @@ class AndroidDriver extends BaseDriver {
     const knownPackages = ["org.chromium.chrome.shell",
                            "com.android.chrome",
                            "com.chrome.beta",
-                           "org.chromium.chrome"];
+                           "org.chromium.chrome",
+                           "org.chromium.webview_shell"];
 
     if (!_.contains(knownPackages, this.opts.appPackage)) {
       opts.chromeAndroidActivity = this.opts.appActivity;

--- a/test/functional/webview-browser-tester-e2e-specs.js
+++ b/test/functional/webview-browser-tester-e2e-specs.js
@@ -1,0 +1,46 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import AndroidDriver from '../..';
+import path from 'path';
+import { sleep } from 'asyncbox';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const AVD_ANDROID_24_WITHOUT_GMS = "Nexus_5_API_24";
+const capabilities = {
+  "browserName": "chromium-webview",
+  "avd": AVD_ANDROID_24_WITHOUT_GMS,
+  "platformName": "Android",
+  "platformVersion": "7.0",
+  "deviceName": "Android Emulator",
+  "chromedriverExecutable": path.join(process.cwd(), "chromedriver")
+};
+
+describe('createSession', function () {
+  let driver;
+  before(() => {
+    driver = new AndroidDriver();
+  });
+  afterEach(async () => {
+    await driver.deleteSession();
+  });
+  it('should start android session using webview browser tester on android 7', async () => {
+    await driver.createSession(capabilities);
+    await driver.setUrl("http://google.com");
+    await sleep(1500);
+    let contexts = await driver.getContexts();
+    contexts.indexOf("CHROMIUM").should.not.equal(-1);
+    await driver.setContext("CHROMIUM");
+    let el = await driver.findElOrEls("id", "lst-ib", false);
+    el.should.not.equal(null);
+    await driver.click(el.ELEMENT);
+    await sleep(500);
+    await driver.setElementValue("android", el.ELEMENT);
+    await sleep(1500);
+    el = await driver.findElOrEls("id", "tsbb", false);
+    el.should.not.equal(null);
+    await driver.click(el.ELEMENT);
+    await sleep(5000);
+  });
+});

--- a/test/functional/webview-browser-tester-e2e-specs.js
+++ b/test/functional/webview-browser-tester-e2e-specs.js
@@ -17,7 +17,7 @@ const capabilities = {
   "chromedriverExecutable": path.join(process.cwd(), "chromedriver")
 };
 
-describe('createSession', function () {
+describe.skip('createSession', function () {
   let driver;
   before(() => {
     driver = new AndroidDriver();

--- a/test/functional/webview-browser-tester-e2e-specs.js
+++ b/test/functional/webview-browser-tester-e2e-specs.js
@@ -17,16 +17,23 @@ const capabilities = {
   "chromedriverExecutable": path.join(process.cwd(), "chromedriver")
 };
 
-describe.skip('createSession', function () {
-  let driver;
+describe('Android 7 Webview Browser tester', function () {
+  let driver, test = this;
   before(() => {
+    if (process.env.REAL_DEVICE) {
+      test.pending = true;
+    }
+  });
+  beforeEach(async () => {
     driver = new AndroidDriver();
+    await driver.createSession(capabilities);
   });
   afterEach(async () => {
-    await driver.deleteSession();
+    if (driver) {
+      await driver.deleteSession();
+    }
   });
-  it('should start android session using webview browser tester on android 7', async () => {
-    await driver.createSession(capabilities);
+  it('should start android session using webview browser tester', async () => {
     await driver.setUrl("http://google.com");
     await sleep(1500);
     let contexts = await driver.getContexts();

--- a/test/functional/webview-browser-tester-e2e-specs.js
+++ b/test/functional/webview-browser-tester-e2e-specs.js
@@ -18,10 +18,10 @@ const capabilities = {
 };
 
 describe('Android 7 Webview Browser tester', function () {
-  let driver, test = this;
-  before(() => {
+  let driver;
+  before(function () {
     if (process.env.REAL_DEVICE) {
-      test.pending = true;
+      return this.skip();
     }
   });
   beforeEach(async () => {


### PR DESCRIPTION
Android 7 emulators without Google Play Services doesnt have the Stock Browser or Chrome by default, it comes with *WebView Browser Tester* (chromium 51.x)

Added the package and activity to run tests over this browser, it works with chromedriver `2.23` or below, so it will work by setting a custom `chromedriverExecutable`, since `appium-chromedriver` current version is `2.26`. 

<img src="https://www.dropbox.com/s/z9lh1tjeou860f1/Screen%20Shot%202017-03-19%20at%205.49.16%20PM.png?dl=1" />

Please review @imurchie @mhan