### PR TITLE
Remove chromedrivers when closing app

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -238,6 +238,7 @@ commands.closeApp = async function () {
   await this.adb.forceStop(this.opts.appPackage);
   // reset context since we don't know what kind on context we will end up after app launch.
   this.curContext = NATIVE_WIN;
+  await this.stopChromedriverProxies();
 };
 
 commands.getDisplayDensity = async function () {


### PR DESCRIPTION
No need to keep them around. And they cause problems such as https://travis-ci.org/appium/appium-uiautomator2-driver/jobs/340963005