### PR TITLE
Dismiss chrome welcome

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -337,11 +337,11 @@ class AndroidDriver extends BaseDriver {
       let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
       await this.click(el.ELEMENT);
       try {
-        el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
-        if (!_.isUndefined(el)) {
-          await this.click(el.ELEMENT);
-        }
+        let el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
+        await this.click(el.ELEMENT);
       } catch (e) {
+        // DO NOTHING, THIS DEVICE DIDNT LAUNCH THE SIGNIN DIALOG
+        // IT MUST BE A NON GMS DEVICE
         log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
       }
     } else {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -337,7 +337,7 @@ class AndroidDriver extends BaseDriver {
       let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
       await this.click(el.ELEMENT);
       el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false).catch((e) => {
-        // DO NOTHING, THIS DEVICE DONT LAUNCH THE SIGNIN DIALOG,
+        // DO NOTHING, THIS DEVICE DIDNT LAUNCH THE SIGNIN DIALOG,
         // IT MUST BE A NON GMS DEVICE
         log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
       });
@@ -345,7 +345,7 @@ class AndroidDriver extends BaseDriver {
         await this.click(el.ELEMENT);
       }
     } else {
-      log.info("Chrome welcome dialog never show up! Continue");
+      log.info("Chrome welcome dialog never showoed up! Continuing");
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -261,6 +261,25 @@ class AndroidDriver extends BaseDriver {
       opts.chromeOptions.args.indexOf('--no-first-run') !== -1);
   }
 
+  async dismissChromeWelcome () {
+    log.info("Trying to dismiss Chrome welcome");
+    let activity = await this.getCurrentActivity();
+    if (activity === "org.chromium.chrome.browser.firstrun.FirstRunActivity") {
+      let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
+      await this.click(el.ELEMENT);
+      try {
+        let el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
+        await this.click(el.ELEMENT);
+      } catch (e) {
+        // DO NOTHING, THIS DEVICE DIDNT LAUNCH THE SIGNIN DIALOG
+        // IT MUST BE A NON GMS DEVICE
+        log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
+      }
+    } else {
+      log.info("Chrome welcome dialog never showoed up! Continuing");
+    }
+  }
+
   async initAutoWebview () {
     if (this.opts.autoWebview) {
       let viewName = this.defaultWebviewName();
@@ -274,7 +293,6 @@ class AndroidDriver extends BaseDriver {
       });
     }
   }
-
 
   async initAUT () {
     // populate appPackage, appActivity, appWaitPackage, appWaitActivity,
@@ -333,25 +351,6 @@ class AndroidDriver extends BaseDriver {
     this.sessionChromedrivers[CHROMIUM_WIN] = this.chromedriver;
     this.proxyReqRes = this.chromedriver.proxyReq.bind(this.chromedriver);
     this.jwpProxyActive = true;
-  }
-
-  async dismissChromeWelcome () {
-    log.info("Trying to dismiss Chrome welcome");
-    let activity = await this.getCurrentActivity();
-    if (activity === "org.chromium.chrome.browser.firstrun.FirstRunActivity") {
-      let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
-      await this.click(el.ELEMENT);
-      try {
-        let el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
-        await this.click(el.ELEMENT);
-      } catch (e) {
-        // DO NOTHING, THIS DEVICE DIDNT LAUNCH THE SIGNIN DIALOG
-        // IT MUST BE A NON GMS DEVICE
-        log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
-      }
-    } else {
-      log.info("Chrome welcome dialog never showoed up! Continuing");
-    }
   }
 
   async checkAppPresent () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -264,19 +264,19 @@ class AndroidDriver extends BaseDriver {
   async dismissChromeWelcome () {
     log.info("Trying to dismiss Chrome welcome");
     let activity = await this.getCurrentActivity();
-    if (activity === "org.chromium.chrome.browser.firstrun.FirstRunActivity") {
-      let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
-      await this.click(el.ELEMENT);
-      try {
-        let el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
-        await this.click(el.ELEMENT);
-      } catch (e) {
-        // DO NOTHING, THIS DEVICE DIDNT LAUNCH THE SIGNIN DIALOG
-        // IT MUST BE A NON GMS DEVICE
-        log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
-      }
-    } else {
+    if (activity !== "org.chromium.chrome.browser.firstrun.FirstRunActivity") {
       log.info("Chrome welcome dialog never showed up! Continuing");
+      return;
+    }
+    let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
+    await this.click(el.ELEMENT);
+    try {
+      let el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
+      await this.click(el.ELEMENT);
+    } catch (e) {
+      // DO NOTHING, THIS DEVICE DIDNT LAUNCH THE SIGNIN DIALOG
+      // IT MUST BE A NON GMS DEVICE
+      log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -242,7 +242,7 @@ class AndroidDriver extends BaseDriver {
     if (this.isChromeSession) {
       // start a chromedriver session and proxy to it
       await this.startChromeSession();
-      if (this.shouldDismissChromeWelcome(this.opts)) {
+      if (this.shouldDismissChromeWelcome()) {
         // dismiss Chrome welcome dialog
         await this.dismissChromeWelcome();
       }
@@ -255,10 +255,10 @@ class AndroidDriver extends BaseDriver {
     await this.initAutoWebview();
   }
 
-  shouldDismissChromeWelcome (opts) {
-    return !_.isUndefined(opts.chromeOptions) &&
-      _.isArray(opts.chromeOptions.args) &&
-      opts.chromeOptions.args.indexOf('--no-first-run') !== -1;
+  shouldDismissChromeWelcome () {
+    return !_.isUndefined(this.opts.chromeOptions) &&
+      _.isArray(this.opts.chromeOptions.args) &&
+      this.opts.chromeOptions.args.indexOf('--no-first-run') !== -1;
   }
 
   async dismissChromeWelcome () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -339,11 +339,13 @@ class AndroidDriver extends BaseDriver {
       el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false).catch((e) => {
         // DO NOTHING, THIS DEVICE DONT LAUNCH THE SIGNIN DIALOG,
         // IT MUST BE A NON GMS DEVICE
-        log.warn(`This device didnt show Signin dialog, ${e.message}`);
+        log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
       });
       if (!_.isUndefined(el)) {
         await this.click(el.ELEMENT);
       }
+    } else {
+      log.info("Chrome welcome dialog never show up! Continue");
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -256,9 +256,9 @@ class AndroidDriver extends BaseDriver {
   }
 
   shouldDismissChromeWelcome (opts) {
-    return (!_.isUndefined(opts.chromeOptions) &&
-      !_.isUndefined(opts.chromeOptions.args) &&
-      opts.chromeOptions.args.indexOf('--no-first-run') !== -1);
+    return !_.isUndefined(opts.chromeOptions) &&
+      _.isArray(opts.chromeOptions.args) &&
+      opts.chromeOptions.args.indexOf('--no-first-run') !== -1;
   }
 
   async dismissChromeWelcome () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -336,13 +336,13 @@ class AndroidDriver extends BaseDriver {
     if (activity === "org.chromium.chrome.browser.firstrun.FirstRunActivity") {
       let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
       await this.click(el.ELEMENT);
-      el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false).catch((e) => {
-        // DO NOTHING, THIS DEVICE DIDNT LAUNCH THE SIGNIN DIALOG,
-        // IT MUST BE A NON GMS DEVICE
+      try {
+        el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
+        if (!_.isUndefined(el)) {
+          await this.click(el.ELEMENT);
+        }
+      } catch (e) {
         log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
-      });
-      if (!_.isUndefined(el)) {
-        await this.click(el.ELEMENT);
       }
     } else {
       log.info("Chrome welcome dialog never showoed up! Continuing");

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -323,6 +323,28 @@ class AndroidDriver extends BaseDriver {
     this.sessionChromedrivers[CHROMIUM_WIN] = this.chromedriver;
     this.proxyReqRes = this.chromedriver.proxyReq.bind(this.chromedriver);
     this.jwpProxyActive = true;
+
+    // Dismiss Chrome welcome dialog
+    if (opts.chromeOptions.args.indexOf('--no-first-run') !== -1) {
+      await this.dismissChromeWelcome();
+    }
+  }
+
+  async dismissChromeWelcome () {
+    log.info("Trying to dismiss Chrome welcome");
+    let activity = await this.getCurrentActivity();
+    if (activity === "org.chromium.chrome.browser.firstrun.FirstRunActivity") {
+      let el = await this.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
+      await this.click(el.ELEMENT);
+      el = await this.findElOrEls('id', 'com.android.chrome:id/negative_button', false).catch((e) => {
+        // DO NOTHING, THIS DEVICE DONT LAUNCH THE SIGNIN DIALOG,
+        // IT MUST BE A NON GMS DEVICE
+        log.warn(`This device didnt show Signin dialog, ${e.message}`);
+      });
+      if (!_.isUndefined(el)) {
+        await this.click(el.ELEMENT);
+      }
+    }
   }
 
   async checkAppPresent () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -276,7 +276,7 @@ class AndroidDriver extends BaseDriver {
         log.warn(`This device didnt show Chrome SignIn dialog, ${e.message}`);
       }
     } else {
-      log.info("Chrome welcome dialog never showoed up! Continuing");
+      log.info("Chrome welcome dialog never showed up! Continuing");
     }
   }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -242,6 +242,10 @@ class AndroidDriver extends BaseDriver {
     if (this.isChromeSession) {
       // start a chromedriver session and proxy to it
       await this.startChromeSession();
+      if (this.shouldDismissChromeWelcome(this.opts)) {
+        // dismiss Chrome welcome dialog
+        await this.dismissChromeWelcome();
+      }
     } else {
       if (this.opts.autoLaunch) {
         // start app
@@ -249,6 +253,12 @@ class AndroidDriver extends BaseDriver {
       }
     }
     await this.initAutoWebview();
+  }
+
+  shouldDismissChromeWelcome (opts) {
+    return (!_.isUndefined(opts.chromeOptions) &&
+      !_.isUndefined(opts.chromeOptions.args) &&
+      opts.chromeOptions.args.indexOf('--no-first-run') !== -1);
   }
 
   async initAutoWebview () {
@@ -323,11 +333,6 @@ class AndroidDriver extends BaseDriver {
     this.sessionChromedrivers[CHROMIUM_WIN] = this.chromedriver;
     this.proxyReqRes = this.chromedriver.proxyReq.bind(this.chromedriver);
     this.jwpProxyActive = true;
-
-    // Dismiss Chrome welcome dialog
-    if (opts.chromeOptions.args.indexOf('--no-first-run') !== -1) {
-      await this.dismissChromeWelcome();
-    }
   }
 
   async dismissChromeWelcome () {

--- a/test/functional/chrome-e2e-specs.js
+++ b/test/functional/chrome-e2e-specs.js
@@ -13,8 +13,7 @@ const capabilities = {
   "deviceName": "Android Emulator",
   "chromeOptions": {
     "args": ["--no-first-run"]
-  },
-  "chromedriverExecutable": "/Users/vruno/Sauce/appium-android-driver/chromedriver"
+  }  
 };
 
 describe('createSession', function () {

--- a/test/functional/chrome-e2e-specs.js
+++ b/test/functional/chrome-e2e-specs.js
@@ -1,0 +1,33 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import AndroidDriver from '../..';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const capabilities = {
+  "browserName": "chrome",
+  "avd": "Nexus_5_API_25",
+  "platformName": "Android",
+  "platformVersion": "7.1",
+  "deviceName": "Android Emulator",
+  "chromeOptions": {
+    "args": ["--no-first-run"]
+  },
+  "chromedriverExecutable": "/Users/vruno/Sauce/appium-android-driver/chromedriver"
+};
+
+describe('createSession', function () {
+  let driver;
+  before(() => {
+    driver = new AndroidDriver();
+  });
+  afterEach(async () => {
+    await driver.deleteSession();
+  });
+  it('should start chrome and dismiss the welcome dialog', async () => {
+    await driver.createSession(capabilities);
+    let appActivity = await driver.getCurrentActivity();
+    appActivity.should.not.equal("org.chromium.chrome.browser.firstrun.FirstRunActivity");
+  });
+});

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -255,12 +255,18 @@ describe('driver', () => {
       driver = new AndroidDriver();
     });
     it('should verify chromeOptions args', () => {
-      driver.shouldDismissChromeWelcome({}).should.be.false;
-      driver.shouldDismissChromeWelcome({"chromeOptions":{}}).should.be.false;
-      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":[]}}).should.be.false;
-      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":"--no-first-run"}}).should.be.false;
-      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--disable-dinosaur-easter-egg"]}}).should.be.false;
-      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--no-first-run"]}}).should.be.true;
+      driver.opts = {};
+      driver.shouldDismissChromeWelcome().should.be.false;
+      driver.opts = {"chromeOptions":{}};
+      driver.shouldDismissChromeWelcome().should.be.false;
+      driver.opts = {"chromeOptions":{"args":[]}};
+      driver.shouldDismissChromeWelcome().should.be.false;
+      driver.opts = {"chromeOptions":{"args":"--no-first-run"}};
+      driver.shouldDismissChromeWelcome().should.be.false;
+      driver.opts = {"chromeOptions":{"args":["--disable-dinosaur-easter-egg"]}};
+      driver.shouldDismissChromeWelcome().should.be.false;
+      driver.opts = {"chromeOptions":{"args":["--no-first-run"]}};
+      driver.shouldDismissChromeWelcome().should.be.true;
     });
   });
   describe('startAndroidSession', () => {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -255,11 +255,12 @@ describe('driver', () => {
       driver = new AndroidDriver();
     });
     it('should verify chromeOptions args', () => {
-      driver.shouldDismissChromeWelcome({}).should.equal(false);
-      driver.shouldDismissChromeWelcome({"chromeOptions":{}}).should.equal(false);
-      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":[]}}).should.equal(false);
-      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--disable-dinosaur-easter-egg"]}}).should.equal(false);
-      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--no-first-run"]}}).should.equal(true);
+      driver.shouldDismissChromeWelcome({}).should.be.false;
+      driver.shouldDismissChromeWelcome({"chromeOptions":{}}).should.be.false;
+      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":[]}}).should.be.false;
+      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":"--no-first-run"}}).should.be.false;
+      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--disable-dinosaur-easter-egg"]}}).should.be.false;
+      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--no-first-run"]}}).should.be.true;
     });
   });
   describe('startAndroidSession', () => {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -250,6 +250,18 @@ describe('driver', () => {
       driver.adb.uninstallApk.calledOnce.should.be.true;
     });
   });
+  describe('shouldDismissChromeWelcome', () => {
+    before(async () => {
+      driver = new AndroidDriver();
+    });
+    it('should verify chromeOptions args', () => {
+      driver.shouldDismissChromeWelcome({}).should.equal(false);
+      driver.shouldDismissChromeWelcome({"chromeOptions":{}}).should.equal(false);
+      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":[]}}).should.equal(false);
+      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--disable-dinosaur-easter-egg"]}}).should.equal(false);
+      driver.shouldDismissChromeWelcome({"chromeOptions":{"args":["--no-first-run"]}}).should.equal(true);
+    });
+  });
   describe('startAndroidSession', () => {
     beforeEach(async () => {
       driver = new AndroidDriver();
@@ -272,6 +284,7 @@ describe('driver', () => {
       sandbox.stub(driver, 'defaultWebviewName');
       sandbox.stub(driver, 'setContext');
       sandbox.stub(driver, 'startChromeSession');
+      sandbox.stub(driver, 'dismissChromeWelcome');
       sandbox.stub(driver.settings, 'update');
       sandbox.stub(driver.adb, 'getPlatformVersion');
       sandbox.stub(driver.adb, 'getScreenSize');
@@ -352,6 +365,19 @@ describe('driver', () => {
       await driver.startAndroidSession();
       driver.settings.update.calledOnce.should.be.true;
       driver.settings.update.firstCall.args[0].ignoreUnimportantViews.should.be.true;
+    });
+    it('should not call dismissChromeWelcome on missing chromeOptions', async () => {
+      driver.opts.browserName = 'Chrome';
+      await driver.startAndroidSession();
+      driver.dismissChromeWelcome.calledOnce.should.be.false;
+    });
+    it('should call dismissChromeWelcome', async () => {
+      driver.opts.browserName = 'Chrome';
+      driver.opts.chromeOptions = {
+        "args" : ["--no-first-run"]
+      };
+      await driver.startAndroidSession();
+      driver.dismissChromeWelcome.calledOnce.should.be.true;
     });
   });
   describe('validateDesiredCaps', () => {


### PR DESCRIPTION
Some Chrome browsers are failing to avoid the Welcome dialog using the `--no-first-run` flag making tests to fail. 
I look at chromeOptions args in here;

* https://sites.google.com/a/chromium.org/chromedriver/capabilities
* http://peter.sh/experiments/chromium-command-line-switches/
* https://cs.chromium.org/chromium/src/chrome/common/chrome_switches.cc?q=kNoFirstRun&sq=package:chromium&type=cs&l=487

Unless i'm wrong I believe this flag is the one that should avoid the welcome dialog, since it's working for Android 7 gms emulators that had Chrome 51, but not for Android 7.1 emus with Chrome 53. 
We can avoid this by dismissing the dialog using uiautomation