### PR TITLE
replace the set locale method

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -97,10 +97,9 @@ helpers.ensureDeviceLocale = async function (adb, language, country) {
 
   await adb.setDeviceLanguageCountry(language, country);
 
-  if (await adb.ensureCurrentLocale(language, country)) {
-    return;
+  if (!await adb.ensureCurrentLocale(language, country)) {
+    throw new Error(`Failed to set language: ${language} and country: ${country}`);
   }
-  throw new Error(`Failed to set language: ${language} and country: ${country}`);
 };
 
 helpers.getDeviceInfoFromCaps = async function (opts = {}) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -89,9 +89,7 @@ helpers.ensureNetworkSpeed = function (adb, networkSpeed) {
 };
 
 helpers.ensureDeviceLocale = async function (adb, language, country) {
-  let hasLanguage = language && _.isString(language);
-  let hasCountry = country && _.isString(country);
-  if (!hasLanguage && !hasCountry) {
+  if (!_.isString(language) && !_.isString(country)) {
     logger.warn(`setDeviceLanguageCountry requires language or country.`);
     logger.warn(`Got language: '${language}' and country: '${country}'`);
     return;
@@ -99,17 +97,8 @@ helpers.ensureDeviceLocale = async function (adb, language, country) {
 
   await adb.setDeviceLanguageCountry(language, country);
 
-  if (await adb.getApiLevel() < 23) {
-    const curLanguage = await adb.getDeviceLanguage();
-    const curCountry = await adb.getDeviceCountry();
-    if (language === curLanguage && country === curCountry) {
-      return;
-    }
-  } else {
-    const curLocale = await adb.getDeviceLocale();
-    if (`${language}-${country}` === curLocale)  {
-      return;
-    }
+  if (await adb.ensureCurrentLocale(language, country)) {
+    return;
   }
   throw new Error(`Failed to set language: ${language} and country: ${country}`);
 };

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -102,7 +102,7 @@ helpers.ensureDeviceLocale = async function (adb, language, country) {
   if (await adb.getApiLevel() < 23) {
     const curLanguage = await adb.getDeviceLanguage();
     const curCountry = await adb.getDeviceCountry();
-    if ((language === curLanguage) && (country === curCountry)) {
+    if (language === curLanguage && country === curCountry) {
       return;
     }
   } else {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -89,43 +89,7 @@ helpers.ensureNetworkSpeed = function (adb, networkSpeed) {
 };
 
 helpers.ensureDeviceLocale = async function (adb, language, country) {
-  let haveLanguage = language && typeof language === "string";
-  let haveCountry = country && typeof country === "string";
-  if (!haveLanguage && !haveCountry) {
-    return;
-  }
-  let changed = false;
-  if (await adb.getApiLevel() < 23) {
-    let curLanguage = await adb.getDeviceLanguage();
-    let curCountry = await adb.getDeviceCountry();
-    if (haveLanguage && language !== curLanguage) {
-      await adb.setDeviceLanguage(language);
-      changed = true;
-    }
-    if (haveCountry && country !== curCountry) {
-      await adb.setDeviceCountry(country);
-      changed = true;
-    }
-  } else { // API >= 23
-    let curLocale = await adb.getDeviceLocale();
-    let locale;
-    if (!haveCountry) {
-      locale = language.toLowerCase();
-    } else if (!haveLanguage) {
-      locale = country;
-    } else {
-      locale = `${language.toLowerCase()}-${country.toUpperCase()}`;
-    }
-
-    logger.debug(`Current locale: '${curLocale}'; requested locale: '${locale}'`);
-    if (locale !== curLocale) {
-      await adb.setDeviceLocale(locale);
-      changed = true;
-    }
-  }
-  if (changed) {
-    await adb.reboot();
-  }
+  await adb.setDeviceLanguageCountry(language, country);
 };
 
 helpers.getDeviceInfoFromCaps = async function (opts = {}) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -89,7 +89,29 @@ helpers.ensureNetworkSpeed = function (adb, networkSpeed) {
 };
 
 helpers.ensureDeviceLocale = async function (adb, language, country) {
-  return await adb.setDeviceLanguageCountry(language, country);
+  let hasLanguage = language && _.isString(language);
+  let hasCountry = country && _.isString(country);
+  if (!hasLanguage && !hasCountry) {
+    logger.warn(`setDeviceLanguageCountry requires language or country.`);
+    logger.warn(`Got language: '${language}' and country: '${country}'`);
+    return;
+  }
+
+  await adb.setDeviceLanguageCountry(language, country);
+
+  if (await adb.getApiLevel() < 23) {
+    const curLanguage = await adb.getDeviceLanguage();
+    const curCountry = await adb.getDeviceCountry();
+    if ((language === curLanguage) && (country === curCountry)) {
+      return;
+    }
+  } else {
+    const curLocale = await adb.getDeviceLocale();
+    if (`${language}-${country}` === curLocale)  {
+      return;
+    }
+  }
+  throw new Error(`Failed to set language: ${language} and country: ${country}`);
 };
 
 helpers.getDeviceInfoFromCaps = async function (opts = {}) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -89,7 +89,7 @@ helpers.ensureNetworkSpeed = function (adb, networkSpeed) {
 };
 
 helpers.ensureDeviceLocale = async function (adb, language, country) {
-  await adb.setDeviceLanguageCountry(language, country);
+  return await adb.setDeviceLanguageCountry(language, country);
 };
 
 helpers.getDeviceInfoFromCaps = async function (opts = {}) {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-plugin-promise": "^3.3.1",
     "mocha": "^3.5.0",
     "mock-fs": "^4.2.0",
+    "gulp": "^3.9.1",
     "pre-commit": "^1.1.3",
     "sinon": "^1.16.1",
     "unzip": "^0.1.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-adb": "^5.0.0",
+    "appium-adb": "^5.2.0",
     "appium-android-bootstrap": "^2.7.5",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-adb": "^4.2.0",
+    "appium-adb": "^5.0.0",
     "appium-android-bootstrap": "^2.7.5",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^2.0.0",
@@ -38,7 +38,7 @@
     "asyncbox": "^2.0.4",
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^2.5.0",
+    "io.appium.settings": "^2.4.0",
     "jimp": "^0.2.24",
     "lodash": "^3.10.0",
     "portfinder": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-adb": "^4.1.0",
+    "appium-adb": "^4.2.0",
     "appium-android-bootstrap": "^2.7.5",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^2.0.0",
@@ -38,7 +38,7 @@
     "asyncbox": "^2.0.4",
     "babel-runtime": "=5.8.24",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^2.3.0",
+    "io.appium.settings": "^2.5.0",
     "jimp": "^0.2.24",
     "lodash": "^3.10.0",
     "portfinder": "^1.0.6",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -103,32 +103,22 @@ describe('Android Helpers', () => {
   describe('ensureDeviceLocale', withMocks({adb}, (mocks) => {
     it('should call setDeviceLanguageCountry', async () => {
       mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US').once();
-      mocks.adb.expects('getApiLevel').withExactArgs().once().returns(24);
-      mocks.adb.expects('getDeviceLocale').withExactArgs().once().returns('en-US');
+      mocks.adb.expects('ensureCurrentLocale').withExactArgs('en', 'US').once().returns(true);
       await helpers.ensureDeviceLocale(adb, 'en', 'US');
       mocks.adb.verify();
     });
-
     it('should never call setDeviceLanguageCountry', async () => {
       mocks.adb.expects('setDeviceLanguageCountry').never();
       mocks.adb.expects('getApiLevel').never();
       await helpers.ensureDeviceLocale(adb);
       mocks.adb.verify();
     });
-    it('should call setDeviceLanguageCountry with throw for API 24', async () => {
+    it('should call setDeviceLanguageCountry with throw', async () => {
       mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('fr', 'FR').once();
-      mocks.adb.expects('getApiLevel').withExactArgs().once().returns(24);
-      mocks.adb.expects('getDeviceLocale').withExactArgs().once().returns('en-US');
+      mocks.adb.expects('ensureCurrentLocale').withExactArgs('fr', 'FR').once().returns(false);
       await helpers.ensureDeviceLocale(adb, 'fr', 'FR').should.eventually.be.rejectedWith(Error, `Failed to set language: fr and country: FR`);
+      mocks.adb.verify();
     });
-    it('should call setDeviceLanguageCountry with throw for API 22', async () => {
-      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('fr', 'FR').once();
-      mocks.adb.expects('getApiLevel').withExactArgs().once().returns(22);
-      mocks.adb.expects('getDeviceLanguage').withExactArgs().once().returns('en');
-      mocks.adb.expects('getDeviceCountry').withExactArgs().once().returns('US');
-      await helpers.ensureDeviceLocale(adb, 'fr', 'FR').should.eventually.be.rejectedWith(Error, `Failed to set language: fr and country: FR`);
-    });
-
   }));
 
   describe('getDeviceInfoFromCaps', () => {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -102,8 +102,18 @@ describe('Android Helpers', () => {
   });
   describe('ensureDeviceLocale', withMocks({adb}, (mocks) => {
     it('should call setDeviceLanguageCountry', async () => {
-      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US').once().returns("");
+      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US').once();
       await helpers.ensureDeviceLocale(adb, 'en', 'US');
+      mocks.adb.verify();
+    });
+    it('should call setDeviceLanguageCountry with undefined', async () => {
+      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs(undefined, undefined).once();
+      await helpers.ensureDeviceLocale(adb);
+      mocks.adb.verify();
+    });
+    it('should call setDeviceLanguageCountry with one argument', async () => {
+      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('US', undefined).once();
+      await helpers.ensureDeviceLocale(adb, 'US');
       mocks.adb.verify();
     });
   }));

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -101,9 +101,9 @@ describe('Android Helpers', () => {
     });
   });
   describe('ensureDeviceLocale', withMocks({adb}, (mocks) => {
-    it.skip('should call setDeviceLanguageCountry', async () => {
-      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US').once().return("");
-      await helpers.ensureDeviceLocale(adb);
+    it('should call setDeviceLanguageCountry', async () => {
+      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US').once().returns("");
+      await helpers.ensureDeviceLocale(adb, 'en', 'US');
       mocks.adb.verify();
     });
   }));

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -103,19 +103,32 @@ describe('Android Helpers', () => {
   describe('ensureDeviceLocale', withMocks({adb}, (mocks) => {
     it('should call setDeviceLanguageCountry', async () => {
       mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US').once();
+      mocks.adb.expects('getApiLevel').withExactArgs().once().returns(24);
+      mocks.adb.expects('getDeviceLocale').withExactArgs().once().returns('en-US');
       await helpers.ensureDeviceLocale(adb, 'en', 'US');
       mocks.adb.verify();
     });
-    it('should call setDeviceLanguageCountry with undefined', async () => {
-      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs(undefined, undefined).once();
+
+    it('should never call setDeviceLanguageCountry', async () => {
+      mocks.adb.expects('setDeviceLanguageCountry').never();
+      mocks.adb.expects('getApiLevel').never();
       await helpers.ensureDeviceLocale(adb);
       mocks.adb.verify();
     });
-    it('should call setDeviceLanguageCountry with one argument', async () => {
-      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('US', undefined).once();
-      await helpers.ensureDeviceLocale(adb, 'US');
-      mocks.adb.verify();
+    it('should call setDeviceLanguageCountry with throw for API 24', async () => {
+      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('fr', 'FR').once();
+      mocks.adb.expects('getApiLevel').withExactArgs().once().returns(24);
+      mocks.adb.expects('getDeviceLocale').withExactArgs().once().returns('en-US');
+      await helpers.ensureDeviceLocale(adb, 'fr', 'FR').should.eventually.be.rejectedWith(Error, `Failed to set language: fr and country: FR`);
     });
+    it('should call setDeviceLanguageCountry with throw for API 22', async () => {
+      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('fr', 'FR').once();
+      mocks.adb.expects('getApiLevel').withExactArgs().once().returns(22);
+      mocks.adb.expects('getDeviceLanguage').withExactArgs().once().returns('en');
+      mocks.adb.expects('getDeviceCountry').withExactArgs().once().returns('US');
+      await helpers.ensureDeviceLocale(adb, 'fr', 'FR').should.eventually.be.rejectedWith(Error, `Failed to set language: fr and country: FR`);
+    });
+
   }));
 
   describe('getDeviceInfoFromCaps', () => {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -101,82 +101,9 @@ describe('Android Helpers', () => {
     });
   });
   describe('ensureDeviceLocale', withMocks({adb}, (mocks) => {
-    it('should return if language and country are not passed', async () => {
-      mocks.adb.expects('getDeviceLanguage').never();
-      mocks.adb.expects('getDeviceCountry').never();
-      mocks.adb.expects('getDeviceLocale').never();
-      mocks.adb.expects('setDeviceLanguage').never();
-      mocks.adb.expects('setDeviceCountry').never();
-      mocks.adb.expects('setDeviceLocale').never();
-      mocks.adb.expects('reboot').never();
+    it.skip('should call setDeviceLanguageCountry', async () => {
+      mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US').once().return("");
       await helpers.ensureDeviceLocale(adb);
-      mocks.adb.verify();
-    });
-    it('should not set language and country if it does not change when API < 23', async () => {
-      mocks.adb.expects('getApiLevel').returns(18);
-      mocks.adb.expects('getDeviceLanguage').returns('en');
-      mocks.adb.expects('getDeviceCountry').returns('us');
-      mocks.adb.expects('getDeviceLocale').never();
-      mocks.adb.expects('setDeviceLanguage').never();
-      mocks.adb.expects('setDeviceCountry').never();
-      mocks.adb.expects('setDeviceLocale').never();
-      mocks.adb.expects('reboot').never();
-      await helpers.ensureDeviceLocale(adb, 'en', 'us');
-      mocks.adb.verify();
-    });
-    it('should set language and country if they are different when API < 23', async () => {
-      mocks.adb.expects('getApiLevel').returns(18);
-      mocks.adb.expects('getDeviceLanguage').returns('fr');
-      mocks.adb.expects('getDeviceCountry').returns('FR');
-      mocks.adb.expects('getDeviceLocale').never();
-      mocks.adb.expects('setDeviceLanguage').withExactArgs('en')
-        .returns("");
-      mocks.adb.expects('setDeviceCountry').withExactArgs('us')
-        .returns("");
-      mocks.adb.expects('setDeviceLocale').never();
-      mocks.adb.expects('reboot').returns(null);
-      await helpers.ensureDeviceLocale(adb, 'en', 'us');
-      mocks.adb.verify();
-    });
-    it('should not set locale if it does not change when API = 23', async () => {
-      mocks.adb.expects('getApiLevel').returns(23);
-      mocks.adb.expects('getDeviceLanguage').never();
-      mocks.adb.expects('getDeviceCountry').never();
-      mocks.adb.expects('getDeviceLocale').returns('en-US');
-      mocks.adb.expects('setDeviceLanguage').never();
-      mocks.adb.expects('setDeviceCountry').never();
-      mocks.adb.expects('setDeviceLocale').never();
-      mocks.adb.expects('reboot').never();
-      await helpers.ensureDeviceLocale(adb, 'en', 'us');
-      mocks.adb.verify();
-    });
-    it('should set locale if it is different when API = 23', async () => {
-      mocks.adb.expects('getApiLevel').returns(23);
-      mocks.adb.expects('getDeviceLanguage').never();
-      mocks.adb.expects('getDeviceCountry').never();
-      mocks.adb.expects('getDeviceLocale').returns('fr-FR');
-      mocks.adb.expects('setDeviceLanguage').never();
-      mocks.adb.expects('setDeviceCountry').never();
-      mocks.adb.expects('setDeviceLocale').withExactArgs('en-US')
-        .returns("");
-      mocks.adb.expects('reboot').returns(null);
-      await helpers.ensureDeviceLocale(adb, 'en', 'us');
-      mocks.adb.verify();
-    });
-    it('should set locale to country only if language is not passed when API = 23', async () => {
-      mocks.adb.expects('getApiLevel').returns(23);
-      mocks.adb.expects('getDeviceLocale').returns('fr-FR');
-      mocks.adb.expects('setDeviceLocale').withExactArgs('en').returns("");
-      mocks.adb.expects('reboot').returns(null);
-      await helpers.ensureDeviceLocale(adb, 'en');
-      mocks.adb.verify();
-    });
-    it('should set locale to language only if country is not passed when API = 23', async () => {
-      mocks.adb.expects('getApiLevel').returns(23);
-      mocks.adb.expects('getDeviceLocale').returns('fr-FR');
-      mocks.adb.expects('setDeviceLocale').withExactArgs('US').returns("");
-      mocks.adb.expects('reboot').returns(null);
-      await helpers.ensureDeviceLocale(adb, null, 'US');
       mocks.adb.verify();
     });
   }));


### PR DESCRIPTION
related issues and PRs

- [x] https://github.com/appium/appium-adb/pull/273 and release the new version
    - https://github.com/appium/appium-adb/pull/271/files
- [x] https://github.com/appium/io.appium.settings/pull/12 and release the new version

After applying the above, I'll remove `it.skip` in this PR and confirm the test will pass.

---

update

`$ npm install && npm run mocha -- -t 360000  build/test/functional/android-helper-e2e-specs.js -i` passed against the API Level 27 device.

```js
  describe('ensureDeviceLocale @skip-ci', function () {
    after(async function () {
      await helpers.ensureDeviceLocale(adb, 'en', 'US');
    });
    it('should set device language and country', async function () {
      await helpers.ensureDeviceLocale(adb, 'fr', 'FR');

      if (await adb.getApiLevel() < 23) {
        await adb.getDeviceLanguage().should.eventually.equal('fr');
        await adb.getDeviceCountry().should.eventually.equal('FR');
      } else {
        await adb.getDeviceLocale().should.eventually.equal('fr-FR');
      }
    });
  });
```