### PR TITLE
Add application management primitives

### DIFF
--- a/lib/commands/apps-management.js
+++ b/lib/commands/apps-management.js
@@ -1,0 +1,94 @@
+import _ from 'lodash';
+import waitForCondition from 'asyncbox';
+import {fs, utils} from 'appium-support';
+import log from '../logger';
+
+let commands = {};
+const APP_STATE_NOT_INSTALLED = 0;
+const APP_STATE_NOT_RUNNING = 1;
+const APP_STATE_RUNNING_IN_FOREGROUND = 2;
+const APP_STATE_RUNNING_IN_BACKGROUND = 3;
+
+
+function extractMandatoryOptions (opts = {}, namesList) {
+  const result = {};
+  for (const name of namesList) {
+    if (!utils.hasValue(opts[name])) {
+      throw new Error(`'${name}' option is mandatory.`);
+    }
+    result[name] = opts[name];
+  }
+  return result;
+}
+
+commands.mobileInstallApp = async function (opts = {}) {
+  const {app} = extractMandatoryOptions(opts, ['app']);
+  const dstPath = await this.helpers.configureApp(app, '.apk');
+  log.info(`Installing '${dstPath}' to the device...`);
+  if (!await fs.exists(dstPath)) {
+    log.errorAndThrow(`The application at '${dstPath}' does not exist or is not accessible`);
+  }
+  let installArgs = [];
+  if (utils.hasValue(opts.installArgs)) {
+    installArgs = _.isArray(opts.installArgs) ? opts.installArgs : [opts.installArgs];
+  }
+  const installTimeout = _.isNumber(opts.installlTimeout) ? parseInt(opts.installlTimeout, 10) : 2 * 60 * 1000;
+  try {
+    await this.adbExec(['install', ...installArgs, dstPath], {timeout: installTimeout});
+    log.info(`Installation of '${dstPath}' succeeded`);
+  } finally {
+    if (dstPath !== app) {
+      await fs.rimraf(dstPath);
+    }
+  }
+};
+
+commands.mobileIsAppInstalled = async function (opts = {}) {
+  const {appPackage} = extractMandatoryOptions(opts, ['appPackage']);
+  log.info(`Cheking if '${appPackage}' is installed`);
+  return await this.adb.isAppInstalled(appPackage);
+};
+
+commands.mobileUninstallApp = async function (opts = {}) {
+  const {appPackage} = extractMandatoryOptions(opts, ['appPackage']);
+  log.info(`Uninstalling '${appPackage}'`);
+  await this.adb.uninstallApk(appPackage);
+  log.info(`'${appPackage}' has been successfully uninstalled`);
+};
+
+commands.mobileQueryAppState =  async function (opts = {}) {
+  const {appPackage} = extractMandatoryOptions(opts, ['appPackage']);
+  log.info(`Querying the state of  '${appPackage}'`);
+  if (!await this.adb.isAppInstalled(appPackage)) {
+    return APP_STATE_NOT_INSTALLED;
+  }
+  if (!await this.adb.processExists(appPackage)) {
+    return APP_STATE_NOT_RUNNING;
+  }
+  const output = await this.adb.shell(['dumpsys', 'window', 'windows']);
+  for (const line of output.split('\n')) {
+    if (line.includes(appPackage) && (line.includes('mCurrentFocus') || line.includes('mFocusedApp'))) {
+      return APP_STATE_RUNNING_IN_FOREGROUND;
+    }
+  }
+  return APP_STATE_RUNNING_IN_BACKGROUND;
+};
+
+commands.mobileTerminateApp =  async function (opts = {}) {
+  const {appPackage} = extractMandatoryOptions(opts, ['appPackage']);
+  log.info(`Terminating '${appPackage}'`);
+  if (await this.adb.processExists(appPackage)) {
+    log.info(`The app '${appPackage}' is not running`);
+    return false;
+  }
+  await this.adb.forceStop(appPackage);
+  const timeout = _.isNumber(opts.timeout) ? parseInt(opts.timeout, 10) : 500;
+  await waitForCondition(async () => await this.mobileQueryAppState(opts) < APP_STATE_RUNNING_IN_FOREGROUND,
+                          {waitMs: timeout, intervalMs: 100});
+  log.info(`'${appPackage}' has been terminated`);
+  return true;
+};
+
+
+export { commands };
+export default commands;

--- a/lib/commands/apps-management.js
+++ b/lib/commands/apps-management.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import waitForCondition from 'asyncbox';
-import {fs, utils} from 'appium-support';
+import { utils } from 'appium-support';
 import log from '../logger';
 
 let commands = {};
@@ -20,41 +20,6 @@ function extractMandatoryOptions (opts = {}, namesList) {
   }
   return result;
 }
-
-commands.mobileInstallApp = async function (opts = {}) {
-  const {app} = extractMandatoryOptions(opts, ['app']);
-  const dstPath = await this.helpers.configureApp(app, '.apk');
-  log.info(`Installing '${dstPath}' to the device...`);
-  if (!await fs.exists(dstPath)) {
-    log.errorAndThrow(`The application at '${dstPath}' does not exist or is not accessible`);
-  }
-  let installArgs = [];
-  if (utils.hasValue(opts.installArgs)) {
-    installArgs = _.isArray(opts.installArgs) ? opts.installArgs : [opts.installArgs];
-  }
-  const installTimeout = _.isNumber(opts.installlTimeout) ? parseInt(opts.installlTimeout, 10) : 2 * 60 * 1000;
-  try {
-    await this.adbExec(['install', ...installArgs, dstPath], {timeout: installTimeout});
-    log.info(`Installation of '${dstPath}' succeeded`);
-  } finally {
-    if (dstPath !== app) {
-      await fs.rimraf(dstPath);
-    }
-  }
-};
-
-commands.mobileIsAppInstalled = async function (opts = {}) {
-  const {appPackage} = extractMandatoryOptions(opts, ['appPackage']);
-  log.info(`Cheking if '${appPackage}' is installed`);
-  return await this.adb.isAppInstalled(appPackage);
-};
-
-commands.mobileUninstallApp = async function (opts = {}) {
-  const {appPackage} = extractMandatoryOptions(opts, ['appPackage']);
-  log.info(`Uninstalling '${appPackage}'`);
-  await this.adb.uninstallApk(appPackage);
-  log.info(`'${appPackage}' has been successfully uninstalled`);
-};
 
 commands.mobileQueryAppState =  async function (opts = {}) {
   const {appPackage} = extractMandatoryOptions(opts, ['appPackage']);

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -15,9 +15,6 @@ extensions.execute = async function (script, args) {
 extensions.executeMobile = async function (mobileCommand, opts = {}) {
   const mobileCommandsMapping = {
     shell: 'mobileShell',
-    installApp: 'mobileInstallApp',
-    isAppInstalled: 'mobileIsAppInstalled',
-    uninstallApp: 'mobileUninstallApp',
     queryAppState: 'mobileQueryAppState',
     terminateApp: 'mobileTerminateApp',
   };

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -15,7 +15,7 @@ extensions.execute = async function (script, args) {
 extensions.executeMobile = async function (mobileCommand, opts = {}) {
   const mobileCommandsMapping = {
     shell: 'mobileShell',
-    insstallApp: 'mobileInstallApp',
+    installApp: 'mobileInstallApp',
     isAppInstalled: 'mobileIsAppInstalled',
     uninstallApp: 'mobileUninstallApp',
     queryAppState: 'mobileQueryAppState',

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -15,6 +15,11 @@ extensions.execute = async function (script, args) {
 extensions.executeMobile = async function (mobileCommand, opts = {}) {
   const mobileCommandsMapping = {
     shell: 'mobileShell',
+    insstallApp: 'mobileInstallApp',
+    isAppInstalled: 'mobileIsAppInstalled',
+    uninstallApp: 'mobileUninstallApp',
+    queryAppState: 'mobileQueryAppState',
+    terminateApp: 'mobileTerminateApp',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -12,6 +12,7 @@ import recordscreenCmds from './recordscreen';
 import performanceCmds from './performance';
 import executeCmds from "./execute";
 import shellCmds from "./shell";
+import appManagementCommands from './apps-management';
 
 let commands = {};
 Object.assign(
@@ -30,6 +31,7 @@ Object.assign(
   performanceCmds,
   executeCmds,
   shellCmds,
+  appManagementCommands,
   // add other command types here
 );
 


### PR DESCRIPTION
This might be useful while multiple applications are affected in a single test or for some complicated scenarios where application upgrade/restart is checked.