### PR TITLE
Add support for setting device time

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -40,7 +40,7 @@ commands.getDeviceTime = async function () {
 };
 
 commands.setDeviceTime = async function (dateTime) {
-  log.info('Attempting to set device date and time')
+  log.info('Attempting to set device date and time');
   try {
     let out = await this.adb.shell(['date', dateTime]);
     return out.trim();

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -39,6 +39,16 @@ commands.getDeviceTime = async function () {
   }
 };
 
+commands.setDeviceTime = async function (dateTime) {
+  log.info('Attempting to set device date and time')
+  try {
+    let out = await this.adb.shell(['date', dateTime]);
+    return out.trim();
+  } catch (err) {
+    log.errorAndThrow(`Could not set device date and time: ${err}`);
+  }
+};
+
 commands.getPageSource = function () {
   return this.bootstrap.sendAction('source');
 };

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -54,9 +54,21 @@ describe('General', () => {
       await driver.getDeviceTime().should.become('11:12');
       driver.adb.shell.calledWithExactly(['date']).should.be.true;
     });
-    it('should thorws error if shell command failed', async () => {
+    it('should throw error if shell command failed', async () => {
       sandbox.stub(driver.adb, 'shell').throws();
       await driver.getDeviceTime().should.be.rejectedWith('Could not capture');
+    });
+  });
+  describe('getDeviceTime', () =>{
+    if('should set device date and time', async () => {
+      sandbox.stub(driver.adb, 'shell');
+      driver.adb.shell.returns('Fri Nov 10 20:39:00 EST 2017');
+      await driver.setDeviceTime('111019992017.00').should.become('Fri Nov 10 20:39:00 EST 2017');
+      driver.adb.shell.calledWithExactly(['date', '111019992017.00']).should.equal('Fri Nov 10 20:39:00 EST 2017');
+    });
+    it('should throw error on invalid input', async () => {
+      sandbox.stub(driver.adb, 'shell').throws();
+      await driver.setDeviceTime('bad-format').should.be.rejectedWith('Could not set device date and time');
     });
   });
   describe('getPageSource', () => {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -59,12 +59,12 @@ describe('General', () => {
       await driver.getDeviceTime().should.be.rejectedWith('Could not capture');
     });
   });
-  describe('getDeviceTime', () =>{
-    if('should set device date and time', async () => {
+  describe('setDeviceTime', () => {
+    it('should set device date and time', async () => {
       sandbox.stub(driver.adb, 'shell');
       driver.adb.shell.returns('Fri Nov 10 20:39:00 EST 2017');
       await driver.setDeviceTime('111019992017.00').should.become('Fri Nov 10 20:39:00 EST 2017');
-      driver.adb.shell.calledWithExactly(['date', '111019992017.00']).should.equal('Fri Nov 10 20:39:00 EST 2017');
+      driver.adb.shell.calledWithExactly(['date', '111019992017.00']).should.be.true;
     });
     it('should throw error on invalid input', async () => {
       sandbox.stub(driver.adb, 'shell').throws();


### PR DESCRIPTION
Implementing setting device time for the Android platform across this repo, appium-base-driver and python-client