### PR TITLE
Added new Capability

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -154,6 +154,9 @@ let commonCapConstraints = {
   unlockKey: {
     isString: true
   },
+  userProfile: {
+    isNumber: true
+  },
 };
 
 let uiautomatorCapConstraints = {


### PR DESCRIPTION
Hi

I am trying to add new capability(user profile) for Android. This capability is related to the appium [issue](https://github.com/appium/appium/issues/8305). However I need help in below issues:

1. The idea is to make this capability as optional.

2. I have added the new capability 'userProfile'  in "**desired-caps.js**" of _appium-android-driver_ package.
        `userProfile: {
    isNumber: true
  },`

3. If user specifies this capability then this capability value should be added to defaultArgs of executable so that each and every adb command goes with this parameter.

    For eg. `executable.defaultArgs.push("--user", opts.userProfile);`

4. However, I want to make sure that this capability is added only if the the user profile available on the device. We can get the list of available users by using below adb command.
            `adb shell pm list users`

    Once we get the list of users and we can parse the values from output of the above command.

5. If the user profile is not available on the device then we can initialize the device with the traditional way without using this capability.

6. I am little confused about where add the this piece of code to. Whether to add this to "**driver.js**", "**android-helpers.js**" of _appium-android-driver_ package or  add this to "**system-calls.js**" of _appium-adb_ package .

Waiting for suggestions