### PR TITLE
Skip setting of mock location app for emulator

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -471,11 +471,11 @@ helpers.initDevice = async function (adb, opts) {
   }
   if (!opts.avd) {
     await helpers.pushSettingsApp(adb);
+    await helpers.setMockLocationApp(adb, SETTINGS_HELPER_PKG_ID);
   }
   if (_.isUndefined(opts.unlockType)) {
     await helpers.pushUnlock(adb);
   }
-  await helpers.setMockLocationApp(adb, 'io.appium.settings');
   return defaultIME;
 };
 


### PR DESCRIPTION
This is a copy of https://github.com/appium/appium-android-driver/pull/239, which has been accidentally deleted before it was merged.

Addresses https://github.com/appium/appium/issues/9000