### PR TITLE
Do not try to pull zero-size screenshots

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -193,6 +193,9 @@ async function getScreenshotDataWithAdbShell (adb, opts) {
     const png = path.posix.resolve(pngDir, 'screenshot.png');
     const cmd = ['/system/bin/rm', `${png};`, '/system/bin/screencap', '-p', png];
     await adb.shell(cmd);
+    if (!await adb.fileSize(png)) {
+      throw new Error('The size of the taken screenshot equals to zero.');
+    }
     await adb.pull(png, localFile);
     return await jimp.read(localFile);
   } finally {
@@ -205,6 +208,9 @@ async function getScreenshotDataWithAdbShell (adb, opts) {
 async function getScreenshotDataWithAdbExecOut (adb) {
   let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
                             {encoding: 'binary', isBuffer: true});
+  if (!stdout.byteLength) {
+    throw new Error('The size of the taken screenshot equals to zero.');
+  }
   return await jimp.read(stdout);
 }
 

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -208,7 +208,7 @@ async function getScreenshotDataWithAdbShell (adb, opts) {
 async function getScreenshotDataWithAdbExecOut (adb) {
   let {stdout} = await exec(adb.executable.path, ['exec-out', '/system/bin/screencap -p'],
                             {encoding: 'binary', isBuffer: true});
-  if (!stdout.byteLength) {
+  if (!stdout.length) {
     throw new Error('The size of the taken screenshot equals to zero.');
   }
   return await jimp.read(stdout);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-adb": "^2.23.0",
+    "appium-adb": "^2.23.5",
     "appium-android-bootstrap": "^2.7.5",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^2.0.0",


### PR DESCRIPTION
Do not try to pull/handle zero-sized screenshots. The screencap utility may return such if one tries to take a screenshot where this is prohibited by Android API. And there is a [complain](https://github.com/appium/appium/issues/8697) about unexpected freeze after one tries to pull zero-size screenshot from the device. 