### PR TITLE
Update lock logic, so it's in sync with iOS

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -121,16 +121,26 @@ commands.doDrag = async function (dragOpts) {
   }
 };
 
-commands.lock = async function () {
-  return await this.adb.lock();
+commands.lock = async function (seconds) {
+  await this.adb.lock();
+  if (isNaN(seconds)) {
+    return;
+  }
+
+  const floatSeconds = parseFloat(seconds);
+  if (floatSeconds <= 0) {
+    return;
+  }
+  await B.delay(1000 * parseFloat(seconds));
+  await this.unlock(this.caps);
 };
 
 commands.isLocked = async function () {
   return await this.adb.isScreenLocked();
 };
 
-commands.unlock = async function (unlockCapabilities) {
-  return await androidHelpers.unlock(this, this.adb, unlockCapabilities);
+commands.unlock = async function () {
+  return await androidHelpers.unlock(this, this.adb, this.caps);
 };
 
 commands.openNotifications = async function () {

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -131,8 +131,8 @@ commands.lock = async function (seconds) {
   if (floatSeconds <= 0) {
     return;
   }
-  await B.delay(1000 * parseFloat(seconds));
-  await this.unlock(this.caps);
+  await B.delay(1000 * floatSeconds);
+  await this.unlock();
 };
 
 commands.isLocked = async function () {

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -148,6 +148,12 @@ let commonCapConstraints = {
   clearDeviceLogsOnStart: {
     isBoolean: true
   },
+  unlockType: {
+    isString: true
+  },
+  unlockKey: {
+    isString: true
+  },
 };
 
 let uiautomatorCapConstraints = {

--- a/test/unit/commands/actions-specs.js
+++ b/test/unit/commands/actions-specs.js
@@ -5,7 +5,6 @@ import Bootstrap from 'appium-android-bootstrap';
 import path from 'path';
 import mockFS from 'mock-fs';
 import AndroidDriver from '../../..';
-import androidHelpers from '../../../lib/android-helpers';
 import * as support from 'appium-support';
 import temp from 'temp';
 import ADB from 'appium-adb';

--- a/test/unit/commands/actions-specs.js
+++ b/test/unit/commands/actions-specs.js
@@ -180,14 +180,6 @@ describe('Actions', function () {
       driver.adb.isScreenLocked.calledOnce.should.be.true;
     });
   });
-  describe('unlock', function () {
-    it('should call android-helpers.unlock()', async function () {
-      sandbox.stub(androidHelpers, 'unlock');
-      await driver.unlock('caps');
-      androidHelpers.unlock.calledWithExactly(driver, driver.adb, 'caps')
-        .should.be.true;
-    });
-  });
   describe('openNotifications', function () {
     it('should be able to open notifications', async function () {
       await driver.openNotifications();


### PR DESCRIPTION
the endpoint in base driver requires lock to have the required `seconds` parameter. the previous implementation was ignoring it. Now this is fixed and the server will wait for given number of seconds before to unlock the screen if seconds > 0. The same behaviour is implemented for iOS.

FYI @vrunoa 