### PR TITLE
fix for issue  #10086

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -273,7 +273,9 @@ helpers.reinstallRemoteApk = async function (adb, localApkPath, pkg,
 
 helpers.installApkRemotely = async function (adb, opts) {
   let {app, appPackage, fastReset, androidInstallTimeout} = opts;
-
+  if (androidInstallTimeout ==null){
+	androidInstallTimeout = REMOTE_INSTALL_TIMEOUT
+  }
   if (!app || !appPackage) {
     throw new Error("'app' and 'appPackage' options are required");
   }


### PR DESCRIPTION
A simple fix for the timeout issue for appium-android-driver when installing app. You can reference the issue number for more information. I screwed up the CLA signing so I am opening a new pull request