### PR TITLE
Fix emulator detection

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -350,7 +350,7 @@ helpers.pushSettingsApp = async function (adb) {
   try {
     await adb.installOrUpgrade(settingsApkPath, SETTINGS_HELPER_PKG_ID);
   } catch (err) {
-    logger.warn(`Ignored error while installing Appium setting helper: "${err.message}". ` +
+    logger.warn(`Ignored error while installing Appium Settings helper: "${err.message}". ` +
                 `Expect some Appium features may not work as expected unless this problem is fixed.`);
   }
   try {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -347,8 +347,17 @@ helpers.setMockLocationApp = async function (adb, app) {
 
 helpers.pushSettingsApp = async function (adb) {
   logger.debug("Pushing settings apk to device...");
-  await adb.installOrUpgrade(settingsApkPath, SETTINGS_HELPER_PKG_ID);
-  await adb.grantAllPermissions(SETTINGS_HELPER_PKG_ID);
+  try {
+    await adb.installOrUpgrade(settingsApkPath, SETTINGS_HELPER_PKG_ID);
+  } catch (err) {
+    logger.warn(`Ignored error while installing Appium setting helper: "${err.message}". ` +
+                `Expect some Appium features may not work as expected unless this problem is fixed.`);
+  }
+  try {
+    await adb.grantAllPermissions(SETTINGS_HELPER_PKG_ID);
+  } catch (err) {
+    // errors are expected there, since the app contains non-changeable permissons
+  }
 };
 
 helpers.pushUnlock = async function (adb) {
@@ -455,7 +464,7 @@ helpers.initDevice = async function (adb, opts) {
   if (opts.unicodeKeyboard) {
     defaultIME = await helpers.initUnicodeKeyboard(adb);
   }
-  if (_.isUndefined(opts.avd)) {
+  if (!opts.avd) {
     await helpers.pushSettingsApp(adb);
   }
   if (_.isUndefined(opts.unlockType)) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -165,7 +165,7 @@ class AndroidDriver extends BaseDriver {
   }
 
   isEmulator () {
-    return !_.isUndefined(this.opts.avd);
+    return !!this.opts.avd;
   }
 
   setAvdFromCapabilities (caps) {


### PR DESCRIPTION
I dunno why, but it seems like the **avd** option is not equal to _undefined_ by default, but rather _null_
This patch should fix emulator detection for such case. See the issue report https://github.com/appium/appium/issues/8164 for the reference