### PR TITLE
Move to real find methods, not findByElOrEls

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -19,9 +19,6 @@ helpers.doFindElementOrEls = async function (params) {
 // mult: multiple elements or just one?
 // context: finding an element from the root context? or starting from another element
 helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
-  // throws error if not valid, uses this.locatorStrategies
-  this.validateLocatorStrategy(strategy);
-
   if (!selector) {
     throw new Error("Must provide a selector when finding elements");
   }

--- a/test/functional/commands/actions-e2e-specs.js
+++ b/test/functional/commands/actions-e2e-specs.js
@@ -29,7 +29,7 @@ describe('actions', function () {
 
   describe('replaceValue', function () {
     it('should replace existing value in a text field', async function () {
-      let el = _.last(await driver.findElOrEls('class name', 'android.widget.EditText', true));
+      let el = _.last(await driver.findElements('class name', 'android.widget.EditText'));
       el.should.exist;
       await driver.setValue('original value', el.ELEMENT);
       await driver.getText(el.ELEMENT).should.eventually.equal('original value');

--- a/test/functional/commands/basic/attribute-e2e-specs.js
+++ b/test/functional/commands/basic/attribute-e2e-specs.js
@@ -14,7 +14,7 @@ describe('apidemo - attributes', function () {
   before(async function () {
     driver = new AndroidDriver();
     await driver.createSession(DEFAULT_CAPS);
-    let animation = await driver.findElOrEls('accessibility id', 'Animation', false);
+    let animation = await driver.findElement('accessibility id', 'Animation');
     animationEl = animation.ELEMENT;
   });
   after(async function () {
@@ -31,7 +31,7 @@ describe('apidemo - attributes', function () {
   });
   it('should be able to find name attribute, falling back to text', async function () {
     await driver.click(animationEl);
-    let textView = await driver.findElOrEls('class name', 'android.widget.TextView', true);
+    let textView = await driver.findElements('class name', 'android.widget.TextView');
     let textViewEl = textView[1].ELEMENT;
     await driver.getAttribute('name', textViewEl).should.eventually.become('Bouncing Balls');
     await driver.back();

--- a/test/functional/commands/basic/element-e2e-specs.js
+++ b/test/functional/commands/basic/element-e2e-specs.js
@@ -19,7 +19,7 @@ describe('element', function () {
   before(async function () {
     driver = new AndroidDriver();
     await driver.createSession(caps);
-    el = _.last(await driver.findElOrEls('class name', 'android.widget.EditText', true));
+    el = _.last(await driver.findElements('class name', 'android.widget.EditText'));
     el.should.exist;
   });
   after(async function () {

--- a/test/functional/commands/find/by-accessibility-id-e2e-specs.js
+++ b/test/functional/commands/find/by-accessibility-id-e2e-specs.js
@@ -17,14 +17,14 @@ describe('Find - accessibility ID', function () {
     await driver.deleteSession();
   });
   it('should find an element by name', async function () {
-    await driver.findElOrEls('accessibility id', 'Animation', false).should.eventually.exist;
+    await driver.findElement('accessibility id', 'Animation').should.eventually.exist;
   });
   it('should return an array of one element if the `multi` param is true', async function () {
-    let els = await driver.findElOrEls('accessibility id', 'Animation', true);
+    let els = await driver.findElements('accessibility id', 'Animation');
     els.should.be.an.instanceof(Array);
     els.should.have.length(1);
   });
   it('should find an element with a content-desc property containing an apostrophe', async function () {
-    await driver.findElOrEls('accessibility id', "Access'ibility", false).should.eventually.exist;
+    await driver.findElement('accessibility id', `Access'ibility`).should.eventually.exist;
   });
 });

--- a/test/functional/commands/find/by-id-e2e-specs.js
+++ b/test/functional/commands/find/by-id-e2e-specs.js
@@ -17,11 +17,11 @@ describe('Find - ID', function () {
     await driver.deleteSession();
   });
   it('should find an element by id', async function () {
-    await driver.findElOrEls('id', 'android:id/text1', false).should.eventually.exist;
+    await driver.findElement('id', 'android:id/text1').should.eventually.exist;
   });
   it('should return an array of one element if the `multi` param is true', async function () {
     // TODO: this returns an object instead of an array. Investigate.
-    let els = await driver.findElOrEls('id', 'android:id/text1', true);
+    let els = await driver.findElements('id', 'android:id/text1');
     els.should.be.an.instanceof(Array);
     els.should.have.length.above(1);
   });

--- a/test/functional/commands/find/by-uiautomator-e2e-specs.js
+++ b/test/functional/commands/find/by-uiautomator-e2e-specs.js
@@ -17,119 +17,119 @@ describe('Find - uiautomator', function () {
     await driver.deleteSession();
   });
   it('should find elements with a boolean argument', async function () {
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true)', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().clickable(true)')
       .should.eventually.have.length.at.least(10);
   });
   it('should find elements within the context of another element', async function () {
     let els = await driver
-      .findElOrEls('-android uiautomator', 'new UiSelector().className("android.widget.TextView")', true);
+      .findElements('-android uiautomator', 'new UiSelector().className("android.widget.TextView")');
     els.length.should.be.above(8);
     els.length.should.be.below(14);
   });
   it('should find elements without prepending "new UiSelector()"', async function () {
-    await driver.findElOrEls('-android uiautomator', '.clickable(true)', true)
+    await driver.findElements('-android uiautomator', '.clickable(true)')
       .should.eventually.have.length.at.least(10);
   });
   it('should find elements without prepending "new UiSelector()"', async function () {
-    await driver.findElOrEls('-android uiautomator', '.clickable(true)', true)
+    await driver.findElements('-android uiautomator', '.clickable(true)')
       .should.eventually.have.length.at.least(10);
   });
   it('should find elements without prepending "new UiSelector()"', async function () {
-    await driver.findElOrEls('-android uiautomator', 'clickable(true)', true)
+    await driver.findElements('-android uiautomator', 'clickable(true)')
       .should.eventually.have.length.at.least(10);
   });
   it('should find elements without prepending "new "', async function () {
-    await driver.findElOrEls('-android uiautomator', 'UiSelector().clickable(true)', true)
+    await driver.findElements('-android uiautomator', 'UiSelector().clickable(true)')
       .should.eventually.have.length.at.least(10);
   });
   it('should ignore trailing semicolons', async function () {
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true);', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().clickable(true);')
       .should.eventually.have.length.at.least(10);
   });
   it('should find an element with an int argument', async function () {
-    let el = await driver.findElOrEls('-android uiautomator', 'new UiSelector().index(0)', false);
+    let el = await driver.findElement('-android uiautomator', 'new UiSelector().index(0)');
     await driver.getName(el.ELEMENT).should.eventually.equal('android.widget.FrameLayout');
   });
   it('should find an element with a string argument', async function () {
     await driver
-      .findElOrEls('-android uiautomator', 'new UiSelector().description("Animation")', false)
+      .findElement('-android uiautomator', 'new UiSelector().description("Animation")')
       .should.eventually.exist;
   });
   it('should find an element with an overloaded method argument', async function () {
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().className("android.widget.TextView")', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().className("android.widget.TextView")')
       .should.eventually.have.length.at.least(10);
   });
   it('should find an element with a Class<T> method argument', async function () {
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().className(android.widget.TextView)', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().className(android.widget.TextView)')
       .should.eventually.have.length.at.least(10);
   });
   it('should find an element with a long chain of methods', async function () {
-    let el = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true).className(android.widget.TextView).index(1)', false);
+    let el = await driver.findElement('-android uiautomator', 'new UiSelector().clickable(true).className(android.widget.TextView).index(1)');
     await driver.getText(el.ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find an element with recursive UiSelectors', async function () {
     // TODO: figure out why this fails with 7.1.1
     if (await driver.adb.getApiLevel() >= 24) return this.skip(); //eslint-disable-line curly
 
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().childSelector(new UiSelector().clickable(true)).clickable(true)', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().childSelector(new UiSelector().clickable(true)).clickable(true)')
       .should.eventually.have.length(1);
   });
   it('should not find an element with bad syntax', async function () {
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable((true)', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().clickable((true)')
       .should.eventually.be.rejectedWith(/resource could not be found/);
   });
   it('should not find an element with bad syntax', async function () {
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().drinkable(true)', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().drinkable(true)')
       .should.eventually.be.rejectedWith(/resource could not be found/);
   });
   it('should not find an element which does not exist', async function () {
-    await driver.findElOrEls('-android uiautomator', 'new UiSelector().description("chuckwudi")', true)
+    await driver.findElements('-android uiautomator', 'new UiSelector().description("chuckwudi")')
       .should.eventually.have.length(0);
   });
   it('should allow multiple selector statements and return the Union of the two sets', async function () {
-    let clickable = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true)', true);
+    let clickable = await driver.findElements('-android uiautomator', 'new UiSelector().clickable(true)');
     clickable.length.should.be.above(0);
-    let notClickable = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(false)', true);
+    let notClickable = await driver.findElements('-android uiautomator', 'new UiSelector().clickable(false)');
     notClickable.length.should.be.above(0);
-    let both = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true); new UiSelector().clickable(false);', true);
+    let both = await driver.findElements('-android uiautomator', 'new UiSelector().clickable(true); new UiSelector().clickable(false);');
     both.should.have.length(clickable.length + notClickable.length);
   });
   it('should allow multiple selector statements and return the Union of the two sets', async function () {
-    let clickable = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true)', true);
+    let clickable = await driver.findElements('-android uiautomator', 'new UiSelector().clickable(true)');
     clickable.length.should.be.above(0);
-    let clickableClickable = await driver.findElOrEls('-android uiautomator', 'new UiSelector().clickable(true); new UiSelector().clickable(true);', true);
+    let clickableClickable = await driver.findElements('-android uiautomator', 'new UiSelector().clickable(true); new UiSelector().clickable(true);');
     clickableClickable.length.should.be.above(0);
     clickableClickable.should.have.length(clickable.length);
   });
   it('should find an element in the second selector if the first finds no elements', async function () {
     let selector = 'new UiSelector().className("not.a.class"); new UiSelector().className("android.widget.TextView")';
-    await driver.findElOrEls('-android uiautomator', selector, true)
+    await driver.findElements('-android uiautomator', selector)
       .should.eventually.exist;
   });
   it('should scroll to, and return elements using UiScrollable', async function () {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0))';
-    let el = await driver.findElOrEls('-android uiautomator', selector, false);
+    let el = await driver.findElement('-android uiautomator', selector);
     await driver.getText(el.ELEMENT).should.eventually.equal('Views');
   });
   it('should allow chaining UiScrollable methods', async function () {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).setMaxSearchSwipes(10).scrollIntoView(new UiSelector().text("Views").instance(0))';
-    let el = await driver.findElOrEls('-android uiautomator', selector, false);
+    let el = await driver.findElement('-android uiautomator', selector);
     await driver.getText(el.ELEMENT).should.eventually.equal('Views');
   });
   it('should allow UiScrollable scrollIntoView', async function () {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0));';
-    let el = await driver.findElOrEls('-android uiautomator', selector, false);
+    let el = await driver.findElement('-android uiautomator', selector);
     await driver.getText(el.ELEMENT).should.eventually.equal('Views');
   });
   it('should error reasonably if a UiScrollable does not return a UiObject', async function () {
     let selector = 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).setMaxSearchSwipes(10)';
-    await driver.findElOrEls('-android uiautomator', selector, false)
+    await driver.findElement('-android uiautomator', selector)
       .should.eventually.be.rejectedWith(/resource could not be found/);
   });
   it('should allow UiScrollable with unicode string', async function () {
     await driver.startActivity('io.appium.android.apis', '.text.Unicode');
     let selector = 'new UiSelector().text("عربي").instance(0);';
-    let el = await driver.findElOrEls('-android uiautomator', selector, false);
+    let el = await driver.findElement('-android uiautomator', selector);
     await driver.getText(el.ELEMENT).should.eventually.equal('عربي');
   });
 });

--- a/test/functional/commands/find/by-xpath-e2e-specs.js
+++ b/test/functional/commands/find/by-xpath-e2e-specs.js
@@ -20,30 +20,30 @@ describe('Find - xpath', function () {
     await driver.deleteSession();
   });
   it('should throw when matching nothing', async function () {
-    await driver.findElOrEls('xpath', '//whatthat', false).should.eventually.be.rejectedWith(/could not be located/);
+    await driver.findElement('xpath', '//whatthat').should.eventually.be.rejectedWith(/could not be located/);
   });
   it('should throw with status 7 for hierarchy root', async function () {
-    await driver.findElOrEls('xpath', '/*', false).should.eventually.be.rejectedWith(/could not be located/);
+    await driver.findElement('xpath', '/*').should.eventually.be.rejectedWith(/could not be located/);
   });
   it('should find element by type', async function () {
-    let el = await driver.findElOrEls('xpath', `//${atv}`, false);
+    let el = await driver.findElement('xpath', `//${atv}`);
     await driver.getText(el.ELEMENT).should.eventually.equal('API Demos');
   });
   it('should find element by text', async function () {
-    let el = await driver.findElOrEls('xpath', `//${atv}[@text='Accessibility']`, false);
+    let el = await driver.findElement('xpath', `//${atv}[@text='Accessibility']`);
     await driver.getText(el.ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find exactly one element via elementsByXPath', async function () {
-    let el = await driver.findElOrEls('xpath', `//${atv}[@text='Accessibility']`, true);
+    let el = await driver.findElements('xpath', `//${atv}[@text='Accessibility']`);
     el.length.should.equal(1);
     await driver.getText(el[0].ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find element by partial text', async function () {
-    let el = await driver.findElOrEls('xpath', `//${atv}[contains(@text, 'Accessibility')]`, false);
+    let el = await driver.findElement('xpath', `//${atv}[contains(@text, 'Accessibility')]`);
     await driver.getText(el.ELEMENT).should.eventually.equal('Accessibility');
   });
   it('should find the last element', async function () {
-    let el = await driver.findElOrEls('xpath', `(//${atv})[last()]`, false);
+    let el = await driver.findElement('xpath', `(//${atv})[last()]`);
     let text = await driver.getText(el.ELEMENT);
     ["OS", "Text", "Views", "Preference"].should.include(text);
   });
@@ -51,27 +51,27 @@ describe('Find - xpath', function () {
   // TODO: Doesn't work on CI. Works locally on API_LEVEL 23
   //it('should find element by xpath index and child @skip-ci', async () => {
     // let alv = 'android.widget.ListView';
-    // let el = await driver.findElOrEls('xpath', `//${f}[2]/${alv}[1]/${atv}[4]`, false);
+    // let el = await driver.findElement('xpath', `//${f}[2]/${alv}[1]/${atv}[4]`);
     // await driver.getText(el.ELEMENT).should.eventually.equal('App');
   //});
 
   it('should find element by index and embedded desc', async function () {
-    let el = await driver.findElOrEls('xpath', `//${f}//${atv}[5]`, false);
+    let el = await driver.findElement('xpath', `//${f}//${atv}[5]`);
     await driver.getText(el.ELEMENT).should.eventually.equal('Content');
   });
   it('should find all elements', async function () {
-    let el = await driver.findElOrEls('xpath', `//*`, true);
-    el.length.should.be.above(2);
+    let els = await driver.findElements('xpath', `//*`);
+    els.length.should.be.above(2);
   });
   it('should find the first element when searching for all elements', async function () {
-    let el = await driver.findElOrEls('xpath', `//*`, true);
+    let el = await driver.findElements('xpath', `//*`);
     el[0].should.exist;
   });
   it('should find less elements with compression turned on', async function () {
     await driver.updateSettings({ignoreUnimportantViews: false});
-    let elementsWithoutCompression = await driver.findElOrEls('xpath', `//*`, true);
+    let elementsWithoutCompression = await driver.findElements('xpath', `//*`);
     await driver.updateSettings({ignoreUnimportantViews: true});
-    let elementsWithCompression = await driver.findElOrEls('xpath', `//*`, true);
+    let elementsWithCompression = await driver.findElements('xpath', `//*`);
     elementsWithoutCompression.length.should.be.greaterThan(elementsWithCompression.length);
   });
 });

--- a/test/functional/commands/find/find-basic-e2e-specs.js
+++ b/test/functional/commands/find/find-basic-e2e-specs.js
@@ -24,54 +24,54 @@ describe('Find - basic', function () {
     await driver.deleteSession();
   });
   it('should find a single element by content-description', async function () {
-    let el = await driver.findElOrEls('accessibility id', 'Animation', false);
+    let el = await driver.findElement('accessibility id', 'Animation');
     await driver.getText(el.ELEMENT).should.eventually.equal('Animation');
   });
   it('should find an element by class name', async function () {
-    let el = await driver.findElOrEls('class name', 'android.widget.TextView', false);
+    let el = await driver.findElement('class name', 'android.widget.TextView');
     await driver.getText(el.ELEMENT).should.eventually.equal('API Demos');
   });
   it('should find multiple elements by class name', async function () {
-    await driver.findElOrEls('class name', 'android.widget.TextView', true)
+    await driver.findElements('class name', 'android.widget.TextView')
       .should.eventually.have.length.at.least(10);
   });
   it('should not find an element that doesnt exist', async function () {
-    await driver.findElOrEls('class name', 'blargimarg', false)
+    await driver.findElement('class name', 'blargimarg')
       .should.be.rejectedWith(/could not be located/);
   });
   it('should not find multiple elements that doesnt exist', async function () {
-    await driver.findElOrEls('class name', 'blargimarg', true)
+    await driver.findElements('class name', 'blargimarg')
       .should.eventually.have.length(0);
   });
   it('should fail on empty locator', async function () {
-    await driver.findElOrEls('class name', '', true).should.be.rejectedWith(/selector/);
+    await driver.findElements('class name', '').should.be.rejectedWith(/selector/);
   });
   it('should find a single element by string id @skip-android-all', async function () {
-    let el = await driver.findElOrEls('id', 'activity_sample_code', false);
+    let el = await driver.findElement('id', 'activity_sample_code');
     await driver.getText(el.ELEMENT).should.eventually.equal('API Demos');
   });
   it('should find a single element by resource-id', async function () {
-    await driver.findElOrEls('id', `android:id/${singleResourceId}`, false)
+    await driver.findElement('id', `android:id/${singleResourceId}`)
       .should.eventually.exist;
   });
   it('should find multiple elements by resource-id', async function () {
-    await driver.findElOrEls('id', 'android:id/text1', true)
+    await driver.findElements('id', 'android:id/text1')
       .should.eventually.have.length.at.least(10);
   });
   it('should find multiple elements by resource-id even when theres just one', async function () {
-    await driver.findElOrEls('id', `android:id/${singleResourceId}`, true)
+    await driver.findElements('id', `android:id/${singleResourceId}`)
       .should.eventually.have.length(1);
   });
   it('should find a single element by resource-id with implicit package', async function () {
-    await driver.findElOrEls('id', singleResourceId, false)
+    await driver.findElement('id', singleResourceId)
       .should.eventually.exist;
   });
   it('should find a single element by resource-id with implicit package', async function () {
-    await driver.findElOrEls('id', 'text1', true)
+    await driver.findElements('id', 'text1')
       .should.eventually.have.length.at.least(10);
   });
   it('should find multiple elements by resource-id with implicit package even when theres just one', async function () {
-    await driver.findElOrEls('id', singleResourceId, true)
+    await driver.findElements('id', singleResourceId)
       .should.eventually.have.length(1);
   });
   describe('implicit wait', function () {
@@ -81,7 +81,7 @@ describe('Find - basic', function () {
     });
     it('should respect implicit wait with multiple elements', async function () {
       let beforeMs = Date.now();
-      await driver.findElOrEls('id', 'there_is_nothing_called_this', true)
+      await driver.findElements('id', 'there_is_nothing_called_this')
         .should.eventually.have.length(0);
       let afterMs = Date.now();
       (afterMs - beforeMs).should.be.below(implicitWait + 5000);
@@ -89,7 +89,7 @@ describe('Find - basic', function () {
     });
     it('should respect implicit wait with a single element', async function () {
       let beforeMs = Date.now();
-      await driver.findElOrEls('id', 'there_is_nothing_called_this', false)
+      await driver.findElement('id', 'there_is_nothing_called_this')
         .should.eventually.be.rejectedWith(/could not be located/);
       let afterMs = Date.now();
       (afterMs - beforeMs).should.be.below(implicitWait + 5000);

--- a/test/functional/commands/find/from-el-e2e-specs.js
+++ b/test/functional/commands/find/from-el-e2e-specs.js
@@ -12,31 +12,30 @@ const alv = 'android.widget.ListView';
 
 describe('Find - from element', function () {
   let driver;
+  let el;
   before(async function () {
     driver = new AndroidDriver();
     await driver.createSession(DEFAULT_CAPS);
+    el = await driver.findElement('class name', alv);
+    el = el.ELEMENT;
   });
   after(async function () {
     await driver.deleteSession();
   });
   it('should find a single element by tag name', async function () {
-    let el = await driver.findElOrEls('class name', alv, false);
-    let innerEl = await driver.findElOrEls('class name', atv, false, el.ELEMENT);
+    let innerEl = await driver.findElementFromElement('class name', atv, el);
     await driver.getText(innerEl.ELEMENT).should.eventually.equal("Access'ibility");
   });
   it('should find multiple elements by tag name', async function () {
-    let el = await driver.findElOrEls('class name', alv, false);
-    let innerEl = await driver.findElOrEls('class name', atv, true, el.ELEMENT);
+    let innerEl = await driver.findElementsFromElement('class name', atv, el);
     await driver.getText(innerEl[0].ELEMENT).should.eventually.have.length.above(10);
   });
-  it('should not find an element that doesnt exist', async function () {
-    let el = await driver.findElOrEls('class name', alv, false);
-    await driver.findElOrEls('class name', 'blargimarg', false, el.ELEMENT)
+  it('should not find an element that does not exist', async function () {
+    await driver.findElementFromElement('class name', 'blargimarg', el)
       .should.be.rejectedWith(/could not be located/);
   });
-  it('should not find multiple elements that dont exist', async function () {
-    let el = await driver.findElOrEls('class name', alv, true);
-    await driver.findElOrEls('class name', 'blargimarg', false, el.ELEMENT)
+  it('should not find multiple elements that do not exist', async function () {
+    await driver.findElementFromElement('class name', 'blargimarg', el)
       .should.be.rejectedWith(/could not be located/);
   });
 });

--- a/test/functional/commands/find/from-el-e2e-specs.js
+++ b/test/functional/commands/find/from-el-e2e-specs.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import AndroidDriver from '../../../..';
 import DEFAULT_CAPS from '../../desired';
+import { util } from 'appium-support';
 
 
 chai.should();
@@ -12,30 +13,31 @@ const alv = 'android.widget.ListView';
 
 describe('Find - from element', function () {
   let driver;
-  let el;
+  let parentEl;
+
   before(async function () {
     driver = new AndroidDriver();
     await driver.createSession(DEFAULT_CAPS);
-    el = await driver.findElement('class name', alv);
-    el = el.ELEMENT;
+    parentEl = await driver.findElement('class name', alv);
+    parentEl = util.unwrapElement(parentEl);
   });
   after(async function () {
     await driver.deleteSession();
   });
   it('should find a single element by tag name', async function () {
-    let innerEl = await driver.findElementFromElement('class name', atv, el);
+    let innerEl = await driver.findElementFromElement('class name', atv, parentEl);
     await driver.getText(innerEl.ELEMENT).should.eventually.equal("Access'ibility");
   });
   it('should find multiple elements by tag name', async function () {
-    let innerEl = await driver.findElementsFromElement('class name', atv, el);
+    let innerEl = await driver.findElementsFromElement('class name', atv, parentEl);
     await driver.getText(innerEl[0].ELEMENT).should.eventually.have.length.above(10);
   });
   it('should not find an element that does not exist', async function () {
-    await driver.findElementFromElement('class name', 'blargimarg', el)
+    await driver.findElementFromElement('class name', 'blargimarg', parentEl)
       .should.be.rejectedWith(/could not be located/);
   });
   it('should not find multiple elements that do not exist', async function () {
-    await driver.findElementFromElement('class name', 'blargimarg', el)
+    await driver.findElementFromElement('class name', 'blargimarg', parentEl)
       .should.be.rejectedWith(/could not be located/);
   });
 });

--- a/test/functional/commands/find/invalid-strategy-e2e-specs.js
+++ b/test/functional/commands/find/invalid-strategy-e2e-specs.js
@@ -17,7 +17,7 @@ describe('Find - invalid strategy', function () {
     await driver.deleteSession();
   });
   it('should not accept -ios uiautomation locator strategy', async function () {
-    await driver.findElOrEls('-ios uiautomation', '.elements()', false)
+    await driver.findElement('-ios uiautomation', '.elements()')
       .should.eventually.be.rejectedWith(/not supported/);
   });
 });

--- a/test/functional/commands/geo-location-e2e-specs.js
+++ b/test/functional/commands/geo-location-e2e-specs.js
@@ -20,7 +20,7 @@ describe.skip("geo-location", function () {
 
   it('should set geo location @skip-ci', async function () {
     let getText = async () => {
-      let els = await driver.findElOrEls('class name', 'android.widget.TextView', true);
+      let els = await driver.findElements('class name', 'android.widget.TextView');
       return await driver.getText(els[1].ELEMENT);
     };
 

--- a/test/functional/commands/keyboard/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard/keyboard-e2e-specs.js
@@ -36,7 +36,7 @@ function deSamsungify (text) {
 
 async function getElement (driver, className) {
   return await retryInterval(10, 1000, async () => {
-    let el = _.last(await driver.findElOrEls('class name', className, true));
+    let el = _.last(await driver.findElements('class name', className));
     return el.ELEMENT;
   });
 }
@@ -168,13 +168,13 @@ describe('keyboard', function () {
       }
 
       it('should be able to clear a password field', async function () {
-        let els = await driver.findElOrEls('class name', EDITTEXT_CLASS, true);
+        let els = await driver.findElements('class name', EDITTEXT_CLASS);
         let el = els[1].ELEMENT;
 
         await driver.setValue('super-duper password', el);
 
         // the text is printed into a text field, so we can retrieve and assert
-        let textEl = await driver.findElOrEls('id', 'edit1Text', false);
+        let textEl = await driver.findElement('id', 'edit1Text');
         let text = await driver.getText(textEl.ELEMENT);
         text.should.eql('super-duper password');
 

--- a/test/functional/commands/notifications-e2e-specs.js
+++ b/test/functional/commands/notifications-e2e-specs.js
@@ -34,7 +34,7 @@ describe('apidemo - notifications', function () {
   });
 
   it('should open the notification shade @skip-ci', async function () {
-    let el = await driver.findElOrEls('accessibility id', ':-|', false);
+    let el = await driver.findElement('accessibility id', ':-|');
     await driver.click(el.ELEMENT);
 
     // give the app a second to catch up before opening notifications
@@ -42,7 +42,7 @@ describe('apidemo - notifications', function () {
     await driver.openNotifications();
 
     await retry(4, async () => {
-      let textViews = await driver.findElOrEls('class name', 'android.widget.TextView', true);
+      let textViews = await driver.findElements('class name', 'android.widget.TextView');
       let text = [];
       for (let view of textViews) {
         text.push(await driver.getText(view.ELEMENT));

--- a/test/functional/commands/recordscreen-e2e-specs.js
+++ b/test/functional/commands/recordscreen-e2e-specs.js
@@ -32,7 +32,7 @@ describe('recording the screen', function () {
     await driver.startRecordingScreen();
 
     // do some interacting, to take some time
-    let el = await driver.findElOrEls('class name', 'android.widget.EditText', false);
+    let el = await driver.findElement('class name', 'android.widget.EditText');
     el = el.ELEMENT;
     await driver.setValue('Recording the screen!', el);
     let text = await driver.getText(el);

--- a/test/functional/commands/touch/drag-e2e-specs.js
+++ b/test/functional/commands/touch/drag-e2e-specs.js
@@ -29,26 +29,26 @@ describe('apidemo - touch', function () {
   });
   describe('drag', function () {
     it('should drag by element', async function () {
-      let dot3 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_3', false);
-      let dot2 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_2', false);
+      let dot3 = await driver.findElement('id', 'io.appium.android.apis:id/drag_dot_3');
+      let dot2 = await driver.findElement('id', 'io.appium.android.apis:id/drag_dot_2');
       let gestures = [
         {options: {element: dot3.ELEMENT}},
         {options: {element: dot2.ELEMENT}}
       ];
       await driver.doTouchDrag(gestures);
 
-      let results = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_result_text', false);
+      let results = await driver.findElement('id', 'io.appium.android.apis:id/drag_result_text');
       await driver.getText(results.ELEMENT).should.eventually.include('Dropped');
     });
     it('should drag by element with an offset', async function () {
-      let dot3 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_3', false);
-      let dot2 = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_dot_2', false);
+      let dot3 = await driver.findElement('id', 'io.appium.android.apis:id/drag_dot_3');
+      let dot2 = await driver.findElement('id', 'io.appium.android.apis:id/drag_dot_2');
       let gestures = [
         {options: {element: dot3.ELEMENT, x: 5, y: 5}},
         {options: {element: dot2.ELEMENT, x: 5, y: 5}}
       ];
       await driver.doTouchDrag(gestures);
-      let results = await driver.findElOrEls('id', 'io.appium.android.apis:id/drag_result_text', false);
+      let results = await driver.findElement('id', 'io.appium.android.apis:id/drag_result_text');
       await driver.getText(results.ELEMENT).should.eventually.include('Dropped');
     });
   });

--- a/test/functional/commands/touch/multi-action-e2e-specs.js
+++ b/test/functional/commands/touch/multi-action-e2e-specs.js
@@ -22,7 +22,7 @@ describe('apidemo - touch - multi-actions', function () {
     await driver.deleteSession();
   });
   it('should scroll two different lists', async function () {
-    let lists = await driver.findElOrEls('class name', 'android.widget.ListView', true);
+    let lists = await driver.findElements('class name', 'android.widget.ListView');
     let leftList = lists[0].ELEMENT;
     let rightList = lists[1].ELEMENT;
     let leftGestures = [

--- a/test/functional/commands/url-e2e-specs.js
+++ b/test/functional/commands/url-e2e-specs.js
@@ -42,17 +42,17 @@ describe('setUrl', function () {
     if (caps.browserName === 'Chrome') {
       try {
         // on some chrome systems, we always get the terms and conditions page
-        let btn = await driver.findElOrEls('id', 'com.android.chrome:id/terms_accept', false);
+        let btn = await driver.findElement('id', 'com.android.chrome:id/terms_accept');
         await driver.click(btn.ELEMENT);
 
-        btn = await driver.findElOrEls('id', 'com.android.chrome:id/negative_button', false);
+        btn = await driver.findElement('id', 'com.android.chrome:id/negative_button');
         await driver.click(btn.ELEMENT);
       } catch (ign) {}
     }
 
     await driver.setUrl('http://saucelabs.com');
 
-    let el = await driver.findElOrEls('id', urlId, false);
+    let el = await driver.findElement('id', urlId);
     await driver.getText(el.ELEMENT).should.eventually.include('saucelabs.com');
   });
 });

--- a/test/functional/webview-browser-tester-e2e-specs.js
+++ b/test/functional/webview-browser-tester-e2e-specs.js
@@ -58,10 +58,10 @@ describe('Android 7 Webview Browser tester', function () {
     // make sure we are in the right context
     await driver.getCurrentContext().should.eventually.eql("CHROMIUM");
 
-    let el = await driver.findElOrEls('id', 'i am a link', false);
+    let el = await driver.findElement('id', 'i am a link');
     await driver.click(el.ELEMENT);
 
-    el = await driver.findElOrEls('id', 'I am another page title', false);
+    el = await driver.findElement('id', 'I am another page title');
     el.should.exist;
   });
 });


### PR DESCRIPTION
Unit tests should (as they do) test `findElOrEls`, but the rest of the time we ought to use the base driver methods that are actually called by the protocol.

This also relieves us of the need of validating the locators, which is done already (https://github.com/appium/appium-base-driver/blob/master/lib/basedriver/commands/find.js#L19), and leads to weird logs with multiple validation lines.