### PR TITLE
Fix parsing of webview process name

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -13,6 +13,7 @@ const CROSSWALK_REGEXP_STRING = `(\\S*)${CROSSWALK_SOCKET_SUFFIX}`;
 const CROSSWALK_REGEXP = new RegExp(`@${CROSSWALK_REGEXP_STRING}`);
 const CROSSWALK_PROCESS_REGEXP = new RegExp(WEBVIEW_BASE + CROSSWALK_REGEXP_STRING);
 
+
 let helpers = {};
 
 // This function gets a list of android system processes and returns ones
@@ -97,13 +98,22 @@ helpers.procFromWebview = async function (adb, webview) {
   function slice (line, index) {
     // first find the beginning
     let start = index;
-    while (start > 0) {
-      if (line[start - 1] === ' ') break; // eslint-disable-line curly
-      start--;
+    if (line[start] === ' ') {
+      // the entry has not started yet, so move to the right until we have it
+      while (start < line.length) {
+        if (line[start] !== ' ') break; // eslint-disable-line curly
+        start++;
+      }
+    } else {
+      while (start > 0) {
+        // the entry has started, so move to the left until the beginning
+        if (line[start - 1] === ' ') break; // eslint-disable-line curly
+        start--;
+      }
     }
 
     // now find the end
-    let end = line.indexOf(' ', index);
+    let end = line.indexOf(' ', start);
     if (end === -1) {
       end = line.length;
     }

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -95,9 +95,14 @@ helpers.procFromWebview = async function (adb, webview) {
   let pidIndex = header.indexOf('PID');
   let pkgIndex = header.indexOf('NAME');
 
-  function slice (line, index) {
+  /*
+   * Get the entry based on the position of the header. The entry can be aligned
+   * either the beginning or the end of the header, so the start of the entry
+   * can be before the header starts or after. Figure that out.
+   */
+  function getEntry (line, headerIndex) {
     // first find the beginning
-    let start = index;
+    let start = headerIndex;
     if (line[start] === ' ') {
       // the entry has not started yet, so move to the right until we have it
       while (start < line.length) {
@@ -122,9 +127,9 @@ helpers.procFromWebview = async function (adb, webview) {
   }
 
   for (let line of lines) {
-    let pidEntry = slice(line, pidIndex);
+    let pidEntry = getEntry(line, pidIndex);
     if (pidEntry === pid) {
-      pkg = slice(line, pkgIndex);
+      pkg = getEntry(line, pkgIndex);
       logger.debug(`Parsed pid: '${pidEntry}' pkg: '${pkg}' from`);
       logger.debug(`    ${header}`);
       logger.debug(`    ${line}`);

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -60,7 +60,7 @@ async function webviewsFromProcs (adb, deviceSocket) {
 // want to do this is to make sure we're listing webviews for the actual AUT,
 // not some other running app
 // TODO: this should be called procFromPid and exist in appium-adb
-async function procFromWebview (adb, webview) {
+helpers.procFromWebview = async function (adb, webview) {
   if (webview.match(WEBVIEW_PID_REGEXP) === null) {
     let processName = webview.match(CROSSWALK_PROCESS_REGEXP);
     if (processName === null) {
@@ -80,29 +80,51 @@ async function procFromWebview (adb, webview) {
   let out = await adb.shell("ps");
   let pkg = "unknown";
   let lines = out.split(/\r?\n/);
+
   /* Output of ps is like:
-   USER     PID   PPID  VSIZE  RSS     WCHAN    PC         NAME
+   USER       PID  PPID  VSIZE  RSS   WCHAN    PC         NAME  _or_
+   USER       PID  PPID  VSZ    RSS   WCHAN    ADDR     S NAME
    u0_a136   6248  179   946000 48144 ffffffff 4005903e R com.example.test
+   u0_a136   6249  179   946000 48144 ffffffff          R com.example.test
   */
-  let header = lines[0].trim().split(/\s+/);
+  let header = lines[0];
+
   // the column order may not be identical on all androids
   // dynamically locate the pid and name column.
-  let pidColumn = header.indexOf("PID");
-  let pkgColumn = header.indexOf("NAME") + 1;
+  let pidIndex = header.indexOf('PID');
+  let pkgIndex = header.indexOf('NAME');
+
+  function slice (line, index) {
+    // first find the beginning
+    let start = index;
+    while (start > 0) {
+      if (line[start - 1] === ' ') break; // eslint-disable-line curly
+      start--;
+    }
+
+    // now find the end
+    let end = line.indexOf(' ', index);
+    if (end === -1) {
+      end = line.length;
+    }
+
+    return line.slice(start, end);
+  }
 
   for (let line of lines) {
-    line = line.trim().split(/\s+/);
-    if (line[pidColumn].indexOf(pid) !== -1) {
-      // Android 6.0 support (occasionally returns undefined - Appium issue #5689)
-      pkg = _.isUndefined(line[pkgColumn]) ? line[pkgColumn-1] : line[pkgColumn];
-      logger.debug(`Parsed pid: ${line[pidColumn]} pkg: ${pkg}!`);
-      logger.debug(`from: ${line}`);
+    let pidEntry = slice(line, pidIndex);
+    if (pidEntry === pid) {
+      pkg = slice(line, pkgIndex);
+      logger.debug(`Parsed pid: '${pidEntry}' pkg: '${pkg}' from`);
+      logger.debug(`    ${header}`);
+      logger.debug(`    ${line}`);
+
       break;
     }
   }
-  logger.debug(`returning process name: ${pkg}`);
+  logger.debug(`Returning process name: '${pkg}'`);
   return pkg;
-}
+};
 
 // Get a list of available webviews by introspecting processes with adb, where
 // webviews are listed. It's possible to pass in a 'deviceSocket' arg, which
@@ -117,7 +139,7 @@ helpers.getWebviews = async function (adb, deviceSocket) {
   }
 
   webviews = await asyncmap(webviews, async (webviewName) => {
-    let pkg = await procFromWebview(adb, webviewName);
+    let pkg = await helpers.procFromWebview(adb, webviewName);
     return WEBVIEW_BASE + pkg;
   });
   logger.debug(`Found webviews: ${JSON.stringify(webviews)}`);

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -85,6 +85,34 @@ describe('Webview Helpers', () => {
       let name = await helpers.procFromWebview(adb, webview);
       name.should.eql(pkg);
     });
+    it('should get package name when pid is smaller than three characters long', async function () {
+      sandbox.stub(adb, 'shell', function () {
+        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR   NAME\n' +
+               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
+               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
+               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
+               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
+               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
+               'u0_a88          12  1313 1513968 135756                     0 R io.appium.android.apis\n';
+      });
+
+      let name = await helpers.procFromWebview(adb, 'WEBVIEW_12');
+      name.should.eql(pkg);
+    });
+    it('should get package name when name is smaller than four characters long', async function () {
+      sandbox.stub(adb, 'shell', function () {
+        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR   NAME\n' +
+               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
+               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
+               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
+               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
+               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
+               'u0_a88         123  1313 1513968 135756                     0 R i.o\n';
+      });
+
+      let name = await helpers.procFromWebview(adb, webview);
+      name.should.eql('i.o');
+    });
   });
 
   describe('When the webviews are obtained', function () {

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -7,11 +7,91 @@ let sandbox = sinon.sandbox.create();
 describe('Webview Helpers', () => {
   let adb = new ADB();
 
-  describe('When the webviews are obtained', () => {
-    describe('for an app that embeds Chromium', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('procFromWebview', function () {
+    const webview = 'WEBVIEW_123';
+    const pkg = 'io.appium.android.apis';
+
+    it('should get package name when all fields are filled', async function () {
+      sandbox.stub(adb, 'shell', function () {
+        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR S NAME\n' +
+               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
+               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
+               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
+               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
+               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
+               'u0_a88         123  1313 1513968 135756 ffffffff            0 R io.appium.android.apis\n';
+      });
+
+      let name = await helpers.procFromWebview(adb, webview);
+      name.should.eql(pkg);
+    });
+    it('should get package name when some fields are empty', async function () {
+      sandbox.stub(adb, 'shell', function () {
+        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR S NAME\n' +
+               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
+               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
+               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
+               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
+               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
+               'u0_a88         123  1313 1513968 135756                     0 R io.appium.android.apis\n';
+      });
+
+      let name = await helpers.procFromWebview(adb, webview);
+      name.should.eql(pkg);
+    });
+    it('should get package name when fields are in different order', async function () {
+      sandbox.stub(adb, 'shell', function () {
+        return 'USER           PID  PPID NAME                       VSZ    RSS WCHAN            ADDR S\n' +
+               'root             1     0 init                      9948   2344 SyS_epoll_wait      0 S\n' +
+               'root             2     0 [kthreadd]                   0      0 kthreadd            0 S\n' +
+               'root             3     2 [ksoftirqd/0]                0      0 smpboot_thread_fn   0 S\n' +
+               'root             5     2 [kworker/0:0H]               0      0 worker_thread       0 S\n' +
+               'root             7     2 [rcu_preempt]                0      0 rcu_gp_kthread      0 S\n' +
+               'u0_a88         123  1313 io.appium.android.apis 1513968 135756                     0 R\n';
+      });
+
+      let name = await helpers.procFromWebview(adb, webview);
+      name.should.eql(pkg);
+    });
+    it('should get package name when some headers are empty', async function () {
+      sandbox.stub(adb, 'shell', function () {
+        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR   NAME\n' +
+               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
+               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
+               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
+               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
+               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
+               'u0_a88         123  1313 1513968 135756 ffffffff            0 R io.appium.android.apis\n';
+      });
+
+      let name = await helpers.procFromWebview(adb, webview);
+      name.should.eql(pkg);
+    });
+    it('should get package name when some headers and fields are empty', async function () {
+      sandbox.stub(adb, 'shell', function () {
+        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR   NAME\n' +
+               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
+               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
+               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
+               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
+               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
+               'u0_a88         123  1313 1513968 135756                     0 R io.appium.android.apis\n';
+      });
+
+      let name = await helpers.procFromWebview(adb, webview);
+      name.should.eql(pkg);
+    });
+  });
+
+  describe('When the webviews are obtained', function () {
+    describe('for an app that embeds Chromium', function () {
       let webViews;
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         sandbox.stub(adb, 'shell', () => {
           return 'Num       RefCount Protocol Flags    Type St Inode Path\n' +
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
@@ -23,26 +103,22 @@ describe('Webview Helpers', () => {
         webViews = await helpers.getWebviews(adb, 'webview_devtools_remote_123');
       });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
-
-      it('then the unix sockets are queried', () => {
+      it('then the unix sockets are queried', function () {
         adb.shell.calledOnce.should.be.true;
         adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
       });
 
-      it('then the webview is returned', () => {
+      it('then the webview is returned', function () {
         webViews.length.should.equal(1);
         webViews.should.deep.equal(['WEBVIEW_123']);
       });
     });
 
-    describe('for a Chromium webview', () => {
+    describe('for a Chromium webview', function () {
       let webViews;
 
-      beforeEach(async () => {
-        sandbox.stub(adb, 'shell', () => {
+      beforeEach(async function () {
+        sandbox.stub(adb, 'shell', function () {
           return 'Num       RefCount Protocol Flags    Type St Inode Path\n' +
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
                 '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
@@ -53,26 +129,22 @@ describe('Webview Helpers', () => {
         webViews = await helpers.getWebviews(adb, 'chrome_devtools_remote');
       });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
-
-      it('then the unix sockets are queried', () => {
+      it('then the unix sockets are queried', function () {
         adb.shell.calledOnce.should.be.true;
         adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
       });
 
-      it('then the webview is returned', () => {
+      it('then the webview is returned', function () {
         webViews.length.should.equal(1);
         webViews.should.deep.equal(['CHROMIUM']);
       });
     });
 
-    describe('and no webviews exist', () => {
+    describe('and no webviews exist', function () {
       let webViews;
 
       beforeEach(async () => {
-        sandbox.stub(adb, 'shell', () => {
+        sandbox.stub(adb, 'shell', function () {
           return 'Num       RefCount Protocol Flags    Type St Inode Path\n' +
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
                 '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
@@ -82,21 +154,17 @@ describe('Webview Helpers', () => {
         webViews = await helpers.getWebviews(adb);
       });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
-
-      it('then the unix sockets are queried', () => {
+      it('then the unix sockets are queried', function () {
         adb.shell.calledOnce.should.be.true;
         adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
       });
 
-      it('then no webviews are returned', () => {
+      it('then no webviews are returned', function () {
         webViews.length.should.equal(0);
       });
     });
 
-    describe('and crosswalk webviews exist', () => {
+    describe('and crosswalk webviews exist', function () {
       let webViews;
 
       beforeEach(() => {
@@ -109,88 +177,80 @@ describe('Webview Helpers', () => {
         });
       });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
-
-      describe('and the device socket is not specified', async () => {
+      describe('and the device socket is not specified', function () {
         beforeEach(async () => {
           webViews = await helpers.getWebviews(adb);
         });
 
-        it('then the unix sockets are queried', () => {
+        it('then the unix sockets are queried', function () {
           adb.shell.calledOnce.should.be.true;
           adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
         });
 
-        it('then the webview is returned', () => {
+        it('then the webview is returned', function () {
           webViews.length.should.equal(1);
           webViews.should.deep.equal(['WEBVIEW_com.application.myapp']);
         });
       });
 
-      describe('and the device socket is specified', async () => {
-        beforeEach(async () => {
+      describe('and the device socket is specified', function () {
+        beforeEach(async function () {
           webViews = await helpers.getWebviews(adb, 'com.application.myapp_devtools_remote');
         });
 
-        it('then the unix sockets are queried', () => {
+        it('then the unix sockets are queried', function () {
           adb.shell.calledOnce.should.be.true;
           adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
         });
 
-        it('then the webview is returned', () => {
+        it('then the webview is returned', function () {
           webViews.length.should.equal(1);
           webViews.should.deep.equal(['WEBVIEW_com.application.myapp']);
         });
       });
 
-      describe('and the device socket is specified but is not found', async () => {
-        beforeEach(async () => {
+      describe('and the device socket is specified but is not found', function () {
+        beforeEach(async function () {
           webViews = await helpers.getWebviews(adb, 'com.application.myotherapp_devtools_remote');
         });
 
-        it('then the unix sockets are queried', () => {
+        it('then the unix sockets are queried', function () {
           adb.shell.calledOnce.should.be.true;
           adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
         });
 
-        it('then no webviews are returned', () => {
+        it('then no webviews are returned', function () {
           webViews.length.should.equal(0);
         });
       });
     });
 
-    describe('and webviews exist', async () => {
+    describe('and webviews exist', function () {
       let webViews;
 
-      beforeEach(async () => {
+      beforeEach(async function () {
         let shellStub = sandbox.stub(adb, 'shell');
 
-        shellStub.onCall(0).returns('Num       RefCount Protocol Flags    Type St Inode Path\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @webview_devtools_remote_1234\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n');
-        shellStub.onCall(1).returns('USER      PID   PPID  VSIZE  RSS   WCHAN              PC  NAME\n' +
-                'root      1     0     5792   988   SyS_epoll_ 0000000000 S /init\n' +
-                'root      2     0     0      0       kthreadd 0000000000 S kthreadd\n' +
-                'root   1234     2     0      0     SyS_epoll_ 0000000000 S com.application.myapp\n');
+        shellStub.onCall(0).returns('Num               RefCount Protocol Flags    Type St Inode Path\n' +
+                                    '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
+                                    '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
+                                    '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @webview_devtools_remote_1234\n' +
+                                    '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n');
+        shellStub.onCall(1).returns('USER    PID  PPID VSIZE   RSS   WCHAN              PC   NAME\n' +
+                                    'root      1     0  5792   988   SyS_epoll_ 0000000000 S /init\n' +
+                                    'root      2     0     0     0   kthreadd   0000000000 S kthreadd\n' +
+                                    'root   1234     2     0     0   SyS_epoll_ 0000000000 S com.application.myapp\n');
 
         webViews = await helpers.getWebviews(adb);
       });
 
-      afterEach(() => {
-        sandbox.restore();
-      });
-
-      it('then the unix sockets and process list are queried', () => {
+      it('then the unix sockets and process list are queried', function () {
         adb.shell.calledTwice.should.be.true;
         adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
         adb.shell.getCall(1).args[0].should.equal('ps');
       });
 
-      it('then the webview is returned', async () => {
+      it('then the webview is returned', function () {
         webViews.length.should.equal(1);
         webViews.should.deep.equal(['WEBVIEW_com.application.myapp']);
       });


### PR DESCRIPTION
Rather than parsing the process name by looking at placement in relation to the headers (which is problematic, since there are sometimes no headers for particular fields, and also sometimes there are no entries for fields), use the absolute position in the line, in relation to the header. 