### PR TITLE
Replace `kill -0` with `ps`

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -42,14 +42,23 @@ async function finishScreenCapture (adb, pids) {
     return true;
   }
   try {
+    // Wait until the process is terminated
     await waitForCondition(async () => {
       try {
-        await adb.shell(['kill', '-0', ...pids]);
-      } catch (ign) {
+        const output = await adb.shell(['ps']);
+        for (const line of output.split('\n')) {
+          for (const pid of pids) {
+            if (new RegExp(`\\b${pid}\\b`).test(line) && new RegExp(`\\b${SCREENRECORD_BINARY}\\b`).test(line)) {
+              return false;
+            }
+          }
+        }
         return true;
+      } catch (err) {
+        log.warn(err.message);
+        return false;
       }
-      return false;
-    }, {waitMs: PROCESS_SHUTDOWN_TIMEOUT_SEC * 1000, intervalMs: 300});
+    }, {waitMs: PROCESS_SHUTDOWN_TIMEOUT_SEC * 1000, intervalMs: 500});
   } catch (e) {
     return false;
   }

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -46,11 +46,9 @@ async function finishScreenCapture (adb, pids) {
     await waitForCondition(async () => {
       try {
         const output = await adb.shell(['ps']);
-        for (const line of output.split('\n')) {
-          for (const pid of pids) {
-            if (new RegExp(`\\b${pid}\\b`).test(line) && new RegExp(`\\b${SCREENRECORD_BINARY}\\b`).test(line)) {
-              return false;
-            }
+        for (const pid of pids) {
+          if (new RegExp(`\\b${pid}\\b[^\\n]+\\b${SCREENRECORD_BINARY}$`, 'm').test(output)) {
+            return false;
           }
         }
         return true;

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -121,6 +121,21 @@ describe('recording the screen', function () {
     });
 
     describe('stopRecordingScreen', function () {
+      const psOutput = `
+      USER           PID  PPID     VSZ    RSS WCHAN            ADDR S NAME
+      root          8384     2       0      0 worker_thread       0 S [kworker/0:1]
+      u0_a43        8400  1510 1449772  90992 ep_poll             0 S com.google.android.apps.messaging:rcs
+      root          8423     2       0      0 worker_thread       0 S [kworker/u4:2]
+      u0_a43        8435  1510 1452544  93576 ep_poll             0 S com.google.android.apps.messaging
+      u0_a7         8471  1510 1427536  79804 ep_poll             0 S android.process.acore
+      root          8669     2       0      0 worker_thread       0 S [kworker/u5:1]
+      u0_a35        8805  1510 1426428  61540 ep_poll             0 S com.google.android.apps.wallpaper
+      u0_a10        8864  1510 1427412  69752 ep_poll             0 S android.process.media
+      root          8879     2       0      0 worker_thread       0 S [kworker/1:1]
+      u0_a60        8897  1510 1490420 108852 ep_poll             0 S com.google.android.apps.photos
+      shell         9136  1422    7808   2784 0            ebddfaf0 R ps
+      `;
+
       beforeEach(function () {
         mocks.driver.expects('isEmulator').atLeast(1).returns(false);
         mocks.adb.expects('getApiLevel').atLeast(1).returns(19);
@@ -152,7 +167,7 @@ describe('recording the screen', function () {
           screenrec 11328      shell    9u      REG               0,19     11521     294673 ${remotePath}
         `});
         mocks.adb.expects('shell').withExactArgs(['kill', '-2', ...pids]);
-        mocks.adb.expects('shell').withExactArgs(['kill', '-0', ...pids]).throws();
+        mocks.adb.expects('shell').withExactArgs(['ps']).returns(psOutput);
         mocks.adb.expects('pull').once().withExactArgs(remotePath, localFile);
         mocks.fs.expects('readFile').once().withExactArgs(localFile).returns(mediaContent);
         mocks.adb.expects('rimraf').once().withExactArgs(remotePath);
@@ -169,7 +184,7 @@ describe('recording the screen', function () {
         mocks.adb.expects('getPIDsByName').withExactArgs('screenrecord')
           .atLeast(1).returns(pids);
         mocks.adb.expects('shell').withExactArgs(['kill', '-2', ...pids]);
-        mocks.adb.expects('shell').withExactArgs(['kill', '-0', ...pids]).throws();
+        mocks.adb.expects('shell').withExactArgs(['ps']).returns(psOutput);
         mocks.adb.expects('pull').once().withExactArgs(driver._recentScreenRecordingPath, localFile);
         mocks.fs.expects('readFile').once().withExactArgs(localFile).returns(mediaContent);
         mocks.adb.expects('rimraf').once().withExactArgs(driver._recentScreenRecordingPath);
@@ -186,7 +201,7 @@ describe('recording the screen', function () {
         mocks.adb.expects('getPIDsByName').withExactArgs('screenrecord')
           .atLeast(1).returns(pids);
         mocks.adb.expects('shell').withExactArgs(['kill', '-2', ...pids]);
-        mocks.adb.expects('shell').withExactArgs(['kill', '-0', ...pids]).throws();
+        mocks.adb.expects('shell').withExactArgs(['ps']).returns(psOutput);
         mocks.adb.expects('pull').once().withExactArgs(driver._recentScreenRecordingPath, localFile);
         mocks.adb.expects('rimraf').once().withExactArgs(driver._recentScreenRecordingPath);
         mocks.fs.expects('rimraf').withExactArgs(localFile).once();


### PR DESCRIPTION
It looks like this way of terminated process detection is more precise on Android.