### PR TITLE
Fix the default background command behaviour and remove invalid option

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -118,8 +118,13 @@ commands.installApp = async function (appPath) {
 };
 
 commands.background = async function (seconds) {
-  let {appPackage, appActivity} = await this.adb.getFocusedPackageAndActivity();
   await this.adb.goToHome();
+  if (seconds < 0) {
+    // if user passes in a negative seconds value, interpret that as the instruction
+    // to not bring the app back at all
+    return true;
+  }
+  let {appPackage, appActivity} = await this.adb.getFocusedPackageAndActivity();
   await B.delay(seconds * 1000);
   return this.adb.startApp({
     pkg: this.opts.appPackage,
@@ -130,7 +135,7 @@ commands.background = async function (seconds) {
     waitPkg: appPackage,
     waitActivity: appActivity,
     optionalIntentArguments: this.opts.optionalIntentArguments,
-    stopApp: this.opts.stopAppOnReset || !this.opts.dontStopAppOnReset,
+    stopApp: false
   });
 };
 
@@ -210,7 +215,7 @@ commands.startAUT = async function () {
     waitActivity: this.opts.appWaitActivity,
     waitDuration: this.opts.appWaitDuration,
     optionalIntentArguments: this.opts.optionalIntentArguments,
-    stopApp: this.opts.stopAppOnReset || !this.opts.dontStopAppOnReset,
+    stopApp: !this.opts.dontStopAppOnReset
   });
 };
 


### PR DESCRIPTION
Set the _stopApp_ parameter to _false_ for background command. I believe the value of _dontStopAppOnReset_ should not  affect this particular endpoint and it was just a copypaste issue.

_stopAppOnReset_ capability seems to be obsolete and is neither defined nor used anywhere else in android driver:

```
$ grep -Ri 'stopAppOnReset' *
commands/general.js:                                         dontStopAppOnReset) {
commands/general.js:  // dontStopAppOnReset is both an argument here, and a desired capability
commands/general.js:  if (!util.hasValue(dontStopAppOnReset)) {
commands/general.js:    dontStopAppOnReset = !!this.opts.dontStopAppOnReset;
commands/general.js:    stopApp: !dontStopAppOnReset
commands/general.js:    stopApp: !this.opts.dontStopAppOnReset,
desired-caps.js:  dontStopAppOnReset: {
```

Do not restore the app from background if negative number of seconds is provides - the same behaviour we have for iOS