### PR TITLE
Fix screenshoting with exec-out

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -183,37 +183,39 @@ commands.sendSMS = async function (phoneNumber, message) {
   await this.adb.sendSMS(phoneNumber, message);
 };
 
-async function storeScreenshotDataWithAdbShell (adb, opts, localFile) {
-  let pngDir = opts.androidScreenshotPath || '/data/local/tmp/';
-  const png = path.posix.resolve(pngDir, 'screenshot.png');
-  let cmd = ['/system/bin/rm', `${png};`, '/system/bin/screencap', '-p', png];
-  await adb.shell(cmd);
-  await adb.pull(png, localFile);
-  return await jimp.read(localFile);
-}
-
-async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
-  let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
-                            {encoding: 'binary'});
-  if (!stdout.length) {
-    throw new Error('"adb exec-out" command output is not a valid PNG file');
-  }
-  await fs.writeFile(localFile, new Buffer(stdout, 'binary'), {encoding: 'binary'});
-  return await jimp.read(localFile);
-}
-
-commands.getScreenshot = async function () {
-  let localFile = temp.path({prefix: 'appium', suffix: '.png'});
+async function getScreenshotDataWithAdbShell (adb, opts) {
+  const localFile = temp.path({prefix: 'appium', suffix: '.png'});
   if (await fs.exists(localFile)) {
     await fs.unlink(localFile);
   }
+  try {
+    const pngDir = opts.androidScreenshotPath || '/data/local/tmp/';
+    const png = path.posix.resolve(pngDir, 'screenshot.png');
+    const cmd = ['/system/bin/rm', `${png};`, '/system/bin/screencap', '-p', png];
+    await adb.shell(cmd);
+    await adb.pull(png, localFile);
+    return await jimp.read(localFile);
+  } finally {
+    if (await fs.exists(localFile)) {
+      await fs.unlink(localFile);
+    }
+  }
+}
+
+async function getScreenshotDataWithAdbExecOut (adb) {
+  let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
+                            {encoding: 'binary', isBuffer: true});
+  return await jimp.read(stdout);
+}
+
+commands.getScreenshot = async function () {
   const apiLevel = await this.adb.getApiLevel();
   let image = null;
   if (apiLevel > 20) {
     try {
       // This screenshoting approach is way faster, since it requires less external commands
       // to be executed. Unfortunately, exec-out option is only supported by newer Android/SDK versions (5.0 and later)
-      image = await storeScreenshotDataWithAdbExecOut(this.adb, localFile);
+      image = await getScreenshotDataWithAdbExecOut(this.adb);
     } catch (e) {
       log.info(`Cannot get screenshot data with 'adb exec-out' because of '${e.message}'. ` +
                `Defaulting to 'adb shell' call`);
@@ -221,27 +223,21 @@ commands.getScreenshot = async function () {
   }
   if (!image) {
     try {
-      image = await storeScreenshotDataWithAdbShell(this.adb, this.opts, localFile);
+      image = await getScreenshotDataWithAdbShell(this.adb, this.opts);
     } catch (e) {
       log.errorAndThrow(`Cannot get screenshot data because of '${e.message}'`);
     }
   }
-  try {
-    if (apiLevel < 23) {
-      // Android bug 8433742 - rotate screenshot if screen is rotated
-      let screenOrientation = await this.adb.getScreenOrientation();
-      try {
-        image = await image.rotate(-90 * screenOrientation);
-      } catch (err) {
-        log.warn(`Could not rotate screenshot due to error: ${err}`);
-      }
+  if (apiLevel < 23) {
+    // Android bug 8433742 - rotate screenshot if screen is rotated
+    let screenOrientation = await this.adb.getScreenOrientation();
+    try {
+      image = await image.rotate(-90 * screenOrientation);
+    } catch (err) {
+      log.warn(`Could not rotate screenshot due to error: ${err}`);
     }
-    let b64data = (await B.promisify(image.getBuffer).call(image, jimp.MIME_PNG))
-                  .toString('base64');
-    return b64data;
-  } finally {
-    await fs.unlink(localFile);
   }
+  return (await B.promisify(image.getBuffer).call(image, jimp.MIME_PNG)).toString('base64');
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -196,9 +196,9 @@ async function storeScreenshotDataWithAdbShell (adb, opts, localFile) {
 async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
   let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
                             {encoding: 'binary'});
-  const signature = new Buffer(stdout, 'binary').toString('hex', 0, PNG_MAGIC_LENGTH);
+  const signature = stdout.toString('hex', 0, PNG_MAGIC_LENGTH);
   if (signature === PNG_MAGIC) {
-    await fs.writeFile(localFile, stdout, 'binary');
+    await fs.writeFile(localFile, stdout, {encoding: 'binary', mode: 0o755});
   } else {
     throw new Error(`Command output is not a valid PNG file (${signature} !== ${PNG_MAGIC})`);
   }

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -9,8 +9,6 @@ import { exec } from 'teen_process';
 
 const swipeStepsPerSec = 28;
 const dragStepsPerSec = 40;
-const PNG_MAGIC = '89504e47';
-const PNG_MAGIC_LENGTH = 4;
 
 let commands = {}, helpers = {}, extensions = {};
 
@@ -191,16 +189,17 @@ async function storeScreenshotDataWithAdbShell (adb, opts, localFile) {
   let cmd = ['/system/bin/rm', `${png};`, '/system/bin/screencap', '-p', png];
   await adb.shell(cmd);
   await adb.pull(png, localFile);
+  return await jimp.read(localFile);
 }
 
 async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
   let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
                             {encoding: 'binary'});
-  const signature = new Buffer(stdout).toString('hex', 0, PNG_MAGIC_LENGTH);
-  if (signature !== PNG_MAGIC) {
-    throw new Error(`Command output is not a valid PNG file (${signature} !== ${PNG_MAGIC})`);
+  if (!stdout.length) {
+    throw new Error('"adb exec-out" command output is not a valid PNG file');
   }
   await fs.writeFile(localFile, stdout, {encoding: 'binary', mode: 0o755});
+  return await jimp.read(localFile);
 }
 
 commands.getScreenshot = async function () {
@@ -209,24 +208,25 @@ commands.getScreenshot = async function () {
     await fs.unlink(localFile);
   }
   const apiLevel = await this.adb.getApiLevel();
+  let image = null;
   if (apiLevel > 20) {
     try {
       // This screenshoting approach is way faster, since it requires less external commands
       // to be executed. Unfortunately, exec-out option is only supported by newer Android/SDK versions (5.0 and later)
-      await storeScreenshotDataWithAdbExecOut(this.adb, localFile);
+      image = await storeScreenshotDataWithAdbExecOut(this.adb, localFile);
     } catch (e) {
       log.info(`Cannot get screenshot data with 'adb exec-out' because of '${e.message}'. ` +
                `Defaulting to 'adb shell' call`);
     }
   }
-  if (!await fs.exists(localFile)) {
-    await storeScreenshotDataWithAdbShell(this.adb, this.opts, localFile);
-  }
-  if (!await fs.exists(localFile)) {
-    log.errorAndThrow(`The screenshot is expected to be present at ${localFile}`);
+  if (!image) {
+    try {
+      image = await storeScreenshotDataWithAdbShell(this.adb, this.opts, localFile);
+    } catch (e) {
+      log.errorAndThrow(`Cannot get screenshot data because of '${e.message}'`);
+    }
   }
   try {
-    let image = await jimp.read(localFile);
     if (apiLevel < 23) {
       // Android bug 8433742 - rotate screenshot if screen is rotated
       let screenOrientation = await this.adb.getScreenOrientation();

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -237,7 +237,9 @@ commands.getScreenshot = async function () {
       log.warn(`Could not rotate screenshot due to error: ${err}`);
     }
   }
-  return (await B.promisify(image.getBuffer).call(image, jimp.MIME_PNG)).toString('base64');
+  const getBuffer = B.promisify(image.getBuffer, {context: image});
+  const imgBuffer = await getBuffer(jimp.MIME_PNG);
+  return imgBuffer.toString('base64');
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -196,7 +196,7 @@ async function storeScreenshotDataWithAdbShell (adb, opts, localFile) {
 async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
   let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
                             {encoding: 'binary'});
-  const signature = stdout.toString('hex', 0, PNG_MAGIC_LENGTH);
+  const signature = new Buffer(stdout).toString('hex', 0, PNG_MAGIC_LENGTH);
   if (signature !== PNG_MAGIC) {
     throw new Error(`Command output is not a valid PNG file (${signature} !== ${PNG_MAGIC})`);
   }

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -197,11 +197,10 @@ async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
   let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
                             {encoding: 'binary'});
   const signature = stdout.toString('hex', 0, PNG_MAGIC_LENGTH);
-  if (signature === PNG_MAGIC) {
-    await fs.writeFile(localFile, stdout, {encoding: 'binary', mode: 0o755});
-  } else {
+  if (signature !== PNG_MAGIC) {
     throw new Error(`Command output is not a valid PNG file (${signature} !== ${PNG_MAGIC})`);
   }
+  await fs.writeFile(localFile, stdout, {encoding: 'binary', mode: 0o755});
 }
 
 commands.getScreenshot = async function () {

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -198,7 +198,7 @@ async function storeScreenshotDataWithAdbExecOut (adb, localFile) {
   if (!stdout.length) {
     throw new Error('"adb exec-out" command output is not a valid PNG file');
   }
-  await fs.writeFile(localFile, stdout, {encoding: 'binary', mode: 0o755});
+  await fs.writeFile(localFile, new Buffer(stdout, 'binary'), {encoding: 'binary'});
   return await jimp.read(localFile);
 }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lodash": "^3.10.0",
     "portfinder": "^1.0.6",
     "source-map-support": "^0.3.1",
-    "teen_process": "^1.4.0",
+    "teen_process": "^1.9.0",
     "temp": "^0.8.3",
     "yargs": "^6.6.0"
   },


### PR DESCRIPTION
Trying to address the issue visible in https://gist.github.com/ajaj91/a457b8b378481f9ddee39434f3343785:

> [AndroidDriver] Cannot get screenshot data with 'adb exec-out' because of 'Command output is not a valid PNG file (fd504e47 !== 89504e47)'. Defaulting to 'adb shell' call
