### PR TITLE
Do not perform fast reset for newly installed apps

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -287,12 +287,15 @@ helpers.installApk = async function (adb, opts = {}) {
     return;
   }
 
+  // There is no need to reset the newly installed app
+  const shouldPerformFastReset = fastReset && await adb.isAppInstalled(appPackage);
+
   await adb.installOrUpgrade(app, appPackage, {
     grantPermissions: autoGrantPermissions,
     timeout: androidInstallTimeout
   });
 
-  if (fastReset) {
+  if (shouldPerformFastReset) {
     logger.info(`Performing fast reset on '${appPackage}'`);
     await this.resetApp(adb, opts);
   }

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -362,6 +362,7 @@ describe('Android Helpers', function () {
               .should.eventually.be.rejectedWith(/appPackage/);
     });
     it('should install/upgrade and reset app if fast reset is set to true', async function () {
+      mocks.adb.expects('isAppInstalled').once().returns(true);
       mocks.adb.expects('installOrUpgrade').once().withArgs(opts.app, opts.appPackage);
       mocks.helpers.expects('resetApp').once().withArgs(adb);
       await helpers.installApk(adb, Object.assign({}, opts, {fastReset: true}));
@@ -379,6 +380,14 @@ describe('Android Helpers', function () {
       mocks.adb.expects('installOrUpgrade').once().withArgs(opts.app, opts.appPackage);
       mocks.helpers.expects('resetApp').never();
       await helpers.installApk(adb, opts);
+      mocks.adb.verify();
+      mocks.helpers.verify();
+    });
+    it('should install/upgrade and skip fast reseting the app if this was the fresh install', async function () {
+      mocks.adb.expects('isAppInstalled').once().returns(false);
+      mocks.adb.expects('installOrUpgrade').once().withArgs(opts.app, opts.appPackage);
+      mocks.helpers.expects('resetApp').never();
+      await helpers.installApk(adb, Object.assign({}, opts, {fastReset: true}));
       mocks.adb.verify();
       mocks.helpers.verify();
     });


### PR DESCRIPTION
Setting app permissions is quite costly operation and since these are already set in `installOrUpgrade` method then there is no need to do it again for newly installed apps.