### PR TITLE
Launch settings app

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -367,7 +367,7 @@ helpers.pushSettingsApp = async function (adb) {
   // if the app is not launched prior to start the session on android 7+
   // see https://github.com/appium/appium/issues/8957
   try {
-    if ((await adb.getApiLevel()) >= 24) {
+    if ((await adb.getApiLevel()) >= 23) {
       let startOpts = {
         pkg: "io.appium.settings",
         activity: ".Settings",

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -363,6 +363,24 @@ helpers.pushSettingsApp = async function (adb) {
   } catch (err) {
     // errors are expected there, since the app contains non-changeable permissons
   }
+  // lauch io.appium.settings app due to settings failing to be set
+  // if the app is not launched prior to start the session on android 7+
+  // see https://github.com/appium/appium/issues/8957
+  try {
+    if ((await adb.getApiLevel()) >= 24) {
+      let startOpts = {
+        pkg: "io.appium.settings",
+        activity: ".",
+        action: "android.intent.action.MAIN",
+        category: "android.intent.category.LAUNCHER",
+        flags: "0x10200000",
+        stopApp: false
+      };
+      await adb.startApp(startOpts);
+    }
+  } catch (err) {
+    logger.warn(`Failed to launch settings app: "${err.message}".`);
+  }
 };
 
 helpers.pushUnlock = async function (adb) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -368,7 +368,7 @@ helpers.pushSettingsApp = async function (adb) {
   // if the app is not launched prior to start the session on android 7+
   // see https://github.com/appium/appium/issues/8957
   try {
-    if ((await adb.getApiLevel()) >= 23) {
+    if (!(await adb.processExists(SETTINGS_HELPER_PKG_ID))) {
       let startOpts = {
         pkg: SETTINGS_HELPER_PKG_ID,
         activity: SETTINGS_HELPER_PKG_ACTIVITY,

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -370,7 +370,7 @@ helpers.pushSettingsApp = async function (adb) {
     if ((await adb.getApiLevel()) >= 24) {
       let startOpts = {
         pkg: "io.appium.settings",
-        activity: ".",
+        activity: ".Settings",
         action: "android.intent.action.MAIN",
         category: "android.intent.category.LAUNCHER",
         flags: "0x10200000",

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -17,6 +17,7 @@ const CHROME_BROWSERS = ["Chrome", "Chromium", "Chromebeta", "Browser",
                          "chrome", "chromium", "chromebeta", "browser",
                          "chromium-browser", "chromium-webview"];
 const SETTINGS_HELPER_PKG_ID = 'io.appium.settings';
+const SETTINGS_HELPER_PKG_ACTIVITY = ".Settings";
 
 let helpers = {};
 
@@ -369,8 +370,8 @@ helpers.pushSettingsApp = async function (adb) {
   try {
     if ((await adb.getApiLevel()) >= 23) {
       let startOpts = {
-        pkg: "io.appium.settings",
-        activity: ".Settings",
+        pkg: SETTINGS_HELPER_PKG_ID,
+        activity: SETTINGS_HELPER_PKG_ACTIVITY,
         action: "android.intent.action.MAIN",
         category: "android.intent.category.LAUNCHER",
         flags: "0x10200000",

--- a/test/functional/settings-e2e-specs.js
+++ b/test/functional/settings-e2e-specs.js
@@ -13,11 +13,17 @@ let defaultCaps = _.defaults({
   browserName: 'chrome'
 }, DEFAULT_CAPS);
 
-describe.skip('toggle wifi tests', () => {
+describe('toggle wifi tests', () => {
   let driver;
 
   describe('functional', () => {
     before(() => {
+      if (process.env.TRAVIS) {
+        return this.skip();
+      }
+      if (!process.env.REAL_DEVICE) {
+        return this.skip();
+      }
       driver = new AndroidDriver();
     });
     afterEach(async () => {

--- a/test/functional/settings-e2e-specs.js
+++ b/test/functional/settings-e2e-specs.js
@@ -17,7 +17,7 @@ describe('toggle wifi tests', () => {
   let driver;
 
   describe('functional', () => {
-    before(() => {
+    before(function () {
       if (process.env.TRAVIS) {
         return this.skip();
       }

--- a/test/functional/settings-e2e-specs.js
+++ b/test/functional/settings-e2e-specs.js
@@ -1,0 +1,43 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import _ from 'lodash';
+import AndroidDriver from '../..';
+import DEFAULT_CAPS from './desired';
+import { sleep } from 'asyncbox';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+let defaultCaps = _.defaults({
+  androidInstallTimeout: 90000,
+  browserName: 'chrome'
+}, DEFAULT_CAPS);
+
+describe.skip('toggle wifi tests', () => {
+  let driver;
+
+  describe('functional', () => {
+    before(() => {
+      driver = new AndroidDriver();
+    });
+    afterEach(async () => {
+      await driver.deleteSession();
+    });
+    it('should toggle wifi on real devices', async () => {
+      await driver.createSession(defaultCaps);
+      let isWifiOn = await driver.isWifiOn();
+      if (isWifiOn) {
+        await driver.setWifiState(0, false);
+        await sleep(500);
+        isWifiOn = await driver.isWifiOn();
+        isWifiOn.should.be.false;
+      } else {
+        await driver.setWifiState(1, false);
+        // enabling wifi takes time
+        await sleep(2500);
+        isWifiOn = await driver.isWifiOn();
+        isWifiOn.should.be.true;
+      }
+    });
+  });
+});

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -511,12 +511,16 @@ describe('Android Helpers', () => {
         .returns(true);
       mocks.adb.expects('grantAllPermissions').withExactArgs('io.appium.settings').once()
         .returns(true);
+      mocks.adb.expects('getApiLevel').once()
+        .returns(19);
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });
     it('should skip exception if installOrUpgrade or grantAllPermissions failed', async () => {
       mocks.adb.expects('installOrUpgrade').throws();
       mocks.adb.expects('grantAllPermissions').throws();
+      mocks.adb.expects('getApiLevel').once()
+        .returns(19);
       await helpers.pushSettingsApp(adb).should.be.fulfilled;
     });
     it('should launch settings app on android 7+', async () => {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -525,7 +525,7 @@ describe('Android Helpers', () => {
       mocks.adb.expects('grantAllPermissions')
         .withExactArgs('io.appium.settings').once()
         .returns(true);
-      mocks.adb.expects('getApiLevel').once().returns(24);
+      mocks.adb.expects('getApiLevel').once().returns(23);
       mocks.adb.expects('startApp').once();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -519,6 +519,17 @@ describe('Android Helpers', () => {
       mocks.adb.expects('grantAllPermissions').throws();
       await helpers.pushSettingsApp(adb).should.be.fulfilled;
     });
+    it('should launch settings app on android 7+', async () => {
+      mocks.adb.expects('installOrUpgrade').once()
+        .returns(true);
+      mocks.adb.expects('grantAllPermissions')
+        .withExactArgs('io.appium.settings').once()
+        .returns(true);
+      mocks.adb.expects('getApiLevel').once().returns(24);
+      mocks.adb.expects('startApp').once();
+      await helpers.pushSettingsApp(adb);
+      mocks.adb.verify();
+    });
   }));
   describe('setMockLocationApp', withMocks({adb}, (mocks) => {
     it('should enable mock location for api level below 23', async () => {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -511,16 +511,16 @@ describe('Android Helpers', () => {
         .returns(true);
       mocks.adb.expects('grantAllPermissions').withExactArgs('io.appium.settings').once()
         .returns(true);
-      mocks.adb.expects('getApiLevel').once()
-        .returns(19);
+      mocks.adb.expects('processExists')
+          .withExactArgs('io.appium.settings').once()
+          .returns(true);
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });
     it('should skip exception if installOrUpgrade or grantAllPermissions failed', async () => {
       mocks.adb.expects('installOrUpgrade').throws();
       mocks.adb.expects('grantAllPermissions').throws();
-      mocks.adb.expects('getApiLevel').once()
-        .returns(19);
+      mocks.adb.expects('processExists').throws();
       await helpers.pushSettingsApp(adb).should.be.fulfilled;
     });
     it('should launch settings app on android 7+', async () => {
@@ -529,7 +529,8 @@ describe('Android Helpers', () => {
       mocks.adb.expects('grantAllPermissions')
         .withExactArgs('io.appium.settings').once()
         .returns(true);
-      mocks.adb.expects('getApiLevel').once().returns(23);
+      mocks.adb.expects('processExists').once()
+        .returns(false);
       mocks.adb.expects('startApp').once();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -523,7 +523,7 @@ describe('Android Helpers', () => {
       mocks.adb.expects('processExists').throws();
       await helpers.pushSettingsApp(adb).should.be.fulfilled;
     });
-    it('should launch settings app on android 7+', async () => {
+    it('should launch settings app if it isnt running', async () => {
       mocks.adb.expects('installOrUpgrade').once()
         .returns(true);
       mocks.adb.expects('grantAllPermissions')


### PR DESCRIPTION
Real-devices on Android 7+ seems to be failing to set wifi, data settings if the io.appium.settings app is not launched prior to starting the session. 
https://github.com/appium/appium/issues/8957

Would like to have @mayureshshirodkar confirmation to verify this is not happening on Android 6 or below devices. Right now i'm out of devices.  😄 
