### PR TITLE
Add shutdown timeout for screen recorder process

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import _fs from 'fs';
 import url from 'url';
-import { retryInterval } from 'asyncbox';
+import { retryInterval, waitForCondition } from 'asyncbox';
 import B from 'bluebird';
 import { util, fs, net } from 'appium-support';
 import log from '../logger';
@@ -12,6 +12,8 @@ let commands = {}, extensions = {};
 
 const RETRY_PAUSE = 1000;
 const MAX_RECORDING_TIME_SEC = 60 * 3;
+const DEFAULT_RECORDING_TIME_SEC = MAX_RECORDING_TIME_SEC;
+const PROCESS_SHUTDOWN_TIMEOUT_SEC = 5;
 const SCREENRECORD_BINARY = 'screenrecord';
 const DEFAULT_EXT = '.mp4';
 
@@ -29,6 +31,27 @@ async function extractCurrentRecordingPath (adb, pids) {
   const pattern = new RegExp(/\d+\s+(\/.*\.mp4)/);
   const matches = pattern.exec(lsofOutput);
   return _.isEmpty(matches) ? null : _.last(matches);
+}
+
+async function finishScreenCapture (adb, pids) {
+  try {
+    await adb.shell(['kill', '-2', ...pids]);
+  } catch (e) {
+    return true;
+  }
+  try {
+    await waitForCondition(async () => {
+      try {
+        await adb.shell(['kill', '-0', ...pids]);
+      } catch (ign) {
+        return true;
+      }
+      return false;
+    }, {waitMs: PROCESS_SHUTDOWN_TIMEOUT_SEC * 1000, intervalMs: 300});
+  } catch (e) {
+    return false;
+  }
+  return true;
 }
 
 async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, uploadOptions = {}) {
@@ -126,8 +149,7 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
  * @throws {Error} If screen recording has failed to start.
  */
 commands.startRecordingScreen = async function (options = {}) {
-  const {videoSize, timeLimit, bitRate, forceRestart} = options;
-  let result = '';
+  const {videoSize, timeLimit=DEFAULT_RECORDING_TIME_SEC, bitRate, forceRestart} = options;
   if (this.isEmulator()) {
     throw new Error('Screen recording does not work on emulators');
   }
@@ -138,12 +160,12 @@ commands.startRecordingScreen = async function (options = {}) {
     throw new Error(`Screen recording not available on API Level ${apiLevel}. Minimum API Level is 19.`);
   }
 
+  let result = '';
   if (!forceRestart) {
     result = await this.stopRecordingScreen(options);
   }
   try {
-    const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY))
-      .map((p) => `${p}`);
+    const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY)).map((p) => `${p}`);
     if (!_.isEmpty(pids)) {
       await this.adb.shell(['kill', ...pids]);
     }
@@ -165,29 +187,27 @@ commands.startRecordingScreen = async function (options = {}) {
     cmd.push('--size', videoSize);
   }
   if (util.hasValue(timeLimit)) {
-    cmd.push('--time-limit', timeLimit);
+    cmd.push('--time-limit', `${timeLimit}`);
   }
   if (util.hasValue(bitRate)) {
-    cmd.push('--bit-rate', bitRate);
+    cmd.push('--bit-rate', `${bitRate}`);
   }
   cmd.push(pathOnDevice);
 
   // wrap in a manual Promise so we can handle errors in adb shell operation
   return await new B(async (resolve, reject) => {
     let err = null;
-    const timeoutMs = isNaN(timeLimit) ? MAX_RECORDING_TIME_SEC * 1000 :
-      Math.round(parseFloat(timeLimit) * 1000);
-    if (timeoutMs > MAX_RECORDING_TIME_SEC * 1000) {
-      return reject(new Error(`The timeLimit ${timeLimit} cannot be greater than ` +
-                              `${MAX_RECORDING_TIME_SEC} seconds`));
+    let timeout = Math.floor(parseFloat(timeLimit) * 1000);
+    if (timeout > MAX_RECORDING_TIME_SEC * 1000 || timeout <= 0) {
+      return reject(new Error(`The timeLimit value must be in range (0, ${MAX_RECORDING_TIME_SEC}] seconds. ` +
+                              `The value of ${timeLimit} has been passed instead.`));
     }
-    if (timeoutMs <= 0) {
-      return reject(new Error(`The timeLimit ${timeLimit} must be greater than zero`));
-    }
-    log.debug(`Beginning screen recording with command: 'adb ${cmd.join(' ')}'. ` +
-              `Will timeout in ${timeoutMs / 1000} s`);
+    log.debug(`Beginning screen recording with command: 'adb shell ${cmd.join(' ')}'` +
+              `Will timeout in ${timeout / 1000} s`);
+    // screenrecord has its owen timer, so we only use this one as a safety precaution
+    timeout += PROCESS_SHUTDOWN_TIMEOUT_SEC * 1000 * 2;
     // do not await here, as the call runs in the background and we check for its product
-    this.adb.shell(cmd, {timeout: timeoutMs, killSignal: 'SIGINT'}).catch((e) => {
+    this.adb.shell(cmd, {timeout, killSignal: 'SIGINT'}).catch((e) => {
       err = e;
     });
 
@@ -249,34 +269,32 @@ commands.stopRecordingScreen = async function (options = {}) {
   const {remotePath, user, pass, method} = options;
   let result = '';
 
-  const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY))
-    .map((p) => `${p}`);
+  const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY)).map((p) => `${p}`);
+  let localPath = this._recentScreenRecordingPath;
   if (_.isEmpty(pids)) {
     log.info(`Screen recording is not running. There is nothing to stop.`);
-    if (!_.isEmpty(this._recentScreenRecordingPath)) {
-      result = await uploadRecordedMedia(this.adb, this._recentScreenRecordingPath, remotePath,
-        {user, pass, method});
+  } else {
+    localPath = localPath || await extractCurrentRecordingPath(this.adb, pids);
+    try {
+      if (_.isEmpty(localPath)) {
+        log.errorAndThrow(`Cannot parse the path to the file created by ` +
+                          `screen recorder process from 'ps' output. ` +
+                          `Did you start screen recording before?`);
+      }
+    } finally {
+      if (!await finishScreenCapture(this.adb, pids)) {
+        log.warn(`Unable to stop screen recording. Continuing anyway`);
+      }
+    }
+  }
+
+  if (!_.isEmpty(localPath)) {
+    try {
+      result = await uploadRecordedMedia(this.adb, localPath, remotePath, {user, pass, method});
+    } finally {
       this._recentScreenRecordingPath = null;
     }
-    return result;
   }
-
-  const pathOnDevice = this._recentScreenRecordingPath || await extractCurrentRecordingPath(this.adb, pids);
-  try {
-    if (_.isEmpty(pathOnDevice)) {
-      log.errorAndThrow(`Cannot parse the path to the file created by ` +
-                        `the screen recorder process. Did you start screen recording before?`);
-    }
-  } finally {
-    try {
-      await this.adb.shell(['kill', '-2', ...pids]);
-    } catch (err) {
-      log.warn(`Unable to stop screen recording: ${err.message}. Continuing anyway`);
-    }
-  }
-
-  result = await uploadRecordedMedia(this.adb, pathOnDevice, remotePath, {user, pass, method});
-  this._recentScreenRecordingPath = null;
   return result;
 };
 

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -269,13 +269,13 @@ commands.stopRecordingScreen = async function (options = {}) {
   const {remotePath, user, pass, method} = options;
 
   const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY)).map((p) => `${p}`);
-  let localPath = this._recentScreenRecordingPath;
+  let pathOnDevice = this._recentScreenRecordingPath;
   if (_.isEmpty(pids)) {
     log.info(`Screen recording is not running. There is nothing to stop.`);
   } else {
-    localPath = localPath || await extractCurrentRecordingPath(this.adb, pids);
+    pathOnDevice = pathOnDevice || await extractCurrentRecordingPath(this.adb, pids);
     try {
-      if (_.isEmpty(localPath)) {
+      if (_.isEmpty(pathOnDevice)) {
         log.errorAndThrow(`Cannot parse the path to the file created by ` +
                           `screen recorder process from 'ps' output. ` +
                           `Did you start screen recording before?`);
@@ -288,9 +288,9 @@ commands.stopRecordingScreen = async function (options = {}) {
   }
 
   let result = '';
-  if (!_.isEmpty(localPath)) {
+  if (!_.isEmpty(pathOnDevice)) {
     try {
-      result = await uploadRecordedMedia(this.adb, localPath, remotePath, {user, pass, method});
+      result = await uploadRecordedMedia(this.adb, pathOnDevice, remotePath, {user, pass, method});
     } finally {
       this._recentScreenRecordingPath = null;
     }

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -267,7 +267,6 @@ commands.startRecordingScreen = async function (options = {}) {
  */
 commands.stopRecordingScreen = async function (options = {}) {
   const {remotePath, user, pass, method} = options;
-  let result = '';
 
   const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY)).map((p) => `${p}`);
   let localPath = this._recentScreenRecordingPath;
@@ -288,6 +287,7 @@ commands.stopRecordingScreen = async function (options = {}) {
     }
   }
 
+  let result = '';
   if (!_.isEmpty(localPath)) {
     try {
       result = await uploadRecordedMedia(this.adb, localPath, remotePath, {user, pass, method});

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -27,6 +27,7 @@ describe('recording the screen', function () {
 
       await driver.startRecordingScreen().should.eventually.be.rejectedWith(/Screen recording does not work on emulators/);
     });
+
     it('should fail to recording the screen on a device with API level 18', async function () {
       mocks.driver.expects('isEmulator').returns(false);
       mocks.adb.expects('getApiLevel').returns(18);
@@ -146,6 +147,7 @@ describe('recording the screen', function () {
           screenrec 11328      shell    9u      REG               0,19     11521     294673 ${remotePath}
         `});
         mocks.adb.expects('shell').withExactArgs(['kill', '-2', ...pids]);
+        mocks.adb.expects('shell').withExactArgs(['kill', '-0', ...pids]).throws();
         mocks.adb.expects('pull').once().withExactArgs(remotePath, localFile);
         mocks.fs.expects('readFile').once().withExactArgs(localFile).returns(mediaContent);
         mocks.adb.expects('rimraf').once().withExactArgs(remotePath);
@@ -162,6 +164,7 @@ describe('recording the screen', function () {
         mocks.adb.expects('getPIDsByName').withExactArgs('screenrecord')
           .atLeast(1).returns(pids);
         mocks.adb.expects('shell').withExactArgs(['kill', '-2', ...pids]);
+        mocks.adb.expects('shell').withExactArgs(['kill', '-0', ...pids]).throws();
         mocks.adb.expects('pull').once().withExactArgs(driver._recentScreenRecordingPath, localFile);
         mocks.fs.expects('readFile').once().withExactArgs(localFile).returns(mediaContent);
         mocks.adb.expects('rimraf').once().withExactArgs(driver._recentScreenRecordingPath);
@@ -178,6 +181,7 @@ describe('recording the screen', function () {
         mocks.adb.expects('getPIDsByName').withExactArgs('screenrecord')
           .atLeast(1).returns(pids);
         mocks.adb.expects('shell').withExactArgs(['kill', '-2', ...pids]);
+        mocks.adb.expects('shell').withExactArgs(['kill', '-0', ...pids]).throws();
         mocks.adb.expects('pull').once().withExactArgs(driver._recentScreenRecordingPath, localFile);
         mocks.adb.expects('rimraf').once().withExactArgs(driver._recentScreenRecordingPath);
         mocks.fs.expects('rimraf').withExactArgs(localFile).once();


### PR DESCRIPTION
Screenrecord requires some time to shutdown after SIGINT is sent to the process