### PR TITLE
Make sure we return a context

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -15,7 +15,9 @@ let commands = {}, helpers = {}, extensions = {};
  * Actual MJSONWP command handlers
  * ------------------------------- */
 commands.getCurrentContext = async function () {
-  return this.curContext;
+  // if the current context is `null`, indicating no context
+  // explicitly set, it is the default context
+  return this.curContext || this.defaultContextName();
 };
 
 commands.getContexts = async function () {

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -44,6 +44,10 @@ describe('Context', function () {
       driver.curContext = 'current_context';
       await driver.getCurrentContext().should.become('current_context');
     });
+    it('should return NATIVE_APP if no context is set', async function () {
+      driver.curContext = null;
+      await driver.getCurrentContext().should.become(NATIVE_WIN);
+    });
   });
   describe('getContexts', function () {
     it('should get Chromium context where appropriate', async function () {


### PR DESCRIPTION
When closing apps and resetting, the context is set to null, and it remains so. If it is null when someone asks for the current context, that means it is NATIVE_APP.

Resolves https://github.com/appium/appium/issues/9933