### PR TITLE
Add skipUnlock capability

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -142,6 +142,9 @@ let commonCapConstraints = {
   showChromedriverLog: {
     isBoolean: true
   },
+  skipUnlock: {
+    isBoolean: true
+  },
 };
 
 let uiautomatorCapConstraints = {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -256,8 +256,10 @@ class AndroidDriver extends BaseDriver {
       }
     });
 
-    // Let's try to unlock the device
-    await helpers.unlock(this, this.adb, this.caps);
+    if (!this.opts.skipUnlock) {
+      // Let's try to unlock the device
+      await helpers.unlock(this, this.adb, this.caps);
+    }
 
     // Set CompressedLayoutHierarchy on the device based on current settings object
     // this has to happen _after_ bootstrap is initialized


### PR DESCRIPTION
This cap is present in UIA2, but is missing here. It is necessary to fix such misconception.