### PR TITLE
patch to pass android package name to chromedriver

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -212,9 +212,10 @@ async function setupNewChromedriver (opts, curDeviceId, adbPort) {
     adbPort
   };
   let chromedriver = new Chromedriver(chromeArgs);
+  let appPackage = (opts.chromeOptions && opts.chromeOptions.androidPackage) || opts.appPackage;
   let caps = {
     chromeOptions: {
-      androidPackage: opts.appPackage,
+      androidPackage: appPackage,
     }
   };
   if (opts.chromeUseRunningApp) {


### PR DESCRIPTION
### Modification
Modified lib/commands/context.js setupNewChromedriver() method to accept the androidPackage
passed via opts.chromeOptions passed by the client in desiredCapabilities.

### Git hub Issue  : https://github.com/appium/appium/issues/8032

### Reviewers
@dpgraham 
