### PR TITLE
Fix test-helper-specs path related tests when running on Windows

### DIFF
--- a/test/unit/test-helper-specs.js
+++ b/test/unit/test-helper-specs.js
@@ -15,31 +15,31 @@ describe('test helpers', () => {
 
     it('should get the correct path for Windows', async function () {
       mocks.system.expects('isWindows').once().returns(true);
-      let cdPath = await getChromedriver220Asset();
-      cdPath.should.eql(`${basePath}/test/assets/chromedriver-2.20/windows/chromedriver.exe`);
+      let cdPath = path.normalize(await getChromedriver220Asset());
+      cdPath.should.eql(path.normalize(`${basePath}/test/assets/chromedriver-2.20/windows/chromedriver.exe`));
       mocks.system.verify();
     });
     it('should get the correct path for Mac', async function () {
       mocks.system.expects('isWindows').once().returns(false);
       mocks.system.expects('isMac').once().returns(true);
-      let cdPath = await getChromedriver220Asset();
-      cdPath.should.eql(`${basePath}/test/assets/chromedriver-2.20/mac/chromedriver`);
+      let cdPath = path.normalize(await getChromedriver220Asset());
+      cdPath.should.eql(path.normalize(`${basePath}/test/assets/chromedriver-2.20/mac/chromedriver`));
       mocks.system.verify();
     });
     it('should get the correct path for Unix 32-bit', async function () {
       mocks.system.expects('isWindows').once().returns(false);
       mocks.system.expects('isMac').once().returns(false);
       mocks.system.expects('arch').once().returns('32');
-      let cdPath = await getChromedriver220Asset();
-      cdPath.should.eql(`${basePath}/test/assets/chromedriver-2.20/linux-32/chromedriver`);
+      let cdPath = path.normalize(await getChromedriver220Asset());
+      cdPath.should.eql(path.normalize(`${basePath}/test/assets/chromedriver-2.20/linux-32/chromedriver`));
       mocks.system.verify();
     });
     it('should get the correct path for Unix 64-bit', async function () {
       mocks.system.expects('isWindows').once().returns(false);
       mocks.system.expects('isMac').once().returns(false);
       mocks.system.expects('arch').once().returns('64');
-      let cdPath = await getChromedriver220Asset();
-      cdPath.should.eql(`${basePath}/test/assets/chromedriver-2.20/linux-64/chromedriver`);
+      let cdPath = path.normalize(await getChromedriver220Asset());
+      cdPath.should.eql(path.normalize(`${basePath}/test/assets/chromedriver-2.20/linux-64/chromedriver`));
       mocks.system.verify();
     });
   }));


### PR DESCRIPTION
The test-helper-specs tests do not account for different path segment separation characters on Windows.

I have normalized these paths so that the tests pass on Windows and also tested that the same tests pass on OSX.