### PR TITLE
Tune log entry format for bugreport output

### DIFF
--- a/lib/commands/log.js
+++ b/lib/commands/log.js
@@ -5,6 +5,15 @@ import _ from 'lodash';
 
 let commands = {}, helpers = {}, extensions = {};
 
+// https://github.com/SeleniumHQ/selenium/blob/0d425676b3c9df261dd641917f867d4d5ce7774d/java/client/src/org/openqa/selenium/logging/LogEntry.java
+function toLogRecord (timestamp, level, message) {
+  return {
+    timestamp,
+    level,
+    message,
+  };
+}
+
 extensions.supportedLogTypes = {
   logcat: {
     description: 'Logs for Android applications on real device and emulators via ADB',
@@ -12,7 +21,12 @@ extensions.supportedLogTypes = {
   },
   bugreport: {
     description: `'adb bugreport' output for advanced issues diagnostic`,
-    getter: async (self) => (await self.adb.bugreport()).split(os.EOL),
+    getter: async (self) => {
+      const output = await self.adb.bugreport();
+      const timestamp = Date.now();
+      return output.split(os.EOL)
+        .map((x) => toLogRecord(timestamp, 'ALL', x));
+    },
   },
   server: {
     description: 'Appium server logs',
@@ -21,15 +35,12 @@ extensions.supportedLogTypes = {
         throw new Error('Appium server must have relaxed security flag set ' +
                         'in order to be able to get server logs');
       }
+      const timestamp = Date.now();
       return log.unwrap().record
-        .map((x) => {
-          return {
-            // npmlog does not keep timestamps in the history
-            timestamp: Date.now(),
-            level: 'ALL',
-            message: _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`,
-          };
-        });
+        .map((x) => toLogRecord(timestamp,
+                                'ALL',
+                                _.isEmpty(x.prefix) ? x.message : `[${x.prefix}] ${x.message}`)
+        );
     },
   },
 };

--- a/test/unit/commands/log-specs.js
+++ b/test/unit/commands/log-specs.js
@@ -38,7 +38,9 @@ describe('commands - logging', function () {
     });
     it('should get bugreport logs', async function () {
       sinon.stub(driver.adb, 'bugreport').returns(`line1${os.EOL}line2`);
-      (await driver.getLog('bugreport')).should.be.deep.equal(['line1', 'line2']);
+      const [record1, record2] = await driver.getLog('bugreport');
+      record1.message.should.eql('line1');
+      record2.message.should.eql('line2');
       driver.adb.bugreport.called.should.be.true;
       driver.adb.bugreport.restore();
     });


### PR DESCRIPTION
Selenium client does not like log items, which are not compatible to LogRecord class