### PR TITLE
 Send mapping and location of cds to appium-chromedriver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ build
 .idea/
 *.iml
 coverage
-package-lock.json
+package-lock.json*

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -266,31 +266,30 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
     opts.chromeDriverPort = await getPort();
     log.debug(`A port was not given, using random port: ${opts.chromeDriverPort}`);
   }
-  const chromeArgs = {
+
+  const chromedriver = new Chromedriver({
     port: opts.chromeDriverPort,
     executable: opts.chromedriverExecutable,
     adb,
     verbose: !!opts.showChromedriverLog,
     executableDir: opts.chromedriverExecutableDir,
     mappingPath: opts.chromedriverChromeMappingFile,
-  };
-  let chromedriver = new Chromedriver(chromeArgs);
+  });
 
   // make sure there are chromeOptions
   opts.chromeOptions = opts.chromeOptions || {};
   // try out any prefixed chromeOptions,
   // and strip the prefix
-  for (let opt of _.keys(opts)) {
+  for (const opt of _.keys(opts)) {
     if (opt.endsWith(':chromeOptions')) {
       log.warn(`Merging '${opt}' into 'chromeOptions'. This may cause unexpected behavior`);
       _.merge(opts.chromeOptions, opts[opt]);
     }
   }
 
-  let appPackage = opts.chromeOptions.androidPackage || opts.appPackage;
   let caps = {
     chromeOptions: {
-      androidPackage: appPackage,
+      androidPackage: opts.chromeOptions.androidPackage || opts.appPackage,
     }
   };
   if (opts.chromeUseRunningApp) {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -262,15 +262,17 @@ async function setupExistingChromedriver (chromedriver) {
 helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDeviceId, adb) {
   // if a port wasn't given, pick a random available one
   if (!opts.chromeDriverPort) {
-    let getPort = B.promisify(PortFinder.getPort, {context: PortFinder});
+    const getPort = B.promisify(PortFinder.getPort, {context: PortFinder});
     opts.chromeDriverPort = await getPort();
     log.debug(`A port was not given, using random port: ${opts.chromeDriverPort}`);
   }
-  let chromeArgs = {
+  const chromeArgs = {
     port: opts.chromeDriverPort,
     executable: opts.chromedriverExecutable,
     adb,
     verbose: !!opts.showChromedriverLog,
+    executableDir: opts.chromedriverExecutableDir,
+    mappingPath: opts.chromedriverChromeMappingFile,
   };
   let chromedriver = new Chromedriver(chromeArgs);
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -76,6 +76,12 @@ let commonCapConstraints = {
   chromedriverExecutable: {
     isString: true
   },
+  chromedriverExecutableDir: {
+    isString: true
+  },
+  chromedriverChromeMappingFile: {
+    isString: true
+  },
   autoWebviewTimeout: {
     isNumber: true
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "appium-android-bootstrap": "^2.7.5",
     "appium-android-ime": "^2.0.0",
     "appium-base-driver": "^2.26.0",
-    "appium-chromedriver": "^3.0.0",
+    "appium-chromedriver": "^3.5.0",
     "appium-support": "^2.13.0",
     "appium-unlock": "^2.0.0",
     "asyncbox": "^2.0.4",


### PR DESCRIPTION
`appium-chromedriver` can now take a directory in which CD executables are located, and a mapping file to get the correct Chrome version for a particular CD. Pass those in, from two new desired capabilities:
* `chromedriverExecutableDir` - the full path to a directory in which Chromedriver executables can be found
* `chromedriverChromeMappingFile` - the full path to a file with a JSON structure inside, mapping versions of Chromedriver to minimum versions of Chrome.