### PR TITLE
Add more debug output for java version getter in case of failure

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -33,10 +33,13 @@ helpers.parseJavaVersion = function (stderr) {
 helpers.getJavaVersion = async function () {
   logger.debug("Getting Java version");
 
-  let {stderr} = await exec('java', ['-version']);
+  let {stdout, stderr, code} = await exec('java', ['-version']);
+  if (code !== 0) {
+    throw new Error(`Cannot get the Java version. Command return code: ${code}, stderr: "${stderr}", stdout: "${stdout}"`);
+  }
   let javaVer = helpers.parseJavaVersion(stderr);
   if (javaVer === null) {
-    throw new Error("Could not get the Java version. Is Java installed?");
+    throw new Error(`Cannot parse Java version from "${stderr}"`);
   }
   logger.info(`Java version is: ${javaVer}`);
   return javaVer;

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -34,14 +34,20 @@ describe('Android Helpers', () => {
   describe('getJavaVersion', withMocks({teen_process}, (mocks) => {
     it('should correctly get java version', async () => {
       mocks.teen_process.expects('exec').withExactArgs('java', ['-version'])
-        .returns({stderr: 'java version "1.8.0_40"'});
+        .returns({code: 0, stderr: 'java version "1.8.0_40"'});
       (await helpers.getJavaVersion()).should.equal('1.8.0_40');
       mocks.teen_process.verify();
     });
-    it('should return null if it cannot parse java verstion', async () => {
+    it('should be rejected if cannot parse java verstion', async () => {
       mocks.teen_process.expects('exec').withExactArgs('java', ['-version'])
-        .returns({stderr: 'foo bar'});
-      await helpers.getJavaVersion().should.eventually.be.rejectedWith('Java');
+        .returns({code: 0, stderr: 'foo bar'});
+      await helpers.getJavaVersion().should.eventually.be.rejectedWith('Cannot parse Java version');
+      mocks.teen_process.verify();
+    });
+    it('should be rejected if `java -version` command returns non-zero code', async () => {
+      mocks.teen_process.expects('exec').withExactArgs('java', ['-version'])
+        .returns({code: 1});
+      await helpers.getJavaVersion().should.eventually.be.rejectedWith('Cannot get the Java version');
       mocks.teen_process.verify();
     });
   }));


### PR DESCRIPTION
It looks like Oracle did some changes to `java -version` in the recent SDK release. It unexpectedly fails for me with error code 1 having the current implementation. Getting the stdout and stderr buffers explicitly seem to resolve the problem. 
I've also added more details to the exception message, so one can better investigate java-related issues in case of failure.