### PR TITLE
Do not perform unnecessary call to getSize endpoint

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -206,13 +206,13 @@ helpers.parseTouch = async function (gestures, multi) {
       let elementId = gesture.options.element;
       if (elementId) {
         let pos = await this.getLocationInView(elementId);
-        let size = await this.getSize(elementId);
         if (gesture.options.x || gesture.options.y) {
           options.x = pos.x + (gesture.options.x || 0);
           options.y = pos.y + (gesture.options.y || 0);
         } else {
-          options.x = pos.x + (size.width / 2);
-          options.y = pos.y + (size.height / 2);
+          const {width, height} = await this.getSize(elementId);
+          options.x = pos.x + (width / 2);
+          options.y = pos.y + (height / 2);
         }
         let touchStateObject = {
           action: gesture.action,


### PR DESCRIPTION
This saves some milliseconds while building gestures chain