### PR TITLE
add getting element rect for uiautomator

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If more than one of these capabilities are given, the driver will only use first
 | `getPageSource`            |
 | `getScreenshot`            |
 | `getSize`                  |
+| `getElementRect`           |
 | `getStrings`               |
 | `getSystemBars`            |
 | `getText`                  |

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -117,6 +117,10 @@ commands.getSize = async function (elementId) {
   return await this.bootstrap.sendAction("element:getSize", {elementId});
 };
 
+commands.getElementRect = async function (elementId) {
+  return await this.bootstrap.sendAction("element:getRect", {elementId});
+};
+
 commands.touchLongClick = async function (elementId, x, y, duration) {
   let params = {elementId, x, y, duration};
   androidHelpers.removeNullProperties(params);

--- a/test/unit/commands/element-specs.js
+++ b/test/unit/commands/element-specs.js
@@ -217,6 +217,16 @@ describe('Element', function () {
         .should.be.true;
     });
   });
+  describe('getElementRect', function () {
+    it('should get rect of an element', async function () {
+      driver.bootstrap.sendAction
+        .withArgs('element:getRect').returns('rect_info');
+      await driver.getElementRect('el1').should.become('rect_info');
+      driver.bootstrap.sendAction
+        .calledWithExactly('element:getRect', {elementId: 'el1'})
+        .should.be.true;
+    });
+  });
   describe('touchLongClick', function () {
     it('should do touch long click on element', async function () {
       let params = {elementId: 'el1', x: 12, y: 34, duration: 5};


### PR DESCRIPTION
Only this driver has no `rect` response.

## After
```
[HTTP] <-- POST /wd/hub/session/071827a5-7d43-4a01-81b6-1f2615c23ee3/element 200 29 ms - 53
[debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Returning result: {"status":0,"value":{"ELEMENT":"1"}}
[HTTP] --> GET /wd/hub/session/071827a5-7d43-4a01-81b6-1f2615c23ee3/element/1/rect {}
[debug] [W3C] Calling AppiumDriver.getElementRect() with args: ["1","071827a5-7d43-4a01-81b6-1f2615c23ee3"]
[debug] [AndroidBootstrap] Sending command to android: {"cmd":"action","action":"element:getRect","params":{"elementId":"1"}}
[debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Got data from client: {"cmd":"action","action":"element:getRect","params":{"elementId":"1"}}
[debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Got command of type ACTION
[debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Got command action: getRect
[debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Returning result: {"status":0,"value":{"x":0,"y":726,"width":1080,"height":126}}
[debug] [AndroidBootstrap] Received command result from bootstrap
[debug] [W3C] Responding to client with driver.getElementRect() result: {"x":0,"y":726,"width":1080,"height":126}
[HTTP] <-- GET /wd/hub/session/071827a5-7d43-4a01-81b6-1f2615c23ee3/element/1/rect 200 14 ms - 51
```

## before
```
[debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Using: UiSelector[DESCRIPTION=Content, INSTANCE=0]
[debug] [AndroidBootstrap] [BOOTSTRAP LOG] [debug] Returning result: {"status":0,"value":{"ELEMENT":"1"}}
[debug] [AndroidBootstrap] Received command result from bootstrap
[debug] [W3C] Responding to client with driver.findElement() result: {"element-6066-11e4-a52e-4f735466cecf":"1"}
[HTTP] <-- POST /wd/hub/session/64402ff4-0006-4ded-9994-c3618ee09007/element 200 15 ms - 53
[HTTP] --> GET /wd/hub/session/64402ff4-0006-4ded-9994-c3618ee09007/element/1/rect {}
[debug] [W3C] Calling AppiumDriver.getElementRect() with args: ["1","64402ff4-0006-4ded-9994-c3618ee09007"]
[HTTP] <-- GET /wd/hub/session/64402ff4-0006-4ded-9994-c3618ee09007/element/1/rect 404 6 ms - 2351
```

----

In `uiautomator2`, the `rect` is handled in server side. So, this change doesn't affect that and I also have checked on my local.
https://github.com/appium/appium-uiautomator2-server/blob/6b2a76845c636d5d436dfd349a2ab55d4528950b/app/src/main/java/io/appium/uiautomator2/server/AppiumServlet.java#L129

`XCUITest` as well.