### PR TITLE
Always assume that "'press', 'moveTo', 'tap', 'longPress'" actions require absolute coordinates

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -221,9 +221,6 @@ helpers.parseTouch = async function (gestures, multi) {
         };
         return touchStateObject;
       } else {
-        // expects absolute coordinates, so we need to save these as offsets
-        // and then translate when everything is done
-        options.offset = true;
         options.x = (gesture.options.x || 0);
         options.y = (gesture.options.y || 0);
 

--- a/test/functional/commands/touch/drag-e2e-specs.js
+++ b/test/functional/commands/touch/drag-e2e-specs.js
@@ -3,6 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
 import AndroidDriver from '../../../..';
 import DEFAULT_CAPS from '../../desired';
+import B from 'bluebird';
 
 
 chai.should();
@@ -71,8 +72,16 @@ describe('apidemo - touch', function () {
                       {element: endEle.ELEMENT, x: 5, y: 5}},
                       {action: "release", options: {}}];
       await driver.performTouch(gestures);
-      let element3 = await driver.findElement("id", "io.appium.android.apis:id/drag_result_text");
-      await driver.getText(element3.ELEMENT).should.eventually.equal("Dropped!");
+      let element3;
+      const expectedText = 'Dropped!';
+      for (let retries = 0; retries < 3; ++retries) {
+        element3 = await driver.findElement("id", "io.appium.android.apis:id/drag_result_text");
+        if (await driver.getText(element3.ELEMENT) === expectedText) {
+          break;
+        }
+        await B.delay(500);
+      }
+      await driver.getText(element3.ELEMENT).should.eventually.equal(expectedText);
     });
     it('should drag by absolute position', async function () {
       let startEle = await driver.findElement("id", "io.appium.android.apis:id/drag_dot_3");

--- a/test/functional/commands/touch/drag-e2e-specs.js
+++ b/test/functional/commands/touch/drag-e2e-specs.js
@@ -1,9 +1,9 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
+import { retryInterval } from 'asyncbox';
 import AndroidDriver from '../../../..';
 import DEFAULT_CAPS from '../../desired';
-import B from 'bluebird';
 
 
 chai.should();
@@ -72,16 +72,10 @@ describe('apidemo - touch', function () {
                       {element: endEle.ELEMENT, x: 5, y: 5}},
                       {action: "release", options: {}}];
       await driver.performTouch(gestures);
-      let element3;
-      const expectedText = 'Dropped!';
-      for (let retries = 0; retries < 3; ++retries) {
-        element3 = await driver.findElement("id", "io.appium.android.apis:id/drag_result_text");
-        if (await driver.getText(element3.ELEMENT) === expectedText) {
-          break;
-        }
-        await B.delay(500);
-      }
-      await driver.getText(element3.ELEMENT).should.eventually.equal(expectedText);
+      await retryInterval(3, 500, async () => {
+        const el = await driver.findElement("id", "io.appium.android.apis:id/drag_result_text");
+        (await driver.getText(el.ELEMENT)).should.eql('Dropped!');
+      });
     });
     it('should drag by absolute position', async function () {
       let startEle = await driver.findElement("id", "io.appium.android.apis:id/drag_dot_3");

--- a/test/unit/commands/touch-specs.js
+++ b/test/unit/commands/touch-specs.js
@@ -25,9 +25,9 @@ describe('Touch', function () {
         let touchStates = await driver.parseTouch(actions, false);
         touchStates.length.should.equal(5);
         let parsedActions = [{action: 'press', x: 100, y: 101},
-                             {action: 'moveTo', x: 150, y: 152},
-                             {action: 'wait', x: 150, y: 152},
-                             {action: 'moveTo', x: 110, y: 111},
+                             {action: 'moveTo', x: 50, y: 51},
+                             {action: 'wait', x: 50, y: 51},
+                             {action: 'moveTo', x: -40, y: -41},
                              {action: 'release'}];
         let index = 0;
         for (let state of touchStates) {


### PR DESCRIPTION
It is a breaking change, but at some point of time this should be done anyway. Addresses https://github.com/appium/appium/issues/7486