### PR TITLE
Reset context to NATIVE_APP instead of null

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -209,7 +209,7 @@ commands.reset = async function () {
   // reset context since we don't know what kind on context we will end up after app launch.
   this.curContext = NATIVE_WIN;
 
-  return await this.startAUT();
+  return await this.isChromeSession ? this.startChromeSession() : this.startAUT();
 };
 
 commands.startAUT = async function () {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -3,6 +3,7 @@ import androidHelpers from '../android-helpers';
 import { util } from 'appium-support';
 import B from 'bluebird';
 import log from '../logger';
+import { NATIVE_WIN } from '../webview-helpers';
 
 
 let commands = {}, helpers = {}, extensions = {};
@@ -206,7 +207,7 @@ commands.startActivity = async function (appPackage, appActivity,
 commands.reset = async function () {
   await androidHelpers.resetApp(this.adb, Object.assign({}, this.opts, {fastReset: true}));
   // reset context since we don't know what kind on context we will end up after app launch.
-  this.curContext = null;
+  this.curContext = NATIVE_WIN;
 
   return await this.startAUT();
 };
@@ -236,7 +237,7 @@ commands.setUrl = async function (uri) {
 commands.closeApp = async function () {
   await this.adb.forceStop(this.opts.appPackage);
   // reset context since we don't know what kind on context we will end up after app launch.
-  this.curContext = null;
+  this.curContext = NATIVE_WIN;
 };
 
 commands.getDisplayDensity = async function () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2,7 +2,7 @@ import { BaseDriver, DeviceSettings } from 'appium-base-driver';
 import Chromedriver from 'appium-chromedriver';
 import desiredConstraints from './desired-caps';
 import commands from './commands/index';
-import { setupNewChromedriver } from './commands/context';
+import * as contextCommands from './commands/context';
 import helpers from './android-helpers';
 import { CHROMIUM_WIN } from './webview-helpers';
 import log from './logger';
@@ -261,10 +261,6 @@ class AndroidDriver extends BaseDriver {
     if (this.isChromeSession) {
       // start a chromedriver session and proxy to it
       await this.startChromeSession();
-      if (this.shouldDismissChromeWelcome()) {
-        // dismiss Chrome welcome dialog
-        await this.dismissChromeWelcome();
-      }
     } else {
       if (this.opts.autoLaunch) {
         // start app
@@ -365,8 +361,8 @@ class AndroidDriver extends BaseDriver {
     if (!_.includes(knownPackages, this.opts.appPackage)) {
       opts.chromeAndroidActivity = this.opts.appActivity;
     }
-    this.chromedriver = await setupNewChromedriver(opts, this.adb.curDeviceId,
-                                                   this.adb);
+    this.chromedriver = await contextCommands.setupNewChromedriver(opts, this.adb.curDeviceId,
+                                                                   this.adb);
     this.chromedriver.on(Chromedriver.EVENT_CHANGED, (msg) => {
       if (msg.state === Chromedriver.STATE_STOPPED) {
         this.onChromedriverStop(CHROMIUM_WIN);
@@ -380,6 +376,11 @@ class AndroidDriver extends BaseDriver {
     this.sessionChromedrivers[CHROMIUM_WIN] = this.chromedriver;
     this.proxyReqRes = this.chromedriver.proxyReq.bind(this.chromedriver);
     this.jwpProxyActive = true;
+
+    if (this.shouldDismissChromeWelcome()) {
+      // dismiss Chrome welcome dialog
+      await this.dismissChromeWelcome();
+    }
   }
 
   async checkAppPresent () {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -318,7 +318,7 @@ describe('General', function () {
       await driver.reset().should.eventually.be.equal('aut');
       helpers.resetApp.calledWith(driver.adb).should.be.true;
       driver.startAUT.calledOnce.should.be.true;
-      expect(driver.curContext).to.be.null;
+      expect(driver.curContext).to.eql('NATIVE_APP');
     });
   });
   describe('startAUT', function () {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -3,13 +3,14 @@ import chaiAsPromised from 'chai-as-promised';
 import log from '../../lib/logger';
 import sinon from 'sinon';
 import helpers from '../../lib/android-helpers';
+import * as contextCommands from '../../lib/commands/context';
 import { withMocks } from 'appium-test-support';
 import AndroidDriver from '../..';
 import ADB from 'appium-adb';
 import { errors } from 'appium-base-driver';
 import { fs } from 'appium-support';
 import { SharedPrefsBuilder } from 'shared-preferences-builder';
-
+import _ from 'lodash';
 
 let driver;
 let sandbox = sinon.sandbox.create();
@@ -375,12 +376,30 @@ describe('driver', function () {
       await driver.startAndroidSession();
       driver.dismissChromeWelcome.calledOnce.should.be.false;
     });
+  });
+  describe('startChromeSession', function () {
+    beforeEach(async function () {
+      driver = new AndroidDriver();
+      driver.adb = new ADB();
+      driver.bootstrap = new helpers.bootstrap(driver.adb);
+      driver.settings = { update () { } };
+      driver.caps = {};
+
+      sandbox.stub(contextCommands, 'setupNewChromedriver').returns({
+        on: _.noop,
+        proxyReq: _.noop,
+      });
+      sandbox.stub(driver, 'dismissChromeWelcome');
+    });
+    afterEach(function () {
+      sandbox.restore();
+    });
     it('should call dismissChromeWelcome', async function () {
       driver.opts.browserName = 'Chrome';
       driver.opts.chromeOptions = {
-        "args" : ["--no-first-run"]
+        "args": ["--no-first-run"]
       };
-      await driver.startAndroidSession();
+      await driver.startChromeSession();
       driver.dismissChromeWelcome.calledOnce.should.be.true;
     });
   });


### PR DESCRIPTION
Rather than reset to `null`, which means native and causes much problems (see https://travis-ci.org/appium/appium-uiautomator2-driver/jobs/331143446 for instance), use `'NATIVE_APP'`.

Fixes the build for https://github.com/appium/appium-uiautomator2-driver/pull/134