### PR TITLE
Speed up screenshoting

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -5,9 +5,13 @@ import path from 'path';
 import log from '../logger';
 import B from 'bluebird';
 import jimp from 'jimp';
+import { exec } from 'teen_process';
+import _ from 'lodash';
 
 const swipeStepsPerSec = 28;
 const dragStepsPerSec = 40;
+const PNG_MAGIC = 'efbfbd504e47';
+const PNG_MAGIC_LENGTH = 6;
 
 let commands = {}, helpers = {}, extensions = {};
 
@@ -169,32 +173,66 @@ commands.fingerprint = async function (fingerprintId) {
   await this.adb.fingerprint(fingerprintId);
 };
 
+async function storeScreenshotDataWithAdbShell (adb, opts, localFile) {
+  let pngDir = opts.androidScreenshotPath || '/data/local/tmp/';
+  const png = path.posix.resolve(pngDir, 'screenshot.png');
+  let cmd = ['/system/bin/rm', `${png};`, '/system/bin/screencap', '-p', png];
+  await adb.shell(cmd);
+  await adb.pull(png, localFile);
+}
+
+async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
+  let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p']);
+  if (!_.isString(stdout)) {
+    throw new Error(`Command output '${stdout}' is not a valid PNG file`);
+  }
+  const signature = new Buffer(stdout).toString('hex', 0, PNG_MAGIC_LENGTH);
+  if (signature === PNG_MAGIC) {
+    await fs.writeFile(localFile, stdout);
+  } else {
+    throw new Error(`Command output is not a valid PNG file (${signature} !== ${PNG_MAGIC})`);
+  }
+}
+
 commands.getScreenshot = async function () {
   let localFile = temp.path({prefix: 'appium', suffix: '.png'});
-  let pngDir = this.opts.androidScreenshotPath || '/data/local/tmp/';
-  const png = path.posix.resolve(pngDir, 'screenshot.png');
-  let cmd =  ['/system/bin/rm', `${png};`, '/system/bin/screencap', '-p', png];
-  await this.adb.shell(cmd);
   if (await fs.exists(localFile)) {
     await fs.unlink(localFile);
   }
-  await this.adb.pull(png, localFile);
-  let image = await jimp.read(localFile);
-  if (await this.adb.getApiLevel() < 23) {
-    // Android bug 8433742 - rotate screenshot if screen is rotated
-    let screenOrientation = await this.adb.getScreenOrientation();
+  const apiLevel = await this.adb.getApiLevel();
+  if (apiLevel > 20) {
     try {
-      image = await image.rotate(-90 * screenOrientation);
-    } catch (err) {
-      log.warn(`Could not rotate screenshot due to error: ${err}`);
+      // This screenshoting approach is way faster, since it requires less external commands
+      // to be executed. Unfortunately, exec-out option is only supported by newer Android/SDK versions (5.0 and later)
+      await storeScreenshotDataWithAdbExecOut(this.adb, localFile);
+    } catch (e) {
+      log.info(`Cannot get screenshot data with 'adb exec-out' because of '${e.message}'. Defaulting to 'adb shell' call`);
     }
   }
-  let b64data = (await B.promisify(image.getBuffer).call(image, jimp.MIME_PNG))
-                .toString('base64');
-  await fs.unlink(localFile);
-  return b64data;
+  if (!await fs.exists(localFile)) {
+    await storeScreenshotDataWithAdbShell(this.adb, this.opts, localFile);
+  }
+  if (!await fs.exists(localFile)) {
+    log.errorAndThrow(`The screenshot is expected to be present at ${localFile}`);
+  }
+  try {
+    let image = await jimp.read(localFile);
+    if (apiLevel < 23) {
+      // Android bug 8433742 - rotate screenshot if screen is rotated
+      let screenOrientation = await this.adb.getScreenOrientation();
+      try {
+        image = await image.rotate(-90 * screenOrientation);
+      } catch (err) {
+        log.warn(`Could not rotate screenshot due to error: ${err}`);
+      }
+    }
+    let b64data = (await B.promisify(image.getBuffer).call(image, jimp.MIME_PNG))
+                  .toString('base64');
+    return b64data;
+  } finally {
+    await fs.unlink(localFile);
+  }
 };
-
 
 Object.assign(extensions, commands, helpers);
 export { commands, helpers };

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -10,8 +10,8 @@ import _ from 'lodash';
 
 const swipeStepsPerSec = 28;
 const dragStepsPerSec = 40;
-const PNG_MAGIC = 'efbfbd504e47';
-const PNG_MAGIC_LENGTH = 6;
+const PNG_MAGIC = '89504e47';
+const PNG_MAGIC_LENGTH = 4;
 
 let commands = {}, helpers = {}, extensions = {};
 
@@ -182,7 +182,8 @@ async function storeScreenshotDataWithAdbShell (adb, opts, localFile) {
 }
 
 async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
-  let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p']);
+  let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
+                            {encoding: 'binary'});
   if (!_.isString(stdout)) {
     throw new Error(`Command output '${stdout}' is not a valid PNG file`);
   }
@@ -206,7 +207,8 @@ commands.getScreenshot = async function () {
       // to be executed. Unfortunately, exec-out option is only supported by newer Android/SDK versions (5.0 and later)
       await storeScreenshotDataWithAdbExecOut(this.adb, localFile);
     } catch (e) {
-      log.info(`Cannot get screenshot data with 'adb exec-out' because of '${e.message}'. Defaulting to 'adb shell' call`);
+      log.info(`Cannot get screenshot data with 'adb exec-out' because of '${e.message}'. ` +
+               `Defaulting to 'adb shell' call`);
     }
   }
   if (!await fs.exists(localFile)) {

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -6,7 +6,6 @@ import log from '../logger';
 import B from 'bluebird';
 import jimp from 'jimp';
 import { exec } from 'teen_process';
-import _ from 'lodash';
 
 const swipeStepsPerSec = 28;
 const dragStepsPerSec = 40;
@@ -184,12 +183,9 @@ async function storeScreenshotDataWithAdbShell (adb, opts, localFile) {
 async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
   let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
                             {encoding: 'binary'});
-  if (!_.isString(stdout)) {
-    throw new Error(`Command output '${stdout}' is not a valid PNG file`);
-  }
-  const signature = new Buffer(stdout).toString('hex', 0, PNG_MAGIC_LENGTH);
+  const signature = new Buffer(stdout, 'binary').toString('hex', 0, PNG_MAGIC_LENGTH);
   if (signature === PNG_MAGIC) {
-    await fs.writeFile(localFile, stdout);
+    await fs.writeFile(localFile, stdout, 'binary');
   } else {
     throw new Error(`Command output is not a valid PNG file (${signature} !== ${PNG_MAGIC})`);
   }

--- a/test/functional/commands/actions-e2e-specs.js
+++ b/test/functional/commands/actions-e2e-specs.js
@@ -8,8 +8,8 @@ import DEFAULT_CAPS from '../desired';
 chai.should();
 chai.use(chaiAsPromised);
 
-const PNG_MAGIC = 'efbfbd504e47';
-const PNG_MAGIC_LENGTH = 6;
+const PNG_MAGIC = '89504e47';
+const PNG_MAGIC_LENGTH = 4;
 
 let driver;
 let caps = _.defaults({

--- a/test/functional/commands/actions-e2e-specs.js
+++ b/test/functional/commands/actions-e2e-specs.js
@@ -8,6 +8,9 @@ import DEFAULT_CAPS from '../desired';
 chai.should();
 chai.use(chaiAsPromised);
 
+const PNG_MAGIC = 'efbfbd504e47';
+const PNG_MAGIC_LENGTH = 6;
+
 let driver;
 let caps = _.defaults({
   appPackage: 'io.appium.android.apis',
@@ -52,6 +55,14 @@ describe('actions', () => {
     });
     it('should long press key code 3 with metastate', async () => {
       await driver.longPressKeyCode(3, 193).should.not.be.rejected;
+    });
+  });
+
+  describe('getScreenshot', function () {
+    it('should return valid base64-encoded screenshot', async () => {
+      const base64screenshot = await driver.getScreenshot();
+      const imageMagic = new Buffer(base64screenshot, 'base64').toString('hex', 0, PNG_MAGIC_LENGTH);
+      imageMagic.should.be.equal(PNG_MAGIC);
     });
   });
 });


### PR DESCRIPTION
The new approach to screenshoting uses only one adb call instead of three and is much faster than the previous one. However, I would like to ask you guys to test the new implementation on your devices as well to make sure it works properly for all supported platforms. Thanks in advance.