### PR TITLE
Reset context after reset

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -227,6 +227,8 @@ commands.reset = async function () {
     log.info("Running fast reset (stop and clear)");
     await this.adb.stopAndClear(this.opts.appPackage);
   }
+  // reset context since we don't know what kind on context we will end up after app launch.
+  this.curContext = null;
 
   await this.grantPermissions();
 

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -310,6 +310,7 @@ describe('General', () => {
       helpers.installApkRemotely.calledWithExactly(driver.adb, driver.opts)
         .should.be.true;
       driver.grantPermissions.calledOnce.should.be.true;
+      driver.startAUT.calledOnce.should.be.true;
     });
     it('should do fast reset if fullReset is false', async () => {
       driver.opts.fullReset = false;

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -181,7 +181,7 @@ describe('General', () => {
         .should.be.true;
     });
     it('should throw an error if APK does not exist', async () => {
-      await driver.installApp('non/existent/app.apk').should.be.rejectedWith(/does not exist or is not accessible/);
+      await driver.installApp('non/existent/app.apk').should.be.rejectedWith(/Could not find app apk at/);
     });
   });
   describe('background', function () {
@@ -310,7 +310,6 @@ describe('General', () => {
       helpers.installApkRemotely.calledWithExactly(driver.adb, driver.opts)
         .should.be.true;
       driver.grantPermissions.calledOnce.should.be.true;
-      driver.startAUT.calledOnce.should.be.true;
     });
     it('should do fast reset if fullReset is false', async () => {
       driver.opts.fullReset = false;
@@ -322,6 +321,7 @@ describe('General', () => {
       driver.adb.stopAndClear.calledWithExactly('pkg').should.be.true;
       driver.grantPermissions.calledOnce.should.be.true;
       driver.startAUT.calledOnce.should.be.true;
+      expect(driver.curContext).to.be.null;
     });
   });
   describe('startAUT', () => {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -181,7 +181,7 @@ describe('General', () => {
         .should.be.true;
     });
     it('should throw an error if APK does not exist', async () => {
-      await driver.installApp('non/existent/app.apk').should.be.rejectedWith(/Could not find app apk at/);
+      await driver.installApp('non/existent/app.apk').should.be.rejectedWith(/does not exist or is not accessible/);
     });
   });
   describe('background', function () {


### PR DESCRIPTION
**Problem: context is not reset on reset command**
After invoking `driver.reset` on webview context, appium will keep telling us that chrome is not reachable although the app is up on the foreground. Apparently, switchContext was not invoked since new context is the same as last context (before reset).
Current workaround is by invoking `closeApp` before calling `reset`.

**Solution:**
Similar to `closeApp`, after `reset` we need to reset curContext as well. 