### PR TITLE
Restore application permissions after fast reset

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -248,6 +248,14 @@ helpers.resetApp = async function (adb, opts = {}) {
       }
       logger.warn(msg);
     }
+    // executing `shell pm clear` resets previously assigned application permissions as well
+    if (autoGrantPermissions) {
+      try {
+        await adb.grantAllPermissions(appPackage);
+      } catch (error) {
+        logger.error(`Unable to grant permissions requested. Original error: ${error.message}`);
+      }
+    }
   }
 
   // fullReset has priority over fastReset

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -240,28 +240,23 @@ helpers.resetApp = async function (adb, opts = {}) {
     try {
       await adb.forceStop(appPackage);
     } catch (ign) {}
-    const output = await adb.clear(appPackage);
-    if (_.isString(output) && output.toLowerCase().includes('failed')) {
-      const msg = `Cannot clear the application data of '${appPackage}'. Original error: ${output}`;
-      if (!fullReset && fastReset) {
-        throw new Error(msg);
+    // fullReset has priority over fastReset
+    if (!fullReset && fastReset) {
+      const output = await adb.clear(appPackage);
+      if (_.isString(output) && output.toLowerCase().includes('failed')) {
+        throw new Error(`Cannot clear the application data of '${appPackage}'. Original error: ${output}`);
       }
-      logger.warn(msg);
-    }
-    // executing `shell pm clear` resets previously assigned application permissions as well
-    if (autoGrantPermissions) {
-      try {
-        await adb.grantAllPermissions(appPackage);
-      } catch (error) {
-        logger.error(`Unable to grant permissions requested. Original error: ${error.message}`);
+      // executing `shell pm clear` resets previously assigned application permissions as well
+      if (autoGrantPermissions) {
+        try {
+          await adb.grantAllPermissions(appPackage);
+        } catch (error) {
+          logger.error(`Unable to grant permissions requested. Original error: ${error.message}`);
+        }
       }
+      logger.debug(`Performed fast reset on the installed '${appPackage}' application (stop and clear)`);
+      return;
     }
-  }
-
-  // fullReset has priority over fastReset
-  if (!fullReset && isInstalled && fastReset) {
-    logger.debug(`Performed fast reset on the installed '${appPackage}' application (stop and clear)`);
-    return;
   }
 
   if (!app) {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -321,7 +321,8 @@ describe('Android Helpers', function () {
       mocks.adb.expects('isAppInstalled').once().withExactArgs(pkg).returns(true);
       mocks.adb.expects('forceStop').withExactArgs(pkg).once();
       mocks.adb.expects('clear').withExactArgs(pkg).once().returns('Success');
-      await helpers.resetApp(adb, {app: localApkPath, appPackage: pkg, fastReset: true});
+      mocks.adb.expects('grantAllPermissions').once().withExactArgs(pkg);
+      await helpers.resetApp(adb, {app: localApkPath, appPackage: pkg, fastReset: true, autoGrantPermissions:true});
       mocks.adb.verify();
     });
     it('should perform reinstall if app is not installed and fast reset is requested', async function () {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -311,7 +311,6 @@ describe('Android Helpers', function () {
     it('should be able to do full reset', async function () {
       mocks.adb.expects('install').once().withArgs(localApkPath);
       mocks.adb.expects('forceStop').withExactArgs(pkg).once();
-      mocks.adb.expects('clear').withExactArgs(pkg).once().returns('Success');
       mocks.adb.expects('isAppInstalled').once().withExactArgs(pkg).returns(true);
       mocks.adb.expects('uninstallApk').once().withExactArgs(pkg);
       await helpers.resetApp(adb, {app: localApkPath, appPackage: pkg});


### PR DESCRIPTION
Unfortunately it is not possible to fully get rid of slow grantAllPermissions helper., since all application permissions are reset after `pm clear` command is executed on the application package.