### PR TITLE
Fix the place where activity name is received

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -118,13 +118,14 @@ commands.installApp = async function (appPath) {
 };
 
 commands.background = async function (seconds) {
-  await this.adb.goToHome();
   if (seconds < 0) {
     // if user passes in a negative seconds value, interpret that as the instruction
     // to not bring the app back at all
+    await this.adb.goToHome();
     return true;
   }
   let {appPackage, appActivity} = await this.adb.getFocusedPackageAndActivity();
+  await this.adb.goToHome();
   await B.delay(seconds * 1000);
   return this.adb.startApp({
     pkg: this.opts.appPackage,


### PR DESCRIPTION
It is necessary to get activity name before to tap HOME button, but not after.

Fixes the issue https://github.com/appium/appium/issues/8252
