### PR TITLE
Fix background when using appWaitPkg/Activity

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -124,11 +124,12 @@ commands.background = async function (seconds) {
   if (this.opts.startActivityArgs && this.opts.startActivityArgs[`${appPackage}/${appActivity}`]) {
     // the activity was started with `startActivity`, so use those args to restart
     args = this.opts.startActivityArgs[`${appPackage}/${appActivity}`];
-  } else if (appPackage === this.opts.appPackage && appActivity === this.opts.appActivity) {
+  } else if (appPackage === this.opts.appPackage && appActivity === this.opts.appActivity ||
+    appPackage === this.opts.appWaitPackage && this.opts.appWaitActivity.split(',').indexOf(appActivity) >= 0) {
     // the activity is the original session activity, so use the original args
     args = {
-      pkg: appPackage,
-      activity: appActivity,
+      pkg: this.opts.appPackage,
+      activity: this.opts.appActivity,
       action: this.opts.intentAction,
       category: this.opts.intentCategory,
       flags: this.opts.intentFlags,
@@ -200,7 +201,7 @@ commands.startActivity = async function (appPackage, appActivity,
     stopApp: !dontStopAppOnReset
   };
   this.opts.startActivityArgs = this.opts.startActivityArgs || {};
-  this.opts.startActivityArgs[`${appPackage}/${appActivity}`] = args;
+  this.opts.startActivityArgs[`${args.waitPkg}/${args.waitActivity}`] = args;
   await this.adb.startApp(args);
 };
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -124,8 +124,10 @@ commands.background = async function (seconds) {
   if (this.opts.startActivityArgs && this.opts.startActivityArgs[`${appPackage}/${appActivity}`]) {
     // the activity was started with `startActivity`, so use those args to restart
     args = this.opts.startActivityArgs[`${appPackage}/${appActivity}`];
-  } else if (appPackage === this.opts.appPackage && appActivity === this.opts.appActivity ||
-    appPackage === this.opts.appWaitPackage && this.opts.appWaitActivity.split(',').indexOf(appActivity) >= 0) {
+  } else if ((appPackage === this.opts.appPackage && appActivity === this.opts.appActivity) ||
+    (appPackage === this.opts.appWaitPackage &&
+      this.opts.appWaitActivity &&
+      this.opts.appWaitActivity.split(',').indexOf(appActivity) >= 0)) {
     // the activity is the original session activity, so use the original args
     args = {
       pkg: this.opts.appPackage,

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -126,8 +126,7 @@ commands.background = async function (seconds) {
     args = this.opts.startActivityArgs[`${appPackage}/${appActivity}`];
   } else if ((appPackage === this.opts.appPackage && appActivity === this.opts.appActivity) ||
     (appPackage === this.opts.appWaitPackage &&
-      this.opts.appWaitActivity &&
-      this.opts.appWaitActivity.split(',').indexOf(appActivity) >= 0)) {
+      (this.opts.appWaitActivity || '').split(',').includes(appActivity))) {
     // the activity is the original session activity, so use the original args
     args = {
       pkg: this.opts.appPackage,

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -231,6 +231,31 @@ describe('General', function () {
       B.delay.calledWithExactly(10000).should.be.true;
       driver.adb.startApp.calledWithExactly(params).should.be.true;
     });
+    it('should bring app to background and back if waiting for other pkg / activity', async function () { //eslint-disable-line
+      const appPackage = 'somepkg';
+      const appActivity = 'someacv';
+      const appWaitPackage = 'somewaitpkg';
+      const appWaitActivity = 'somewaitacv';
+      driver.opts = {appPackage, appActivity, appWaitPackage, appWaitActivity,
+                     intentAction: 'act', intentCategory: 'cat',
+                     intentFlags: 'flgs', optionalIntentArguments: 'opt',
+                     stopApp: false};
+      let params = {pkg: appPackage, activity: appActivity,
+                    waitPkg: appWaitPackage, waitActivity: appWaitActivity,
+                    action: 'act', category: 'cat',
+                    flags: 'flgs',
+                    optionalIntentArguments: 'opt', stopApp: false};
+      sandbox.stub(driver.adb, 'goToHome');
+      sandbox.stub(driver.adb, 'getFocusedPackageAndActivity')
+        .returns({appPackage: appWaitPackage, appActivity: appWaitActivity});
+      sandbox.stub(B, 'delay');
+      sandbox.stub(driver.adb, 'startApp');
+      await driver.background(10);
+      driver.adb.getFocusedPackageAndActivity.calledOnce.should.be.true;
+      driver.adb.goToHome.calledOnce.should.be.true;
+      B.delay.calledWithExactly(10000).should.be.true;
+      driver.adb.startApp.calledWithExactly(params).should.be.true;
+    });
     it('should not bring app back if seconds are negative', async function () {
       sandbox.stub(driver.adb, 'goToHome');
       sandbox.stub(driver.adb, 'startApp');


### PR DESCRIPTION
When app is started using an activity but redirects to another one (or
another package) one may use appWaitPackage or appWaitActivity either
as capabilities which will be used during the initial launch, or as parameters
of the startActivity command.

Using the background command in such circumstances would lead to ADB
permission denial error (activity is not exported).

This PR fixes that issue when:
* the activity is the original session activity (launchApp command)
* the app was started using startActivity command