### PR TITLE
Add new unlock type

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -9,7 +9,7 @@ import { path as settingsApkPath } from 'io.appium.settings';
 import { path as unlockApkPath } from 'appium-unlock';
 import Bootstrap from 'appium-android-bootstrap';
 import ADB from 'appium-adb';
-import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK } from './unlock-helpers';
+import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK, SWIPE_UNLOCK } from './unlock-helpers';
 
 const REMOTE_TEMP_PATH = "/data/local/tmp";
 const REMOTE_INSTALL_TIMEOUT = 90000; // milliseconds
@@ -447,14 +447,15 @@ helpers.unlockWithUIAutomation = async function (driver, adb, unlockCapabilities
     throw new Error(`Invalid unlock type ${unlockType}`);
   }
   let unlockKey = unlockCapabilities.unlockKey;
-  if (!unlocker.isValidKey(unlockType, unlockKey)) {
+  if (!unlocker.isValidKey(unlockType, unlockKey) && unlockType !== SWIPE_UNLOCK) {
     throw new Error(`Missing unlockKey ${unlockKey} capability for unlockType ${unlockType}`);
   }
   const unlockMethod = {
     [PIN_UNLOCK]: unlocker.pinUnlock,
     [PASSWORD_UNLOCK]: unlocker.passwordUnlock,
     [PATTERN_UNLOCK]: unlocker.patternUnlock,
-    [FINGERPRINT_UNLOCK]: unlocker.fingerprintUnlock
+    [FINGERPRINT_UNLOCK]: unlocker.fingerprintUnlock,
+    [SWIPE_UNLOCK]: unlocker.swipeUnlock
   }[unlockType];
   await unlockMethod(adb, driver, unlockCapabilities);
 };

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -9,7 +9,7 @@ import { path as settingsApkPath } from 'io.appium.settings';
 import { path as unlockApkPath } from 'appium-unlock';
 import Bootstrap from 'appium-android-bootstrap';
 import ADB from 'appium-adb';
-import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK, SWIPE_UNLOCK } from './unlock-helpers';
+import unlocker from './unlock-helpers';
 
 const REMOTE_TEMP_PATH = "/data/local/tmp";
 const REMOTE_INSTALL_TIMEOUT = 90000; // milliseconds
@@ -442,22 +442,7 @@ helpers.pushStrings = async function (language, adb, opts) {
 };
 
 helpers.unlockWithUIAutomation = async function (driver, adb, unlockCapabilities) {
-  let unlockType = unlockCapabilities.unlockType;
-  if (!unlocker.isValidUnlockType(unlockType)) {
-    throw new Error(`Invalid unlock type ${unlockType}`);
-  }
-  let unlockKey = unlockCapabilities.unlockKey;
-  if (!unlocker.isValidKey(unlockType, unlockKey) && unlockType !== SWIPE_UNLOCK) {
-    throw new Error(`Missing unlockKey ${unlockKey} capability for unlockType ${unlockType}`);
-  }
-  const unlockMethod = {
-    [PIN_UNLOCK]: unlocker.pinUnlock,
-    [PASSWORD_UNLOCK]: unlocker.passwordUnlock,
-    [PATTERN_UNLOCK]: unlocker.patternUnlock,
-    [FINGERPRINT_UNLOCK]: unlocker.fingerprintUnlock,
-    [SWIPE_UNLOCK]: unlocker.swipeUnlock
-  }[unlockType];
-  await unlockMethod(adb, driver, unlockCapabilities);
+  await unlocker.unlock(adb, driver, unlockCapabilities.unlockType, unlockCapabilities.unlockKey);
 };
 
 helpers.unlockWithHelperApp = async function (adb) {
@@ -571,7 +556,6 @@ helpers.getChromePkg = function (browser) {
 };
 
 helpers.bootstrap = Bootstrap;
-helpers.unlocker = unlocker;
 
 export default helpers;
 export { CHROME_BROWSERS };

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -14,6 +14,13 @@ const HIDE_KEYBOARD_WAIT_TIME = 100;
 const INPUT_KEYS_WAIT_TIME = 100;
 
 let helpers = {};
+
+helpers.PIN_UNLOCK = PIN_UNLOCK;
+helpers.PASSWORD_UNLOCK = PASSWORD_UNLOCK;
+helpers.PATTERN_UNLOCK = PATTERN_UNLOCK;
+helpers.FINGERPRINT_UNLOCK = FINGERPRINT_UNLOCK;
+helpers.SWIPE_UNLOCK = SWIPE_UNLOCK;
+
 helpers.isValidUnlockType = function (type) {
   return UNLOCK_TYPES.indexOf(type) !== -1;
 };
@@ -90,18 +97,18 @@ helpers.swipeUnlock = async function (adb, driver) {
   // TODO - implement swipe unlock for Android 5.0 & 4.4
 };
 
-helpers.fingerprintUnlock = async function (adb, driver, capabilities) {
+helpers.fingerprintUnlock = async function (adb, driver, key) {
   if (await adb.getApiLevel() < 23) {
     throw new Error("Fingerprint unlock only works for Android 6+ emulators");
   }
-  await adb.fingerprint(capabilities.unlockKey);
+  await adb.fingerprint(key);
   await sleep(UNLOCK_WAIT_TIME);
 };
 
-helpers.pinUnlock = async function (adb, driver, capabilities) {
-  logger.info(`Trying to unlock device using pin ${capabilities.unlockKey}`);
+helpers.pinUnlock = async function (adb, driver, key) {
+  logger.info(`Trying to unlock device using pin ${key}`);
   await helpers.dismissKeyguard(driver, adb);
-  let keys = helpers.stringKeyToArr(capabilities.unlockKey);
+  let keys = helpers.stringKeyToArr(key);
   if (await adb.getApiLevel() >= 21) {
     let els = await driver.findElOrEls("id", "com.android.systemui:id/digit_text", true);
     if (_.isEmpty(els)) {
@@ -133,10 +140,9 @@ helpers.pinUnlock = async function (adb, driver, capabilities) {
   await sleep(UNLOCK_WAIT_TIME);
 };
 
-helpers.passwordUnlock = async function (adb, driver, capabilities) {
-  logger.info(`Trying to unlock device using password ${capabilities.unlockKey}`);
+helpers.passwordUnlock = async function (adb, driver, key) {
+  logger.info(`Trying to unlock device using password ${key}`);
   await helpers.dismissKeyguard(driver, adb);
-  let key = capabilities.unlockKey;
   // Replace blank spaces with %s
   key = helpers.encodePassword(key);
   // Why adb ? It was less flaky
@@ -208,10 +214,10 @@ helpers.getPatternActions = function (keys, initPos, piece) {
   return actions;
 };
 
-helpers.patternUnlock = async function (adb, driver, capabilities) {
-  logger.info(`Trying to unlock device using pattern ${capabilities.unlockKey}`);
+helpers.patternUnlock = async function (adb, driver, key) {
+  logger.info(`Trying to unlock device using pattern ${key}`);
   await helpers.dismissKeyguard(driver, adb);
-  let keys = helpers.stringKeyToArr(capabilities.unlockKey);
+  let keys = helpers.stringKeyToArr(key);
   /* We set the device pattern buttons as number of a regular phone
    *  | • • • |     | 1 2 3 |
    *  | • • • | --> | 4 5 6 |
@@ -236,10 +242,22 @@ helpers.patternUnlock = async function (adb, driver, capabilities) {
   await sleep(UNLOCK_WAIT_TIME);
 };
 
-helpers.PIN_UNLOCK = PIN_UNLOCK;
-helpers.PASSWORD_UNLOCK = PASSWORD_UNLOCK;
-helpers.PATTERN_UNLOCK = PATTERN_UNLOCK;
-helpers.FINGERPRINT_UNLOCK = FINGERPRINT_UNLOCK;
-helpers.SWIPE_UNLOCK = SWIPE_UNLOCK;
+helpers.unlock = async function (adb, driver, type, key) {
+  if (!helpers.isValidUnlockType(type)) {
+    throw new Error(`Invalid unlock type ${type}`);
+  }
+  // key is not required for SWIPE_UNLOCK
+  if (type !== SWIPE_UNLOCK && !helpers.isValidKey(type, key)) {
+    throw new Error(`Missing unlockKey ${key} capability for unlockType ${type}`);
+  }
+  const method = {
+    [PIN_UNLOCK]: "pinUnlock",
+    [PASSWORD_UNLOCK]: "passwordUnlock",
+    [PATTERN_UNLOCK]: "patternUnlock",
+    [FINGERPRINT_UNLOCK]: "fingerprintUnlock",
+    [SWIPE_UNLOCK]: "swipeUnlock"
+  }[type];
+  await helpers[method](adb, driver, key);
+};
 
 export default helpers;

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -83,11 +83,11 @@ helpers.stringKeyToArr = function (key) {
 helpers.swipeUnlock = async function (adb, driver) {
   logger.info("Swiping to unlock");
   let api = await adb.getApiLevel();
-  if (api < 21) {
+  if (api < 22) {
     throw new Error("Swipe to unlock is only supported on Android 5.1 and above");
   }
   await helpers.dismissKeyguard(driver, adb);
-  // TODO - implement swipe unlock for Android 4.4
+  // TODO - implement swipe unlock for Android 5.0 & 4.4
 };
 
 helpers.fingerprintUnlock = async function (adb, driver, capabilities) {

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -82,26 +82,29 @@ helpers.stringKeyToArr = function (key) {
 
 helpers.swipeUnlock = async function (adb, driver) {
   logger.info("Swiping to unlock");
-  if (await adb.getApiLevel() >= 23) {
+  let api = await adb.getApiLevel();
+  if (api < 18) {
+    throw new Error("Swipe to unlock is only support on Android 4.3 and above");
+  }
+  if (api >= 21) {
     await helpers.dismissKeyguard(driver, adb);
     return;
   }
-  if (await adb.getApiLevel() === 18) {
-    let el = await driver.findElOrEls("id", "android:id/glow_pad_view", false);
-    if (_.isEmpty(el)) {
-      throw new Error("Error finding unlock pad button!");
-    }
-    let location = await driver.getLocation(el.ELEMENT);
-    // let windowSize = await driver.getWindowSize();
-    logger.info(`location ${JSON.stringify(location)}`);
-    let actions = [
-      {action: 'press', options: {element: null, x: location.x, y: location.y}},
-      {action: 'moveTo', options: {element: null, x: location.x, y: 900}},
-      {action: 'release'}
-    ];
-    logger.info(`actions ${JSON.stringify(actions)}`);
-    await driver.performTouch(actions);
+  let padId = api === 19 ? "com.android.keyguard:id/glow_pad_view" : "android:id/glow_pad_view";
+  let el = await driver.findElOrEls("id", padId, false);
+  if (_.isEmpty(el)) {
+    throw new Error("Error finding unlock pad button!");
   }
+  let location = await driver.getLocation(el.ELEMENT);
+    // let windowSize = await driver.getWindowSize();
+  logger.info(`location ${JSON.stringify(location)}`);
+  let actions = [
+    {action: 'press', options: {element: null, x: location.x, y: location.y}},
+    {action: 'moveTo', options: {element: null, x: location.x, y: 900}},
+    {action: 'release'}
+  ];
+  logger.info(`actions ${JSON.stringify(actions)}`);
+  await driver.performTouch(actions);
 };
 
 helpers.fingerprintUnlock = async function (adb, driver, capabilities) {

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -83,28 +83,11 @@ helpers.stringKeyToArr = function (key) {
 helpers.swipeUnlock = async function (adb, driver) {
   logger.info("Swiping to unlock");
   let api = await adb.getApiLevel();
-  if (api < 18) {
-    throw new Error("Swipe to unlock is only support on Android 4.3 and above");
+  if (api < 21) {
+    throw new Error("Swipe to unlock is only supported on Android 5.1 and above");
   }
-  if (api >= 21) {
-    await helpers.dismissKeyguard(driver, adb);
-    return;
-  }
-  let padId = api === 19 ? "com.android.keyguard:id/glow_pad_view" : "android:id/glow_pad_view";
-  let el = await driver.findElOrEls("id", padId, false);
-  if (_.isEmpty(el)) {
-    throw new Error("Error finding unlock pad button!");
-  }
-  let location = await driver.getLocation(el.ELEMENT);
-    // let windowSize = await driver.getWindowSize();
-  logger.info(`location ${JSON.stringify(location)}`);
-  let actions = [
-    {action: 'press', options: {element: null, x: location.x, y: location.y}},
-    {action: 'moveTo', options: {element: null, x: location.x, y: 900}},
-    {action: 'release'}
-  ];
-  logger.info(`actions ${JSON.stringify(actions)}`);
-  await driver.performTouch(actions);
+  await helpers.dismissKeyguard(driver, adb);
+  // TODO - implement swipe unlock for Android 4.4
 };
 
 helpers.fingerprintUnlock = async function (adb, driver, capabilities) {

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -6,7 +6,8 @@ const PIN_UNLOCK = "pin";
 const PASSWORD_UNLOCK = "password";
 const PATTERN_UNLOCK = "pattern";
 const FINGERPRINT_UNLOCK = "fingerprint";
-const UNLOCK_TYPES = [PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK];
+const SWIPE_UNLOCK = "swipe";
+const UNLOCK_TYPES = [PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK, SWIPE_UNLOCK];
 const KEYCODE_NUMPAD_ENTER = "66";
 const UNLOCK_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
@@ -77,6 +78,30 @@ helpers.encodePassword = function (key) {
 
 helpers.stringKeyToArr = function (key) {
   return key.trim().replace(/\s+/g, '').split(/\s*/);
+};
+
+helpers.swipeUnlock = async function (adb, driver) {
+  logger.info("Swiping to unlock");
+  if (await adb.getApiLevel() >= 23) {
+    await helpers.dismissKeyguard(driver, adb);
+    return;
+  }
+  if (await adb.getApiLevel() === 18) {
+    let el = await driver.findElOrEls("id", "android:id/glow_pad_view", false);
+    if (_.isEmpty(el)) {
+      throw new Error("Error finding unlock pad button!");
+    }
+    let location = await driver.getLocation(el.ELEMENT);
+    // let windowSize = await driver.getWindowSize();
+    logger.info(`location ${JSON.stringify(location)}`);
+    let actions = [
+      {action: 'press', options: {element: null, x: location.x, y: location.y}},
+      {action: 'moveTo', options: {element: null, x: location.x, y: 900}},
+      {action: 'release'}
+    ];
+    logger.info(`actions ${JSON.stringify(actions)}`);
+    await driver.performTouch(actions);
+  }
 };
 
 helpers.fingerprintUnlock = async function (adb, driver, capabilities) {
@@ -229,5 +254,6 @@ helpers.PIN_UNLOCK = PIN_UNLOCK;
 helpers.PASSWORD_UNLOCK = PASSWORD_UNLOCK;
 helpers.PATTERN_UNLOCK = PATTERN_UNLOCK;
 helpers.FINGERPRINT_UNLOCK = FINGERPRINT_UNLOCK;
+helpers.SWIPE_UNLOCK = SWIPE_UNLOCK;
 
 export default helpers;

--- a/test/functional/unlocker-e2e-specs.js
+++ b/test/functional/unlocker-e2e-specs.js
@@ -11,6 +11,7 @@ let defaultCaps = _.defaults({
   androidInstallTimeout: 90000
 }, DEFAULT_CAPS);
 
+// const AVD_ANDROID_18_SWIPE_UNLOCK = "Nexus_5X_API_23";
 const AVD_ANDROID_19_PIN_UNLOCK = "ANDROID_API_19_PIN_UNLOCK";
 const AVD_ANDROID_23_PIN_UNLOCK = "ANDROID_API_23_PIN_UNLOCK";
 const AVD_ANDROID_19_PASSWORD_UNLOCK = "ANDROID_API_19_PASSWORD_UNLOCK";
@@ -22,13 +23,21 @@ const AVD_ANDROID_23_FINGERPRINT_UNLOCK = "ANDROID_API_23_FINGERPRINT_UNLOCK";
 describe('unlock tests', () => {
   let driver;
 
-  describe.skip('functional', () => {
+  describe('functional', () => {
     before(() => {
       driver = new AndroidDriver();
     });
     afterEach(async () => {
       await driver.deleteSession();
     });
+    /*
+    it('should unlock an Android 18 device using swipe', async () => {
+      let caps = _.extend(defaultCaps, {unlockType: "swipe", avd: AVD_ANDROID_18_SWIPE_UNLOCK});
+      await driver.createSession(caps);
+      let isLock = await driver.adb.isScreenLocked();
+      isLock.should.equal(false);
+    });
+    */
     it('should unlock an Android 19 device using a PIN', async () => {
       let caps = _.extend(defaultCaps, {unlockType: "pin", unlockKey: "1111", avd: AVD_ANDROID_19_PIN_UNLOCK});
       await driver.createSession(caps);

--- a/test/functional/unlocker-e2e-specs.js
+++ b/test/functional/unlocker-e2e-specs.js
@@ -12,6 +12,7 @@ let defaultCaps = _.defaults({
 }, DEFAULT_CAPS);
 
 // const AVD_ANDROID_18_SWIPE_UNLOCK = "Nexus_5X_API_23";
+const AVD_ANDROID_23_SWIPE_UNLOCK = "Nexus_5X_API_23";
 const AVD_ANDROID_19_PIN_UNLOCK = "ANDROID_API_19_PIN_UNLOCK";
 const AVD_ANDROID_23_PIN_UNLOCK = "ANDROID_API_23_PIN_UNLOCK";
 const AVD_ANDROID_19_PASSWORD_UNLOCK = "ANDROID_API_19_PASSWORD_UNLOCK";
@@ -30,14 +31,12 @@ describe('unlock tests', () => {
     afterEach(async () => {
       await driver.deleteSession();
     });
-    /*
-    it('should unlock an Android 18 device using swipe', async () => {
-      let caps = _.extend(defaultCaps, {unlockType: "swipe", avd: AVD_ANDROID_18_SWIPE_UNLOCK});
+    it('should unlock an Android 23+ device using swipe', async () => {
+      let caps = _.extend(defaultCaps, {unlockType: "swipe", avd: AVD_ANDROID_23_SWIPE_UNLOCK});
       await driver.createSession(caps);
       let isLock = await driver.adb.isScreenLocked();
       isLock.should.equal(false);
     });
-    */
     it('should unlock an Android 19 device using a PIN', async () => {
       let caps = _.extend(defaultCaps, {unlockType: "pin", unlockKey: "1111", avd: AVD_ANDROID_19_PIN_UNLOCK});
       await driver.createSession(caps);

--- a/test/functional/unlocker-e2e-specs.js
+++ b/test/functional/unlocker-e2e-specs.js
@@ -12,7 +12,7 @@ let defaultCaps = _.defaults({
 }, DEFAULT_CAPS);
 
 // const AVD_ANDROID_18_SWIPE_UNLOCK = "Nexus_5X_API_23";
-const AVD_ANDROID_23_SWIPE_UNLOCK = "Nexus_5X_API_23";
+const AVD_ANDROID_21_SWIPE_UNLOCK = "AVD_ANDROID_21_SWIPE_UNLOCK";
 const AVD_ANDROID_19_PIN_UNLOCK = "ANDROID_API_19_PIN_UNLOCK";
 const AVD_ANDROID_23_PIN_UNLOCK = "ANDROID_API_23_PIN_UNLOCK";
 const AVD_ANDROID_19_PASSWORD_UNLOCK = "ANDROID_API_19_PASSWORD_UNLOCK";
@@ -31,8 +31,8 @@ describe('unlock tests', () => {
     afterEach(async () => {
       await driver.deleteSession();
     });
-    it('should unlock an Android 23+ device using swipe', async () => {
-      let caps = _.extend(defaultCaps, {unlockType: "swipe", avd: AVD_ANDROID_23_SWIPE_UNLOCK});
+    it('should unlock an Android 21+ device using swipe', async () => {
+      let caps = _.extend(defaultCaps, {unlockType: "swipe", avd: AVD_ANDROID_21_SWIPE_UNLOCK});
       await driver.createSession(caps);
       let isLock = await driver.adb.isScreenLocked();
       isLock.should.equal(false);

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -11,7 +11,6 @@ import unlocker from '../../lib/unlock-helpers';
 import _ from 'lodash';
 import B from 'bluebird';
 
-
 const should = chai.should();
 const REMOTE_TEMP_PATH = "/data/local/tmp";
 const REMOTE_INSTALL_TIMEOUT = 90000;
@@ -628,7 +627,7 @@ describe('Android Helpers', () => {
     it('should raise an error on undefined unlockKey when unlockType is defined', async () => {
       mocks.adb.expects('isScreenLocked').once().returns(true);
       mocks.unlocker.expects('isValidKey').once();
-      await helpers.unlock(helpers, adb, {unlockType: "pin"}).should.be.rejectedWith('unlockKey');
+      await helpers.unlock(helpers, adb, {unlockType:"pin"}).should.be.rejectedWith('unlockKey');
       mocks.adb.verify();
       mocks.unlocker.verify();
       mocks.helpers.verify();
@@ -637,7 +636,7 @@ describe('Android Helpers', () => {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
       mocks.adb.expects('isScreenLocked').returns(false);
       mocks.unlocker.expects('pinUnlock').once();
-      await helpers.unlock(helpers, adb, {unlockType: "pin", unlockKey: "1111"});
+      await helpers.unlock(helpers, adb, {unlockType:"pin", unlockKey:"1111"});
       mocks.adb.verify();
       mocks.helpers.verify();
     });
@@ -645,7 +644,7 @@ describe('Android Helpers', () => {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
       mocks.adb.expects('isScreenLocked').returns(false);
       mocks.unlocker.expects('passwordUnlock').once();
-      await helpers.unlock(helpers, adb, {unlockType: "password", unlockKey: "appium"});
+      await helpers.unlock(helpers, adb, {unlockType:"password", unlockKey:"appium"});
       mocks.adb.verify();
       mocks.helpers.verify();
     });
@@ -653,7 +652,15 @@ describe('Android Helpers', () => {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
       mocks.adb.expects('isScreenLocked').returns(false);
       mocks.unlocker.expects('patternUnlock').once();
-      await helpers.unlock(helpers, adb, {unlockType: "pattern", unlockKey: "123456789"});
+      await helpers.unlock(helpers, adb, {unlockType:"pattern", unlockKey:"123456789"});
+      mocks.adb.verify();
+      mocks.helpers.verify();
+    });
+    it('should call swipeUnlock if unlockType is swipe', async () => {
+      mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
+      mocks.adb.expects('isScreenLocked').returns(false);
+      mocks.unlocker.expects('swipeUnlock').once();
+      await helpers.unlock(helpers, adb, {unlockType:"swipe"});
       mocks.adb.verify();
       mocks.helpers.verify();
     });
@@ -661,7 +668,7 @@ describe('Android Helpers', () => {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
       mocks.adb.expects('isScreenLocked').returns(false);
       mocks.unlocker.expects('fingerprintUnlock').once();
-      await helpers.unlock(helpers, adb, {unlockType: "fingerprint", unlockKey: "1111"});
+      await helpers.unlock(helpers, adb, {unlockType:"fingerprint", unlockKey:"1111"});
       mocks.adb.verify();
       mocks.unlocker.verify();
     });
@@ -669,7 +676,7 @@ describe('Android Helpers', () => {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
       mocks.adb.expects('isScreenLocked').returns(false);
       mocks.adb.expects('getApiLevel').once().returns(21);
-      await helpers.unlock(helpers, adb, {unlockType: "fingerprint", unlockKey: "1111"}).should.eventually
+      await helpers.unlock(helpers, adb, {unlockType:"fingerprint", unlockKey:"1111"}).should.eventually
         .be.rejectedWith('Fingerprint');
       mocks.helpers.verify();
     });

--- a/test/unit/unlock-helper-specs.js
+++ b/test/unit/unlock-helper-specs.js
@@ -129,11 +129,11 @@ describe('Unlock Helpers', () => {
   });
   describe('fingerprintUnlock', withMocks({adb, asyncbox}, (mocks) => {
     it('should be able to unlock device via fingerprint if API level >= 23', async () => {
-      let caps = {unlockKey: '123'};
+      const unlockKey = '123';
       mocks.adb.expects('getApiLevel').returns(23);
-      mocks.adb.expects('fingerprint').withExactArgs(caps.unlockKey).once();
+      mocks.adb.expects('fingerprint').withExactArgs(unlockKey).once();
       mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).once();
-      await helpers.fingerprintUnlock(adb, driver, caps).should.be.fulfilled;
+      await helpers.fingerprintUnlock(adb, driver, unlockKey).should.be.fulfilled;
       mocks.adb.verify();
       mocks.asyncbox.verify();
     });
@@ -148,7 +148,7 @@ describe('Unlock Helpers', () => {
     });
   }));
   describe('pinUnlock', withMocks({adb, helpers, driver, asyncbox}, (mocks) => {
-    const caps = {unlockKey: '13579'};
+    const unlockKey = '13579';
     const keys = ['1', '3', '5', '7', '9'];
     const els = [{ELEMENT: 1}, {ELEMENT: 2}, {ELEMENT: 3},
                  {ELEMENT: 4}, {ELEMENT: 5}, {ELEMENT: 6},
@@ -173,7 +173,7 @@ describe('Unlock Helpers', () => {
       mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).once();
       sandbox.stub(driver, 'click');
 
-      await helpers.pinUnlock(adb, driver, caps);
+      await helpers.pinUnlock(adb, driver, unlockKey);
 
       driver.click.getCall(0).args[0].should.equal(1);
       driver.click.getCall(1).args[0].should.equal(3);
@@ -202,7 +202,7 @@ describe('Unlock Helpers', () => {
       mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).once();
       sandbox.stub(driver, 'click');
 
-      await helpers.pinUnlock(adb, driver, caps);
+      await helpers.pinUnlock(adb, driver, unlockKey);
 
       driver.click.getCall(0).args[0].should.equal(1);
       driver.click.getCall(1).args[0].should.equal(3);
@@ -221,7 +221,7 @@ describe('Unlock Helpers', () => {
       mocks.helpers.expects('stringKeyToArr').once();
       mocks.adb.expects('getApiLevel').returns(21);
       mocks.driver.expects('findElOrEls').returns(null);
-      await helpers.pinUnlock(adb, driver, caps).should.eventually.be
+      await helpers.pinUnlock(adb, driver, unlockKey).should.eventually.be
         .rejectedWith('Error finding unlock pin buttons!');
       mocks.helpers.verify();
       mocks.driver.verify();
@@ -234,7 +234,7 @@ describe('Unlock Helpers', () => {
       mocks.driver.expects('findElOrEls')
         .withExactArgs('id', 'com.android.keyguard:id/key1', false)
         .returns(null);
-      await helpers.pinUnlock(adb, driver, caps).should.eventually.be
+      await helpers.pinUnlock(adb, driver, unlockKey).should.eventually.be
         .rejectedWith(`Error finding unlock pin '1' button!`);
       mocks.helpers.verify();
       mocks.driver.verify();
@@ -243,14 +243,14 @@ describe('Unlock Helpers', () => {
   }));
   describe('passwordUnlock', withMocks({adb, helpers, asyncbox}, (mocks) => {
     it('should be able to unlock device using password', async () => {
-      let caps = {unlockKey: 'psswrd'};
+      let unlockKey = 'psswrd';
       mocks.helpers.expects('dismissKeyguard').withExactArgs(driver, adb).once();
-      mocks.helpers.expects('encodePassword').withExactArgs(caps.unlockKey).returns(caps.unlockKey);
-      mocks.adb.expects('shell').withExactArgs(['input', 'text', caps.unlockKey]).once();
+      mocks.helpers.expects('encodePassword').withExactArgs(unlockKey).returns(unlockKey);
+      mocks.adb.expects('shell').withExactArgs(['input', 'text', unlockKey]).once();
       mocks.asyncbox.expects('sleep').withExactArgs(INPUT_KEYS_WAIT_TIME).once();
       mocks.adb.expects('shell').withExactArgs(['input', 'keyevent', KEYCODE_NUMPAD_ENTER]);
       mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).once();
-      await helpers.passwordUnlock(adb, driver, caps);
+      await helpers.passwordUnlock(adb, driver, unlockKey);
       mocks.helpers.verify();
       mocks.adb.verify();
       mocks.asyncbox.verify();
@@ -346,7 +346,7 @@ describe('Unlock Helpers', () => {
     const pos = {x: 10, y: 20};
     const size = {width: 300};
     const keys = ['1', '3', '5', '7', '9'];
-    const caps = {unlockKey: '13579'};
+    const unlockKey = '13579';
     beforeEach(() => {
       mocks.helpers.expects('dismissKeyguard').withExactArgs(driver, adb).once();
       mocks.helpers.expects('stringKeyToArr').returns(keys);
@@ -362,7 +362,7 @@ describe('Unlock Helpers', () => {
       mocks.driver.expects('findElOrEls')
         .withExactArgs('id', 'com.android.systemui:id/lockPatternView', false)
         .returns(el);
-      await helpers.patternUnlock(adb, driver, caps);
+      await helpers.patternUnlock(adb, driver, unlockKey);
       mocks.helpers.verify();
       mocks.driver.verify();
       mocks.asyncbox.verify();
@@ -373,7 +373,7 @@ describe('Unlock Helpers', () => {
       mocks.driver.expects('findElOrEls')
         .withExactArgs('id', 'com.android.keyguard:id/lockPatternView', false)
         .returns(el);
-      await helpers.patternUnlock(adb, driver, caps);
+      await helpers.patternUnlock(adb, driver, unlockKey);
       mocks.helpers.verify();
       mocks.driver.verify();
       mocks.asyncbox.verify();

--- a/test/unit/unlock-helper-specs.js
+++ b/test/unit/unlock-helper-specs.js
@@ -326,6 +326,21 @@ describe('Unlock Helpers', () => {
       actions[8].options.y.should.equal(-1);
     });
   });
+  describe('swipeUnlock', withMocks({driver, helpers, adb, asyncbox}, (mocks) => {
+    it('should call dismissKeyguard', async () => {
+      mocks.adb.expects('getApiLevel').returns(24);
+      mocks.helpers.expects('dismissKeyguard');
+      await helpers.swipeUnlock(adb, driver);
+      mocks.adb.verify();
+      mocks.helpers.verify();
+    });
+    it('should throw an error on unsupported platform to unlock via swipe', async () => {
+      mocks.adb.expects('getApiLevel').returns(19);
+      await helpers.swipeUnlock(adb, driver).should.eventually.be
+        .rejectedWith(`supported on Android 5.1 and above`);
+      mocks.adb.verify();
+    });
+  }));
   describe('patternUnlock', withMocks({driver, helpers, adb, asyncbox}, (mocks) => {
     const el = {ELEMENT: 1};
     const pos = {x: 10, y: 20};


### PR DESCRIPTION
Adding a new unlock type, swipe to unlock for Android 5.1 and above. In a second stage(and on another PR) i'm going to implement the swipe unlock for Android 4.4 but wanted to create this first fix since there's already some issues around in appium asking for this implementation for Android 5.1 and above.

Addressing https://github.com/appium/appium/issues/9462