### PR TITLE
Update webview-helpers to handle crosswalk webviews 

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -6,6 +6,8 @@ const NATIVE_WIN = "NATIVE_APP";
 const WEBVIEW_WIN = "WEBVIEW";
 const WEBVIEW_BASE = `${WEBVIEW_WIN}_`;
 const CHROMIUM_WIN = "CHROMIUM";
+const CROSSWALK_SOCKET_SUFFIX = "_devtools_remote";
+const CROSSWALK_REGEXP = `(\\S*)${CROSSWALK_SOCKET_SUFFIX}`;
 
 let helpers = {};
 
@@ -16,23 +18,35 @@ let helpers = {};
 // same as chrome-backed webviews)
 // TODO: some of this function belongs in appium-adb
 async function webviewsFromProcs (adb, deviceSocket) {
+  const WEBVIEW_REGEXP = `@?webview_devtools_remote_(\\d+)`;
   let webviews = [];
   let out = await adb.shell(["cat", "/proc/net/unix"]);
   for (let line of out.split("\n")) {
     line = line.trim();
-    let webviewPid = line.match(/@?webview_devtools_remote_(\d+)/);
     if (deviceSocket) {
       if (line.indexOf(`@${deviceSocket}`) === line.length - deviceSocket.length - 1) {
-        if (webviewPid) {
-          webviews.push(WEBVIEW_BASE + webviewPid[1]);
-        } else {
+        let webviewPid;
+        let crosswalkWebviewSocket;
+
+        if (deviceSocket === "chrome_devtools_remote") {
           webviews.push(CHROMIUM_WIN);
+        } else if ((webviewPid = line.match(new RegExp(WEBVIEW_REGEXP)))) {
+          webviews.push(WEBVIEW_BASE + webviewPid[1]);
+        } else if ((crosswalkWebviewSocket = line.match(new RegExp("@" + CROSSWALK_REGEXP)))) {
+          webviews.push(WEBVIEW_BASE + crosswalkWebviewSocket[1]);
         }
       }
-    } else if (webviewPid) {
-      // for multiple webviews a list of 'WEBVIEW_<index>' will be returned
-      // where <index> is zero based (same is in selendroid)
-      webviews.push(WEBVIEW_BASE + webviewPid[1]);
+    } else {
+      let webviewPid;
+      let crosswalkWebviewSocket;
+
+      if ((webviewPid = line.match(new RegExp(WEBVIEW_REGEXP)))) {
+        // for multiple webviews a list of 'WEBVIEW_<index>' will be returned
+        // where <index> is zero based (same is in selendroid)
+        webviews.push(WEBVIEW_BASE + webviewPid[1]);
+      } else if ((crosswalkWebviewSocket = line.match(new RegExp("@" + CROSSWALK_REGEXP)))) {
+        webviews.push(WEBVIEW_BASE + crosswalkWebviewSocket[1] + CROSSWALK_SOCKET_SUFFIX);
+      }
     }
   }
   return _.uniq(webviews);
@@ -44,6 +58,14 @@ async function webviewsFromProcs (adb, deviceSocket) {
 // not some other running app
 // TODO: this should be called procFromPid and exist in appium-adb
 async function procFromWebview (adb, webview) {
+  if (webview.match(new RegExp(WEBVIEW_BASE + "(\\d+)")) === null) {
+    let processName = webview.match(new RegExp(WEBVIEW_BASE + CROSSWALK_REGEXP));
+    if (processName === null) {
+      throw new Error(`Could not find process name for webview ${webview}`);
+    }
+    return processName[1]; 
+  }
+
   // webview_devtools_remote_4296 => 4296
   let pid = webview.match(/\d+$/);
   if (!pid) {

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -5,9 +5,13 @@ import { asyncmap } from 'asyncbox';
 const NATIVE_WIN = "NATIVE_APP";
 const WEBVIEW_WIN = "WEBVIEW";
 const WEBVIEW_BASE = `${WEBVIEW_WIN}_`;
+const WEBVIEW_REGEXP = new RegExp(`@?webview_devtools_remote_(\\d+)`);
+const WEBVIEW_PID_REGEXP = new RegExp(`${WEBVIEW_BASE}(\\d+)`);
 const CHROMIUM_WIN = "CHROMIUM";
 const CROSSWALK_SOCKET_SUFFIX = "_devtools_remote";
-const CROSSWALK_REGEXP = `(\\S*)${CROSSWALK_SOCKET_SUFFIX}`;
+const CROSSWALK_REGEXP_STRING = `(\\S*)${CROSSWALK_SOCKET_SUFFIX}`;
+const CROSSWALK_REGEXP = new RegExp(`@${CROSSWALK_REGEXP_STRING}`);
+const CROSSWALK_PROCESS_REGEXP = new RegExp(WEBVIEW_BASE + CROSSWALK_REGEXP_STRING);
 
 let helpers = {};
 
@@ -18,34 +22,33 @@ let helpers = {};
 // same as chrome-backed webviews)
 // TODO: some of this function belongs in appium-adb
 async function webviewsFromProcs (adb, deviceSocket) {
-  const WEBVIEW_REGEXP = `@?webview_devtools_remote_(\\d+)`;
   let webviews = [];
   let out = await adb.shell(["cat", "/proc/net/unix"]);
   for (let line of out.split("\n")) {
     line = line.trim();
+
     if (deviceSocket) {
       if (line.indexOf(`@${deviceSocket}`) === line.length - deviceSocket.length - 1) {
-        let webviewPid;
-        let crosswalkWebviewSocket;
-
         if (deviceSocket === "chrome_devtools_remote") {
           webviews.push(CHROMIUM_WIN);
-        } else if ((webviewPid = line.match(new RegExp(WEBVIEW_REGEXP)))) {
-          webviews.push(WEBVIEW_BASE + webviewPid[1]);
-        } else if ((crosswalkWebviewSocket = line.match(new RegExp("@" + CROSSWALK_REGEXP)))) {
-          webviews.push(WEBVIEW_BASE + crosswalkWebviewSocket[1]);
+          continue;
         }
       }
-    } else {
-      let webviewPid;
-      let crosswalkWebviewSocket;
+    }
 
-      if ((webviewPid = line.match(new RegExp(WEBVIEW_REGEXP)))) {
-        // for multiple webviews a list of 'WEBVIEW_<index>' will be returned
-        // where <index> is zero based (same is in selendroid)
-        webviews.push(WEBVIEW_BASE + webviewPid[1]);
-      } else if ((crosswalkWebviewSocket = line.match(new RegExp("@" + CROSSWALK_REGEXP)))) {
-        webviews.push(WEBVIEW_BASE + crosswalkWebviewSocket[1] + CROSSWALK_SOCKET_SUFFIX);
+    let webviewPid;
+    let crosswalkWebviewSocket;
+    if ((webviewPid = line.match(WEBVIEW_REGEXP))) {
+      // for multiple webviews a list of 'WEBVIEW_<index>' will be returned
+      // where <index> is zero based (same is in selendroid)
+      webviews.push(`${WEBVIEW_BASE}${webviewPid[1]}`);
+    } else if ((crosswalkWebviewSocket = line.match(CROSSWALK_REGEXP))) {
+      if (deviceSocket) {
+        if (crosswalkWebviewSocket[0].slice(1) === deviceSocket) {
+          webviews.push(`${WEBVIEW_BASE}${crosswalkWebviewSocket[1]}`);
+        }
+      } else {
+        webviews.push(`${WEBVIEW_BASE}${crosswalkWebviewSocket[1]}${CROSSWALK_SOCKET_SUFFIX}`);
       }
     }
   }
@@ -58,8 +61,8 @@ async function webviewsFromProcs (adb, deviceSocket) {
 // not some other running app
 // TODO: this should be called procFromPid and exist in appium-adb
 async function procFromWebview (adb, webview) {
-  if (webview.match(new RegExp(WEBVIEW_BASE + "(\\d+)")) === null) {
-    let processName = webview.match(new RegExp(WEBVIEW_BASE + CROSSWALK_REGEXP));
+  if (webview.match(WEBVIEW_PID_REGEXP) === null) {
+    let processName = webview.match(CROSSWALK_PROCESS_REGEXP);
     if (processName === null) {
       throw new Error(`Could not find process name for webview ${webview}`);
     }


### PR DESCRIPTION
There has been a long running issue with finding crosswalk webviews on Android as logged in  https://github.com/appium/appium/issues/4597

There is a two part fix:
1. Fix chromedriver (there is a patch in codereview at https://codereview.chromium.org/2375613002/)
2. Update appium-android-driver to find the corresponding crosswalk webviews (this PR)

I have updated the tests to cover this scenario and implemented the changes to the webview-helper code.
