### PR TITLE
fix process check in terminateApp

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -112,7 +112,7 @@ commands.removeApp = async function (appId, options = {}) {
  */
 commands.terminateApp = async function (appId, options = {}) {
   log.info(`Terminating '${appId}'`);
-  if (await this.adb.processExists(appId)) {
+  if (!(await this.adb.processExists(appId))) {
     log.info(`The app '${appId}' is not running`);
     return false;
   }


### PR DESCRIPTION
Currently, terminateApp returns not running error if the app process running, and fit it.