### PR TITLE
Do not include empty avd args

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -68,7 +68,7 @@ helpers.prepareEmulator = async function (adb, opts) {
 };
 
 helpers.prepareAVDArgs = function (opts, adb, avdArgs) {
-  let args = [];
+  let args = avdArgs ? [avdArgs] : [];
   if (!_.isUndefined(opts.networkSpeed)) {
     let networkSpeed = this.ensureNetworkSpeed(adb, opts.networkSpeed);
     args.push('-netspeed', networkSpeed);
@@ -76,7 +76,7 @@ helpers.prepareAVDArgs = function (opts, adb, avdArgs) {
   if (opts.isHeadless) {
     args.push('-no-window');
   }
-  return args.length ? `${avdArgs} ${args.join(' ')}` : avdArgs;
+  return args.join(' ');
 };
 
 helpers.ensureNetworkSpeed = function (adb, networkSpeed) {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -82,11 +82,26 @@ describe('Android Helpers', function () {
     it('should set the correct avdArgs', async function () {
       let avdArgs = '-wipe-data';
       (helpers.prepareAVDArgs({}, adb, avdArgs)).should.equal(avdArgs);
-      (helpers.prepareAVDArgs({isHeadless: true}, adb, avdArgs)).should.have.string('-no-window');
+    });
+    it('should add headless arg', async function () {
+      let avdArgs = '-wipe-data';
+      let args = helpers.prepareAVDArgs({isHeadless: true}, adb, avdArgs);
+      args.should.have.string('-wipe-data');
+      args.should.have.string('-no-window');
+    });
+    it('should add network speed arg', async function () {
+      let avdArgs = '-wipe-data';
       mocks.helpers.expects('ensureNetworkSpeed').once()
         .returns('edge');
-      (helpers.prepareAVDArgs({networkSpeed: 'edge'}, adb, avdArgs)).should.have.string('-netspeed edge');
+      let args = helpers.prepareAVDArgs({networkSpeed: 'edge'}, adb, avdArgs);
+      args.should.have.string('-wipe-data');
+      args.should.have.string('-netspeed edge');
       mocks.adb.verify();
+    });
+    it('should not include empty avdArgs', async function () {
+      let avdArgs = '';
+      let args = helpers.prepareAVDArgs({isHeadless: true}, adb, avdArgs);
+      args.should.eql('-no-window');
     });
   }));
   describe('ensureNetworkSpeed', function () {


### PR DESCRIPTION
If there are no `avdArgs` then don't include them.

Fixes https://github.com/appium/appium/issues/10177