### PR TITLE
Add androidInstallPath capability

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -215,20 +215,22 @@ helpers.getLaunchInfo = async function (adb, opts) {
   return {appPackage, appWaitPackage, appActivity, appWaitActivity};
 };
 
-helpers.getRemoteApkPath = function (localApkMd5) {
-  let remotePath = `${REMOTE_TEMP_PATH}/${localApkMd5}.apk`;
+helpers.getRemoteApkPath = function (localApkMd5, androidInstallPath) {
+  let remotePath = (androidInstallPath || REMOTE_TEMP_PATH).replace(/\/$/, '');
+  remotePath = `${remotePath}/${localApkMd5}.apk`;
   logger.info(`Remote apk path is ${remotePath}`);
   return remotePath;
 };
 
-helpers.resetApp = async function (adb, localApkPath, pkg, fastReset, androidInstallTimeout = REMOTE_INSTALL_TIMEOUT) {
+helpers.resetApp = async function (adb, localApkPath, pkg, fastReset,
+  androidInstallTimeout = REMOTE_INSTALL_TIMEOUT, androidInstallPath = REMOTE_TEMP_PATH) {
   if (fastReset) {
     logger.debug("Running fast reset (stop and clear)");
     await adb.stopAndClear(pkg);
   } else {
     logger.debug("Running old fashion reset (reinstall)");
     let apkMd5 = await fs.md5(localApkPath);
-    let remotePath = helpers.getRemoteApkPath(apkMd5, localApkPath);
+    let remotePath = helpers.getRemoteApkPath(apkMd5, androidInstallPath);
     if (!await adb.fileExists(remotePath)) {
       throw new Error("Can't run slow reset without a remote apk!");
     }
@@ -267,7 +269,7 @@ helpers.installApkRemotely = async function (adb, opts) {
   }
 
   let apkMd5 = await fs.md5(app);
-  let remotePath = await helpers.getRemoteApkPath(apkMd5, app);
+  let remotePath = await helpers.getRemoteApkPath(apkMd5, opts.androidInstallPath);
   let remoteApkExists = await adb.fileExists(remotePath);
   logger.debug("Checking if app is installed");
   let installed = await adb.isAppInstalled(appPackage);

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -216,8 +216,7 @@ helpers.getLaunchInfo = async function (adb, opts) {
 };
 
 helpers.getRemoteApkPath = function (localApkMd5, androidInstallPath) {
-  let remotePath = (androidInstallPath || REMOTE_TEMP_PATH).replace(/\/$/, '');
-  remotePath = `${remotePath}/${localApkMd5}.apk`;
+  let remotePath = path.join(androidInstallPath || REMOTE_TEMP_PATH, `${localApkMd5}.apk`);
   logger.info(`Remote apk path is ${remotePath}`);
   return remotePath;
 };

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -109,6 +109,9 @@ let commonCapConstraints = {
   androidScreenshotPath: {
     isString: true
   },
+  androidInstallPath: {
+    isString: true
+  },
   clearSystemFiles: {
     isBoolean: true
   },

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -267,6 +267,9 @@ describe('Android Helpers', () => {
     it('should return remote path', () => {
       helpers.getRemoteApkPath('foo').should.equal(`${REMOTE_TEMP_PATH}/foo.apk`);
     });
+    it('should return custom install path', () => {
+      helpers.getRemoteApkPath('foo', '/sdcard/Download/').should.equal(`/sdcard/Download/foo.apk`);
+    });
   });
   describe('resetApp', withMocks({adb, fs, helpers}, (mocks) => {
     const localApkPath = 'local';


### PR DESCRIPTION
Add possibility to set custom android install path using `androidInstallPath` capability. On some devices internal storage has low space for pushing large apps to `/data/local/tmp` so users may want to push the app to the sdcard. 