### PR TITLE
Add clearDeviceLogsOnStart capability

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -110,7 +110,8 @@ helpers.getDeviceInfoFromCaps = async function (opts = {}) {
   let adb = await ADB.createADB({
     javaVersion: opts.javaVersion,
     adbPort: opts.adbPort,
-    remoteAdbHost: opts.remoteAdbHost
+    remoteAdbHost: opts.remoteAdbHost,
+    clearDeviceLogsOnStart: opts.clearDeviceLogsOnStart,
   });
   let udid = opts.udid;
   let emPort = null;
@@ -179,8 +180,14 @@ helpers.getDeviceInfoFromCaps = async function (opts = {}) {
 };
 
 // returns a new adb instance with deviceId set
-helpers.createADB = async function (javaVersion, udid, emPort, adbPort, suppressKillServer, remoteAdbHost) {
-  let adb = await ADB.createADB({javaVersion, adbPort, suppressKillServer, remoteAdbHost});
+helpers.createADB = async function (javaVersion, udid, emPort, adbPort, suppressKillServer, remoteAdbHost, clearDeviceLogsOnStart) {
+  let adb = await ADB.createADB({
+    javaVersion,
+    adbPort,
+    suppressKillServer,
+    remoteAdbHost,
+    clearDeviceLogsOnStart,
+  });
 
   adb.setDeviceId(udid);
   if (emPort) {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -145,6 +145,9 @@ let commonCapConstraints = {
   skipUnlock: {
     isBoolean: true
   },
+  clearDeviceLogsOnStart: {
+    isBoolean: true
+  },
 };
 
 let uiautomatorCapConstraints = {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -133,7 +133,8 @@ class AndroidDriver extends BaseDriver {
                                          this.opts.emPort,
                                          this.opts.adbPort,
                                          this.opts.suppressKillServer,
-                                         this.opts.remoteAdbHost);
+                                         this.opts.remoteAdbHost,
+                                         this.opts.clearDeviceLogsOnStart);
 
       if (this.helpers.isPackageOrBundle(this.opts.app)) {
         // user provided package instead of app for 'app' capability, massage options

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -248,9 +248,14 @@ describe('Android Helpers', () => {
       ADB.createADB.restore();
     });
     it('should create adb and set device id and emulator port', async () => {
-      await helpers.createADB("1.7", "111222", "111", "222", true, "remote_host");
-      ADB.createADB.calledWithExactly({javaVersion: "1.7", adbPort: "222",
-        suppressKillServer: true, remoteAdbHost: "remote_host"}).should.be.true;
+      await helpers.createADB("1.7", "111222", "111", "222", true, "remote_host", true);
+      ADB.createADB.calledWithExactly({
+        javaVersion: "1.7",
+        adbPort: "222",
+        suppressKillServer: true,
+        remoteAdbHost: "remote_host",
+        clearDeviceLogsOnStart: true,
+      }).should.be.true;
       curDeviceId.should.equal("111222");
       emulatorPort.should.equal("111");
     });


### PR DESCRIPTION
Add `clearDeviceLogsOnStart` desired capability and pass along to ADB where necessary.