### PR TITLE
Make sure remote path for apk is in posix format

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -216,7 +216,7 @@ helpers.getLaunchInfo = async function (adb, opts) {
 };
 
 helpers.getRemoteApkPath = function (localApkMd5, androidInstallPath) {
-  let remotePath = path.join(androidInstallPath || REMOTE_TEMP_PATH, `${localApkMd5}.apk`);
+  let remotePath = path.posix.join(androidInstallPath || REMOTE_TEMP_PATH, `${localApkMd5}.apk`);
   logger.info(`Remote apk path is ${remotePath}`);
   return remotePath;
 };
@@ -268,7 +268,7 @@ helpers.installApkRemotely = async function (adb, opts) {
   }
 
   let apkMd5 = await fs.md5(app);
-  let remotePath = await helpers.getRemoteApkPath(apkMd5, opts.androidInstallPath);
+  let remotePath = helpers.getRemoteApkPath(apkMd5, opts.androidInstallPath);
   let remoteApkExists = await adb.fileExists(remotePath);
   logger.debug("Checking if app is installed");
   let installed = await adb.isAppInstalled(appPackage);


### PR DESCRIPTION
On Windows systems we end up with Windows-formatted paths for things on the device. See https://github.com/appium/appium/issues/8377