### PR TITLE
Fix logic for getting process name from pid

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -88,48 +88,14 @@ helpers.procFromWebview = async function (adb, webview) {
    u0_a136   6248  179   946000 48144 ffffffff 4005903e R com.example.test
    u0_a136   6249  179   946000 48144 ffffffff          R com.example.test
   */
-  let header = lines[0];
-
-  // the column order may not be identical on all androids
-  // dynamically locate the pid and name column.
-  let pidIndex = header.indexOf('PID');
-  let pkgIndex = header.indexOf('NAME');
-
-  /*
-   * Get the entry based on the position of the header. The entry can be aligned
-   * either the beginning or the end of the header, so the start of the entry
-   * can be before the header starts or after. Figure that out.
-   */
-  function getEntry (line, headerIndex) {
-    // first find the beginning
-    let start = headerIndex;
-    if (line[start] === ' ') {
-      // the entry has not started yet, so move to the right until we have it
-      while (start < line.length) {
-        if (line[start] !== ' ') break; // eslint-disable-line curly
-        start++;
-      }
-    } else {
-      while (start > 0) {
-        // the entry has started, so move to the left until the beginning
-        if (line[start - 1] === ' ') break; // eslint-disable-line curly
-        start--;
-      }
-    }
-
-    // now find the end
-    let end = line.indexOf(' ', start);
-    if (end === -1) {
-      end = line.length;
-    }
-
-    return line.slice(start, end);
-  }
+  const header = lines[0].trim().split(/\s+/);
+  const pidColumn = header.indexOf('PID');
 
   for (let line of lines) {
-    let pidEntry = getEntry(line, pidIndex);
+    const entries = line.trim().split(/\s+/);
+    const pidEntry = entries[pidColumn];
     if (pidEntry === pid) {
-      pkg = getEntry(line, pkgIndex);
+      pkg = _.last(entries);
       logger.debug(`Parsed pid: '${pidEntry}' pkg: '${pkg}' from`);
       logger.debug(`    ${header}`);
       logger.debug(`    ${line}`);
@@ -137,6 +103,7 @@ helpers.procFromWebview = async function (adb, webview) {
       break;
     }
   }
+
   logger.debug(`Returning process name: '${pkg}'`);
   return pkg;
 };

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -43,20 +43,6 @@ describe('Webview Helpers', () => {
       let name = await helpers.procFromWebview(adb, webview);
       name.should.eql(pkg);
     });
-    it('should get package name when fields are in different order', async function () {
-      sandbox.stub(adb, 'shell', function () {
-        return 'USER           PID  PPID NAME                       VSZ    RSS WCHAN            ADDR S\n' +
-               'root             1     0 init                      9948   2344 SyS_epoll_wait      0 S\n' +
-               'root             2     0 [kthreadd]                   0      0 kthreadd            0 S\n' +
-               'root             3     2 [ksoftirqd/0]                0      0 smpboot_thread_fn   0 S\n' +
-               'root             5     2 [kworker/0:0H]               0      0 worker_thread       0 S\n' +
-               'root             7     2 [rcu_preempt]                0      0 rcu_gp_kthread      0 S\n' +
-               'u0_a88         123  1313 io.appium.android.apis 1513968 135756                     0 R\n';
-      });
-
-      let name = await helpers.procFromWebview(adb, webview);
-      name.should.eql(pkg);
-    });
     it('should get package name when some headers are empty', async function () {
       sandbox.stub(adb, 'shell', function () {
         return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR   NAME\n' +
@@ -84,34 +70,6 @@ describe('Webview Helpers', () => {
 
       let name = await helpers.procFromWebview(adb, webview);
       name.should.eql(pkg);
-    });
-    it('should get package name when pid is smaller than three characters long', async function () {
-      sandbox.stub(adb, 'shell', function () {
-        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR   NAME\n' +
-               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
-               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
-               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
-               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
-               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
-               'u0_a88          12  1313 1513968 135756                     0 R io.appium.android.apis\n';
-      });
-
-      let name = await helpers.procFromWebview(adb, 'WEBVIEW_12');
-      name.should.eql(pkg);
-    });
-    it('should get package name when name is smaller than four characters long', async function () {
-      sandbox.stub(adb, 'shell', function () {
-        return 'USER           PID  PPID     VSZ    RSS WCHAN            ADDR   NAME\n' +
-               'root             1     0    9948   2344 SyS_epoll_wait      0 S init\n' +
-               'root             2     0       0      0 kthreadd            0 S [kthreadd]\n' +
-               'root             3     2       0      0 smpboot_thread_fn   0 S [ksoftirqd/0]\n' +
-               'root             5     2       0      0 worker_thread       0 S [kworker/0:0H]\n' +
-               'root             7     2       0      0 rcu_gp_kthread      0 S [rcu_preempt]\n' +
-               'u0_a88         123  1313 1513968 135756                     0 R i.o\n';
-      });
-
-      let name = await helpers.procFromWebview(adb, webview);
-      name.should.eql('i.o');
     });
   });
 


### PR DESCRIPTION
Seems that the update to parsing `ps` output broke for some devices (see https://github.com/appium/appium/issues/9245). It also seems that the `NAME` field is _always_ last, which simplifies the parsing a lot (and is how Chromium does it as well: https://chromium.googlesource.com/chromium/src/+/master/chrome/test/chromedriver/chrome/adb_impl.cc#205).