### PR TITLE
Enable page load strategy

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -238,6 +238,9 @@ async function setupNewChromedriver (opts, curDeviceId, adb) {
   if (opts.browserName === 'chromium-webview') {
     caps.chromeOptions.androidActivity = opts.appActivity;
   }
+  if (opts.pageLoadStrategy) {
+    caps.pageLoadStrategy = opts.pageLoadStrategy;
+  }  
   caps = webviewHelpers.decorateChromeOptions(caps, opts, curDeviceId);
   await chromedriver.start(caps);
   return chromedriver;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -240,7 +240,7 @@ async function setupNewChromedriver (opts, curDeviceId, adb) {
   }
   if (opts.pageLoadStrategy) {
     caps.pageLoadStrategy = opts.pageLoadStrategy;
-  }  
+  }
   caps = webviewHelpers.decorateChromeOptions(caps, opts, curDeviceId);
   await chromedriver.start(caps);
   return chromedriver;

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -263,5 +263,10 @@ describe('Context', () => {
       chromedriver.start.getCall(0).args[0].chromeOptions.androidActivity
         .should.be.equal('app_act');
     });
+    it('should be able to set loggingPrefs capability', async () => {
+      let chromedriver = await setupNewChromedriver({pageLoadStrategy: "strategy"});
+      chromedriver.start.getCall(0).args[0].pageLoadStrategy
+        .should.be.equal("strategy");
+    });
   });
 });


### PR DESCRIPTION
Despite fixes to appium-base-driver to pass along the `pageLoadStrategy` capability, it was ignored by appium-android-driver.  This PR fixes that.  A unit test is included.