### PR TITLE
Speed up driver init

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -378,26 +378,31 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
 
   await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID, 'Settings');
 
+  // Reinstall will stop the application process anyway, so
+  // there is no need to continue if the application is still running
+  if (await adb.processExists(SETTINGS_HELPER_PKG_ID)) {
+    logger.debug(`${SETTINGS_HELPER_PKG_ID} is already running. The is no need to reset permissions.`);
+    return;
+  }
+
   try {
     await adb.grantAllPermissions(SETTINGS_HELPER_PKG_ID);
   } catch (err) {
     // errors are expected there, since the app contains non-changeable permissons
   }
+
   // lauch io.appium.settings app due to settings failing to be set
   // if the app is not launched prior to start the session on android 7+
   // see https://github.com/appium/appium/issues/8957
   try {
-    if (!(await adb.processExists(SETTINGS_HELPER_PKG_ID))) {
-      let startOpts = {
-        pkg: SETTINGS_HELPER_PKG_ID,
-        activity: SETTINGS_HELPER_PKG_ACTIVITY,
-        action: "android.intent.action.MAIN",
-        category: "android.intent.category.LAUNCHER",
-        flags: "0x10200000",
-        stopApp: false
-      };
-      await adb.startApp(startOpts);
-    }
+    await adb.startApp({
+      pkg: SETTINGS_HELPER_PKG_ID,
+      activity: SETTINGS_HELPER_PKG_ACTIVITY,
+      action: "android.intent.action.MAIN",
+      category: "android.intent.category.LAUNCHER",
+      flags: "0x10200000",
+      stopApp: false,
+    });
   } catch (err) {
     logger.warn(`Failed to launch settings app: ${err.message}`);
     if (throwError) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -387,7 +387,7 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
 
   try {
     await adb.grantAllPermissions(SETTINGS_HELPER_PKG_ID);
-  } catch (err) {
+  } catch (ign) {
     // errors are expected there, since the app contains non-changeable permissons
   }
 

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -472,22 +472,15 @@ describe('Android Helpers', function () {
     });
   }));
   describe('pushSettingsApp', withMocks({adb}, (mocks) => {
-    it('should install settingsApp', async function () {
+    it('should skip granting permissions if the app is already running', async function () {
       mocks.adb.expects('installOrUpgrade').once()
         .returns(true);
-      mocks.adb.expects('grantAllPermissions').withExactArgs('io.appium.settings').once()
-        .returns(true);
+      mocks.adb.expects('grantAllPermissions').never();
       mocks.adb.expects('processExists')
           .withExactArgs('io.appium.settings').once()
           .returns(true);
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
-    });
-    it('should skip exception if installOrUpgrade or grantAllPermissions failed', async function () {
-      mocks.adb.expects('installOrUpgrade').throws();
-      mocks.adb.expects('grantAllPermissions').throws();
-      mocks.adb.expects('processExists').throws();
-      await helpers.pushSettingsApp(adb).should.be.fulfilled;
     });
     it('should launch settings app if it isnt running', async function () {
       mocks.adb.expects('installOrUpgrade').once()


### PR DESCRIPTION
Skip setting application permissions for Settings helper if it is already installed and is running on the device. Addresses https://github.com/appium/appium/issues/10070