### PR TITLE
Implements: Keep access to chromedriver after app relaunch

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -100,9 +100,6 @@ helpers.isWebContext = function () {
 // Turn on proxying to an existing Chromedriver session or a new one
 helpers.startChromedriverProxy = async function (context) {
   logger.debug(`Connecting to chrome-backed webview context '${context}'`);
-  if (this.chromedriver !== null) {
-    throw new Error("We already have a chromedriver instance running");
-  }
 
   let cd;
   if (this.sessionChromedrivers[context]) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -257,6 +257,8 @@ commands.setUrl = async function (uri) {
 // closing app using force stop
 commands.closeApp = async function () {
   await this.adb.forceStop(this.opts.appPackage);
+  // reset context since we don't know what kind on context we will end up after app launch.
+  this.curContext = null;
 };
 
 commands.getDisplayDensity = async function () {

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -138,11 +138,6 @@ describe('Context', () => {
     beforeEach(() => {
       sandbox.stub(driver, 'onChromedriverStop');
     });
-    it('should throw an error if a chromedriver instance is already running', async () => {
-      driver.chromedriver = 'CHROMIUM';
-      await driver.startChromedriverProxy('WEBVIEW_1').should.eventually.be
-        .rejectedWith(/instance running/);
-    });
     it('should start new chromedriver session', async () => {
       await driver.startChromedriverProxy('WEBVIEW_1');
       driver.sessionChromedrivers.WEBVIEW_1.should.be.equal(driver.chromedriver);


### PR DESCRIPTION
**Current Behavior:**
Automation steps:
1. launch hybrid app
2. switch to webview context
3. close app
4. launch hybrid app
5. switch to webview context
6. query webview element

Result:
Error: chrome is not reachable

**New Behavior:**
Automation steps:

1. launch hybrid app
2. switch to webview context
3. close app
4. launch hybrid app
5. switch to webview context
6. query webview element

Result:
No error thrown. Element can be found.

**Implementation:**

No need to throw error about current instance of chromedriver. The code can already decide when to reuse or recreate chromedriver session.
Reset current context when app is closed thus switchContext can react properly when app relaunched.