### PR TITLE
Handle incompatible unlock helper during install

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -11,6 +11,7 @@ import Bootstrap from 'appium-android-bootstrap';
 import ADB from 'appium-adb';
 import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK } from './unlock-helpers';
 
+
 const REMOTE_TEMP_PATH = "/data/local/tmp";
 const REMOTE_INSTALL_TIMEOUT = 90000; // milliseconds
 const CHROME_BROWSERS = ["Chrome", "Chromium", "Chromebeta", "Browser",
@@ -18,6 +19,8 @@ const CHROME_BROWSERS = ["Chrome", "Chromium", "Chromebeta", "Browser",
                          "chromium-browser", "chromium-webview"];
 const SETTINGS_HELPER_PKG_ID = 'io.appium.settings';
 const SETTINGS_HELPER_PKG_ACTIVITY = ".Settings";
+const UNLOCK_HELPER_PKG_ID = 'io.appium.unlock';
+const UNLOCK_HELPER_PKG_ACTIVITY = ".Unlock";
 
 let helpers = {};
 
@@ -416,7 +419,18 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
 
 helpers.pushUnlock = async function (adb) {
   logger.debug("Pushing unlock helper app to device...");
-  await adb.install(unlockApkPath, false);
+  try {
+    await adb.install(unlockApkPath, false);
+  } catch (err) {
+    if (!err.message.includes('INSTALL_FAILED_UPDATE_INCOMPATIBLE')) {
+      throw err;
+    }
+
+    // device has old, incompatible, version of the unlocker
+    logger.debug(`Old version of unlock helper found. Re-installing`);
+    await adb.uninstallApk(UNLOCK_HELPER_PKG_ID);
+    await adb.install(unlockApkPath, false);
+  }
 };
 
 // pushStrings method extracts string.xml and converts it to string.json and pushes
@@ -466,11 +480,11 @@ helpers.unlockWithUIAutomation = async function (driver, adb, unlockCapabilities
 
 helpers.unlockWithHelperApp = async function (adb) {
   logger.info("Unlocking screen");
-  await adb.forceStop('io.appium.unlock');
+  await adb.forceStop(UNLOCK_HELPER_PKG_ID);
   // then start the app twice, as once is flakey
   let startOpts = {
-    pkg: "io.appium.unlock",
-    activity: ".Unlock",
+    pkg: UNLOCK_HELPER_PKG_ID,
+    activity: UNLOCK_HELPER_PKG_ACTIVITY,
     action: "android.intent.action.MAIN",
     category: "android.intent.category.LAUNCHER",
     flags: "0x10200000",

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -419,18 +419,7 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
 
 helpers.pushUnlock = async function (adb) {
   logger.debug("Pushing unlock helper app to device...");
-  try {
-    await adb.install(unlockApkPath, false);
-  } catch (err) {
-    if (!err.message.includes('INSTALL_FAILED_UPDATE_INCOMPATIBLE')) {
-      throw err;
-    }
-
-    // device has old, incompatible, version of the unlocker
-    logger.debug(`Old version of unlock helper found. Re-installing`);
-    await adb.uninstallApk(UNLOCK_HELPER_PKG_ID);
-    await adb.install(unlockApkPath, false);
-  }
+  await adb.installOrUpgrade(unlockApkPath, UNLOCK_HELPER_PKG_ID, true);
 };
 
 // pushStrings method extracts string.xml and converts it to string.json and pushes

--- a/test/functional/android-helper-e2e-specs.js
+++ b/test/functional/android-helper-e2e-specs.js
@@ -67,4 +67,20 @@ describe('android-helpers e2e', function () {
       await helpers.pushSettingsApp(adb, true);
     });
   });
+  describe('pushUnlock', function () {
+    const unlockPkg = 'appium-unlock';
+    const unlockBundle = 'io.appium.unlock';
+    it('should be able to upgrade from unlock v0.0.1 to latest', async function () {
+      await adb.uninstallApk(unlockBundle);
+
+      // get and install old version of settings app
+      await exec('npm', ['install', `${unlockPkg}@0.0.1`]);
+      await helpers.pushUnlock(adb);
+
+      // get and install latest version of settings app
+      await exec('npm', ['uninstall', unlockPkg]);
+      await exec('npm', ['install', unlockPkg]);
+      await helpers.pushUnlock(adb);
+    });
+  });
 });

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -575,7 +575,7 @@ describe('Android Helpers', () => {
   }));
   describe('pushUnlock', withMocks({adb}, (mocks) => {
     it('should install unlockApp', async () => {
-      mocks.adb.expects('install').withExactArgs(unlockApkPath, false).once()
+      mocks.adb.expects('installOrUpgrade').withExactArgs(unlockApkPath, 'io.appium.unlock', true).once()
         .returns('');
       await helpers.pushUnlock(adb);
       mocks.adb.verify();


### PR DESCRIPTION
If installing the unlock helper fails because an old version is there (as in https://github.com/appium/appium/issues/9394), uninstall the old version and install the new one.