### PR TITLE
Make it possible to record screen on Android P emulators

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -16,6 +16,8 @@ const DEFAULT_RECORDING_TIME_SEC = MAX_RECORDING_TIME_SEC;
 const PROCESS_SHUTDOWN_TIMEOUT_SEC = 5;
 const SCREENRECORD_BINARY = 'screenrecord';
 const DEFAULT_EXT = '.mp4';
+const MIN_EMULATOR_API_LEVEL = 27;
+
 
 async function extractCurrentRecordingPath (adb, pids) {
   let lsofOutput = '';
@@ -138,7 +140,8 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
  */
 
 /**
- * Record the display of devices running Android 4.4 (API level 19) and higher.
+ * Record the display of a real devices running Android 4.4 (API level 19) and higher.
+ * Emulators are supported since API level 27 (Android P).
  * It records screen activity to an MPEG-4 file. Audio is not recorded with the video file.
  * If screen recording has been already started then the command will stop it forcefully and start a new one.
  * The previously recorded video file will be deleted.
@@ -146,16 +149,15 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
  * @param {?StartRecordingOptions} options - The available options.
  * @returns {string} Base64-encoded content of the recorded media file if
  *                   any screen recording is currently running or an empty string.
- * @throws {Error} If screen recording has failed to start.
+ * @throws {Error} If screen recording has failed to start or is not supported on the device under test.
  */
 commands.startRecordingScreen = async function (options = {}) {
   const {videoSize, timeLimit=DEFAULT_RECORDING_TIME_SEC, bitRate, forceRestart} = options;
-  if (this.isEmulator()) {
-    throw new Error('Screen recording does not work on emulators');
-  }
 
-  // this function is suppported on the device running android 4.4(api level 19)
   const apiLevel = await this.adb.getApiLevel();
+  if (this.isEmulator() && apiLevel < MIN_EMULATOR_API_LEVEL) {
+    throw new Error(`Screen recording does not work on emulators running Android API level less than ${MIN_EMULATOR_API_LEVEL}`);
+  }
   if (apiLevel < 19) {
     throw new Error(`Screen recording not available on API Level ${apiLevel}. Minimum API Level is 19.`);
   }
@@ -263,10 +265,17 @@ commands.startRecordingScreen = async function (options = {}) {
  * @returns {string} Base64-encoded content of the recorded media file if 'remotePath'
  *                   parameter is empty or null or an empty string.
  * @throws {Error} If there was an error while getting the name of a media file
- *                 or the file content cannot be uploaded to the remote location.
+ *                 or the file content cannot be uploaded to the remote location
+ *                 or screen recording is not supported on the device under test.
  */
 commands.stopRecordingScreen = async function (options = {}) {
   const {remotePath, user, pass, method} = options;
+
+  const apiLevel = await this.adb.getApiLevel();
+  if (this.isEmulator() && apiLevel < MIN_EMULATOR_API_LEVEL) {
+    throw new Error(`Screen recording does not work on emulators running at Android API level ${apiLevel}, ` +
+                    `which is less than ${MIN_EMULATOR_API_LEVEL}`);
+  }
 
   const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY)).map((p) => `${p}`);
   let pathOnDevice = this._recentScreenRecordingPath;

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -110,15 +110,14 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
   }
 }
 
-async function verifyApiLevel () {
-  const apiLevel = await this.adb.getApiLevel();
-  if (this.isEmulator() && apiLevel < MIN_EMULATOR_API_LEVEL) {
+async function verifyScreenRecordIsSupported (adb, isEmulator) {
+  const apiLevel = await adb.getApiLevel();
+  if (isEmulator && apiLevel < MIN_EMULATOR_API_LEVEL) {
     throw new Error(`Screen recording does not work on emulators running Android API level less than ${MIN_EMULATOR_API_LEVEL}`);
   }
   if (apiLevel < 19) {
     throw new Error(`Screen recording not available on API Level ${apiLevel}. Minimum API Level is 19.`);
   }
-  return apiLevel;
 }
 
 
@@ -169,7 +168,7 @@ async function verifyApiLevel () {
 commands.startRecordingScreen = async function (options = {}) {
   const {videoSize, timeLimit=DEFAULT_RECORDING_TIME_SEC, bugReport, bitRate, forceRestart} = options;
 
-  await verifyApiLevel();
+  await verifyScreenRecordIsSupported(this.adb, this.isEmulator());
 
   let result = '';
   if (!forceRestart) {
@@ -283,7 +282,7 @@ commands.startRecordingScreen = async function (options = {}) {
 commands.stopRecordingScreen = async function (options = {}) {
   const {remotePath, user, pass, method} = options;
 
-  await verifyApiLevel();
+  await verifyScreenRecordIsSupported(this.adb, this.isEmulator());
 
   const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY)).map((p) => `${p}`);
   let pathOnDevice = this._recentScreenRecordingPath;

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -130,6 +130,9 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
  *                  1280x720 if not. For best results,
  *                  use a size supported by your device's Advanced Video Coding (AVC) encoder.
  *                  For example, "1280x720"
+ * @property {?boolean} bugReport - Set it to `true` in order to display additional information on the video overlay,
+ *                                  such as a timestamp, that is helpful in videos captured to illustrate bugs.
+ *                                  This option is only supported since API level 27 (Android P).
  * @property {?string|number} timeLimit - The maximum recording time, in seconds. The default and maximum value is 180 (3 minutes).
  * @property {?string|number} bitRate - The video bit rate for the video, in megabits per second.
  *                The default value is 4. You can increase the bit rate to improve video quality,
@@ -152,7 +155,7 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
  * @throws {Error} If screen recording has failed to start or is not supported on the device under test.
  */
 commands.startRecordingScreen = async function (options = {}) {
-  const {videoSize, timeLimit=DEFAULT_RECORDING_TIME_SEC, bitRate, forceRestart} = options;
+  const {videoSize, timeLimit=DEFAULT_RECORDING_TIME_SEC, bugReport, bitRate, forceRestart} = options;
 
   const apiLevel = await this.adb.getApiLevel();
   if (this.isEmulator() && apiLevel < MIN_EMULATOR_API_LEVEL) {
@@ -193,6 +196,9 @@ commands.startRecordingScreen = async function (options = {}) {
   }
   if (util.hasValue(bitRate)) {
     cmd.push('--bit-rate', `${bitRate}`);
+  }
+  if (bugReport) {
+    cmd.push('--bugreport');
   }
   cmd.push(pathOnDevice);
 

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -110,6 +110,18 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
   }
 }
 
+async function verifyApiLevel () {
+  const apiLevel = await this.adb.getApiLevel();
+  if (this.isEmulator() && apiLevel < MIN_EMULATOR_API_LEVEL) {
+    throw new Error(`Screen recording does not work on emulators running Android API level less than ${MIN_EMULATOR_API_LEVEL}`);
+  }
+  if (apiLevel < 19) {
+    throw new Error(`Screen recording not available on API Level ${apiLevel}. Minimum API Level is 19.`);
+  }
+  return apiLevel;
+}
+
+
 /**
  * @typedef {Object} StartRecordingOptions
  *
@@ -157,13 +169,7 @@ async function uploadRecordedMedia (adb, pathOnDevice, remotePath = null, upload
 commands.startRecordingScreen = async function (options = {}) {
   const {videoSize, timeLimit=DEFAULT_RECORDING_TIME_SEC, bugReport, bitRate, forceRestart} = options;
 
-  const apiLevel = await this.adb.getApiLevel();
-  if (this.isEmulator() && apiLevel < MIN_EMULATOR_API_LEVEL) {
-    throw new Error(`Screen recording does not work on emulators running Android API level less than ${MIN_EMULATOR_API_LEVEL}`);
-  }
-  if (apiLevel < 19) {
-    throw new Error(`Screen recording not available on API Level ${apiLevel}. Minimum API Level is 19.`);
-  }
+  await verifyApiLevel();
 
   let result = '';
   if (!forceRestart) {
@@ -277,11 +283,7 @@ commands.startRecordingScreen = async function (options = {}) {
 commands.stopRecordingScreen = async function (options = {}) {
   const {remotePath, user, pass, method} = options;
 
-  const apiLevel = await this.adb.getApiLevel();
-  if (this.isEmulator() && apiLevel < MIN_EMULATOR_API_LEVEL) {
-    throw new Error(`Screen recording does not work on emulators running at Android API level ${apiLevel}, ` +
-                    `which is less than ${MIN_EMULATOR_API_LEVEL}`);
-  }
+  await verifyApiLevel();
 
   const pids = (await this.adb.getPIDsByName(SCREENRECORD_BINARY)).map((p) => `${p}`);
   let pathOnDevice = this._recentScreenRecordingPath;

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -39,8 +39,8 @@ describe('recording the screen', function () {
     describe('beginning the recording', function () {
       beforeEach(function () {
         driver._recentScreenRecordingPath = null;
-        mocks.driver.expects('isEmulator').returns(false);
-        mocks.adb.expects('getApiLevel').returns(19);
+        mocks.driver.expects('isEmulator').atLeast(1).returns(false);
+        mocks.adb.expects('getApiLevel').atLeast(1).returns(19);
         mocks.adb.expects('getPIDsByName')
           .atLeast(1).withExactArgs('screenrecord').returns([]);
       });

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -22,8 +22,9 @@ describe('recording the screen', function () {
     const localFile = '/path/to/local.mp4';
     const mediaContent = new Buffer('appium');
 
-    it('should fail to recording the screen on an emulator', async function () {
+    it('should fail to recording the screen on an older emulator', async function () {
       mocks.driver.expects('isEmulator').returns(true);
+      mocks.adb.expects('getApiLevel').returns(26);
 
       await driver.startRecordingScreen().should.eventually.be.rejectedWith(/Screen recording does not work on emulators/);
     });

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -121,6 +121,10 @@ describe('recording the screen', function () {
     });
 
     describe('stopRecordingScreen', function () {
+      beforeEach(function () {
+        mocks.driver.expects('isEmulator').atLeast(1).returns(false);
+        mocks.adb.expects('getApiLevel').atLeast(1).returns(19);
+      });
       afterEach(function () {
         mocks.driver.verify();
         mocks.adb.verify();


### PR DESCRIPTION
It looks like Google has finally fixed compatibility issues since Android P and from now on one can record screen on emulator the same way he does it on real devices.