### PR TITLE
Log error but do not fail if mock location setting fails

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -356,10 +356,14 @@ helpers.initUnicodeKeyboard = async function (adb) {
 };
 
 helpers.setMockLocationApp = async function (adb, app) {
-  if (parseInt(await adb.getApiLevel(), 10) < 23) {
-    await adb.shell(['settings', 'put', 'secure', 'mock_location', '1']);
-  } else {
-    await adb.shell(['appops', 'set', app, 'android:mock_location', 'allow']);
+  try {
+    if (parseInt(await adb.getApiLevel(), 10) < 23) {
+      await adb.shell(['settings', 'put', 'secure', 'mock_location', '1']);
+    } else {
+      await adb.shell(['appops', 'set', app, 'android:mock_location', 'allow']);
+    }
+  } catch (err) {
+    logger.warn(`Unable to set mock location for app '${app}': ${err.message}`);
   }
 };
 


### PR DESCRIPTION
Do not fail the entire startup process for a failing mock location setup.