### PR TITLE
Add support to force upgrade settings app

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -377,12 +377,13 @@ helpers.setMockLocationApp = async function (adb, app) {
   }
 };
 
-helpers.pushSettingsApp = async function (adb) {
+helpers.pushSettingsApp = async function (adb, throwError = false) {
   logger.debug("Pushing settings apk to device...");
+
   try {
-    await adb.installOrUpgrade(settingsApkPath, SETTINGS_HELPER_PKG_ID);
+    await adb.installOrUpgrade(settingsApkPath, SETTINGS_HELPER_PKG_ID, true);
   } catch (err) {
-    logger.warn(`Ignored error while installing Appium Settings helper: "${err.message}". ` +
+    logger.warn(`Ignored error while installing Appium Settings helper: '${err.message}'. ` +
                 `Expect some Appium features may not work as expected unless this problem is fixed.`);
   }
   try {
@@ -406,7 +407,10 @@ helpers.pushSettingsApp = async function (adb) {
       await adb.startApp(startOpts);
     }
   } catch (err) {
-    logger.warn(`Failed to launch settings app: "${err.message}".`);
+    logger.warn(`Failed to launch settings app: ${err.message}`);
+    if (throwError) {
+      throw err;
+    }
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,9 +161,9 @@
       }
     },
     "appium-adb": {
-      "version": "2.28.3",
-      "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-2.28.3.tgz",
-      "integrity": "sha512-vYKuz1xJPHwTRVP034UisXtfhguSNaCQ5Jdrituex9g3GLiAEu+1ghVyX6OVI/geVkQmGkq6O96zeIwVJwTOlQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-3.0.0.tgz",
+      "integrity": "sha512-KUPn2pru/eb47TWJCaViyVLV7ANwNbxW1oVoaP4JByICMP7wzAMexw/rt2+1z8QF17GommvpbWLwNDI2dB+1YQ==",
       "requires": {
         "appium-support": "2.8.3",
         "asyncbox": "2.3.1",
@@ -450,10 +450,41 @@
       "resolved": "https://registry.npmjs.org/appium-uiautomator/-/appium-uiautomator-1.1.2.tgz",
       "integrity": "sha1-wAjOxYKMdpGB2D23NIKy8f249bs=",
       "requires": {
-        "appium-adb": "2.28.3",
+        "appium-adb": "2.28.6",
         "appium-support": "2.8.3",
         "babel-runtime": "5.8.24",
         "source-map-support": "0.3.3"
+      },
+      "dependencies": {
+        "appium-adb": {
+          "version": "2.28.6",
+          "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-2.28.6.tgz",
+          "integrity": "sha512-ut92Rok8PQZDaLCUWz5E+9I4GYRjtVno1PysTh0PmA3i0svC8zTzqS2iJV+m2hPZkDZVHbI19yspivmKb43Dog==",
+          "requires": {
+            "appium-support": "2.8.3",
+            "asyncbox": "2.3.1",
+            "babel-runtime": "5.8.24",
+            "bluebird": "3.5.0",
+            "lodash": "4.17.4",
+            "source-map-support": "0.4.18",
+            "teen_process": "1.10.0"
+          },
+          "dependencies": {
+            "source-map-support": {
+              "version": "0.4.18",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+              "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+              "requires": {
+                "source-map": "0.5.7"
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+        }
       }
     },
     "appium-unlock": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-adb": "^2.28.3",
+    "appium-adb": "^3.0.0",
     "appium-android-bootstrap": "^2.7.5",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^2.0.0",

--- a/test/functional/android-helper-e2e-specs.js
+++ b/test/functional/android-helper-e2e-specs.js
@@ -5,6 +5,7 @@ import helpers from '../../lib/android-helpers';
 import ADB from 'appium-adb';
 import { app } from './desired';
 import { MOCHA_TIMEOUT } from './helpers';
+import { exec } from 'teen_process';
 
 
 let opts = {
@@ -16,12 +17,15 @@ let opts = {
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('android-helpers e2e', () => {
-  describe('installApkRemotely', () => {
+describe('android-helpers e2e', function () {
+  let adb;
+  before(async function () {
+    adb = await ADB.createADB();
+  });
+  describe('installApkRemotely', function () {
     it('installs an apk by pushing it to the device then installing it from within', async function () {
       this.timeout(MOCHA_TIMEOUT);
 
-      let adb = await ADB.createADB();
       await retryInterval(10, 500, async function () {
         if (await adb.isAppInstalled(opts.appPackage)) {
           // this sometimes times out on Travis, so retry
@@ -33,14 +37,8 @@ describe('android-helpers e2e', () => {
       await adb.isAppInstalled(opts.appPackage).should.eventually.be.true;
     });
   });
-  describe('ensureDeviceLocale', () => {
-    let adb;
-    before(async function () {
-      adb = await ADB.createADB();
-
-      if (process.env.TRAVIS) return this.skip(); //eslint-disable-line curly
-    });
-    after(async () => {
+  describe('ensureDeviceLocale @skip-ci', function () {
+    after(async function () {
       await helpers.ensureDeviceLocale(adb, 'en', 'US');
     });
     it('should set device language and country', async function () {
@@ -52,6 +50,21 @@ describe('android-helpers e2e', () => {
       } else {
         await adb.getDeviceLocale().should.eventually.equal('fr-FR');
       }
+    });
+  });
+  describe('pushSettingsApp', function () {
+    const settingsPkg = 'io.appium.settings';
+    it('should be able to upgrade from settings v1 to latest', async function () {
+      await adb.uninstallApk(settingsPkg);
+
+      // get and install old version of settings app
+      await exec('npm', ['install', `${settingsPkg}@2.0.0`]);
+      await helpers.pushSettingsApp(adb, true).should.eventually.be.rejected;
+
+      // get and install latest version of settings app
+      await exec('npm', ['uninstall', settingsPkg]);
+      await exec('npm', ['install', settingsPkg]);
+      await helpers.pushSettingsApp(adb, true);
     });
   });
 });


### PR DESCRIPTION
Force-upgrade settings app. We don't care about its data, so there is no reason to do a real upgrade, which fails in some cases (such as when the device has settings app version 1 on it).

Also add a flag to the function, to aid in testing.