### PR TITLE
Do not try to change connection state if it is already in correct state

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -40,11 +40,11 @@ commands.setNetworkConnection = async function (type) {
   const shouldEnableDataConnection = (type & DATA_MASK) !== 0;
 
   const currentState = await this.getNetworkConnection();
-  const isArirplaneModeEnabled = (currentState & AIRPLANE_MODE_MASK) !== 0;
+  const isAirplaneModeEnabled = (currentState & AIRPLANE_MODE_MASK) !== 0;
   const isWiFiEnabled = (currentState & WIFI_MASK) !== 0;
   const isDataEnabled = (currentState & DATA_MASK) !== 0;
 
-  if (shouldEnableAirplaneMode !== isArirplaneModeEnabled) {
+  if (shouldEnableAirplaneMode !== isAirplaneModeEnabled) {
     await this.wrapBootstrapDisconnect(async () => {
       await this.adb.setAirplaneMode(shouldEnableAirplaneMode);
     });
@@ -55,8 +55,8 @@ commands.setNetworkConnection = async function (type) {
     log.info('Not changing airplane mode, since it already has the correct state');
   }
 
-  if (shouldEnableAirplaneMode) {
-    log.info('Not changing data connection and Wi-Fi states, because airplane mode is enabled');
+  if (shouldEnableAirplaneMode && shouldEnableWifi === isWiFiEnabled) {
+    log.info('Not changing data connection, because airplane mode is enabled');
     return;
   }
   if (shouldEnableWifi === isWiFiEnabled && shouldEnableDataConnection === isDataEnabled) {

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -52,7 +52,7 @@ commands.setNetworkConnection = async function (type) {
       await this.adb.broadcastAirplaneMode(shouldEnableAirplaneMode);
     });
   } else {
-    log.info(`Not changing airplane mode, since it already ` +
+    log.info(`Not changing airplane mode, since it is already ` +
              `${shouldEnableAirplaneMode ? 'enabled' : 'disabled'}`);
   }
 

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -207,6 +207,10 @@ helpers.doKey = async function (key) {
 };
 
 helpers.wrapBootstrapDisconnect = async function (wrapped) {
+  if (!this.bootstrap) {
+    return await wrapped();
+  }
+
   this.bootstrap.ignoreUnexpectedShutdown = true;
   try {
     await wrapped();

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -5,17 +5,21 @@ import B from 'bluebird';
 
 let commands = {}, helpers = {}, extensions = {};
 
+const AIRPLANE_MODE_MASK = 0b001;
+const WIFI_MASK = 0b010;
+const DATA_MASK = 0b100;
+
 commands.getNetworkConnection = async function () {
   log.info("Getting network connection");
   let airplaneModeOn = await this.adb.isAirplaneModeOn();
-  let connection = airplaneModeOn ? 1 : 0;
+  let connection = airplaneModeOn ? AIRPLANE_MODE_MASK : 0;
 
   // no need to check anything else if we are in airplane mode
   if (!airplaneModeOn) {
     let wifiOn = await this.isWifiOn();
-    connection += (wifiOn ? 2 : 0);
+    connection |= (wifiOn ? WIFI_MASK : 0);
     let dataOn = await this.adb.isDataOn();
-    connection += (dataOn ? 4 : 0);
+    connection |= (dataOn ? DATA_MASK : 0);
   }
 
   return connection;
@@ -31,24 +35,47 @@ commands.isWifiOn = async function () {
 commands.setNetworkConnection = async function (type) {
   log.info("Setting network connection");
   // decode the input
-  let airplaneMode = type % 2;
-  type >>= 1;
-  let wifi = type % 2;
-  type >>= 1;
-  let data = type % 2;
+  const shouldEnableAirplaneMode = (type & AIRPLANE_MODE_MASK) !== 0;
+  const shouldEnableWifi = (type & WIFI_MASK) !== 0;
+  const shouldEnableDataConnection = (type & DATA_MASK) !== 0;
+
+  const currentState = await this.getNetworkConnection();
+  const isArirplaneModeEnabled = (currentState & AIRPLANE_MODE_MASK) !== 0;
+  const isWiFiEnabled = (currentState & WIFI_MASK) !== 0;
+  const isDataEnabled = (currentState & DATA_MASK) !== 0;
+
+  if (shouldEnableAirplaneMode !== isArirplaneModeEnabled) {
+    await this.wrapBootstrapDisconnect(async () => {
+      await this.adb.setAirplaneMode(shouldEnableAirplaneMode);
+    });
+    await this.wrapBootstrapDisconnect(async () => {
+      await this.adb.broadcastAirplaneMode(shouldEnableAirplaneMode);
+    });
+  } else {
+    log.info('Not changing airplane mode, since it already has the correct state');
+  }
+
+  if (shouldEnableAirplaneMode) {
+    log.info('Not changing data connection and Wi-Fi states, because airplane mode is enabled');
+    return;
+  }
+  if (shouldEnableWifi === isWiFiEnabled && shouldEnableDataConnection === isDataEnabled) {
+    log.info('Not changing data connection/Wi-Fi states, since they are already set to expected values');
+    return;
+  }
 
   await this.wrapBootstrapDisconnect(async () => {
-    await this.adb.setAirplaneMode(airplaneMode);
+    if (shouldEnableWifi !== isWiFiEnabled) {
+      await this.setWifiState(shouldEnableWifi);
+    } else {
+      log.info('Not changing Wi-Fi state, since it is already set to the expected value');
+    }
+    if (shouldEnableDataConnection !== isDataEnabled) {
+      await this.adb.setDataState(shouldEnableDataConnection, this.isEmulator());
+    } else {
+      log.info('Not changing data connection state, since it is already set to the expected value');
+    }
   });
-  await this.wrapBootstrapDisconnect(async () => {
-    await this.adb.broadcastAirplaneMode(airplaneMode);
-  });
-  if (!airplaneMode) {
-    await this.wrapBootstrapDisconnect(async () => {
-      await this.setWifiState(wifi);
-      await this.adb.setDataState(data, this.isEmulator());
-    });
-  }
 
   return await this.getNetworkConnection();
 };

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -52,7 +52,8 @@ commands.setNetworkConnection = async function (type) {
       await this.adb.broadcastAirplaneMode(shouldEnableAirplaneMode);
     });
   } else {
-    log.info('Not changing airplane mode, since it already has the correct state');
+    log.info(`Not changing airplane mode, since it already ` +
+             `${shouldEnableAirplaneMode ? 'enabled' : 'disabled'}`);
   }
 
   if (shouldEnableAirplaneMode && shouldEnableWifi === isWiFiEnabled) {
@@ -68,12 +69,14 @@ commands.setNetworkConnection = async function (type) {
     if (shouldEnableWifi !== isWiFiEnabled) {
       await this.setWifiState(shouldEnableWifi);
     } else {
-      log.info('Not changing Wi-Fi state, since it is already set to the expected value');
+      log.info(`Not changing Wi-Fi state, since it is already ` +
+               `${shouldEnableWifi ? 'enabled' : 'disabled'}`);
     }
     if (shouldEnableDataConnection !== isDataEnabled) {
       await this.adb.setDataState(shouldEnableDataConnection, this.isEmulator());
     } else {
-      log.info('Not changing data connection state, since it is already set to the expected value');
+      log.info(`Not changing data connection state, since it is already ` +
+               `${shouldEnableDataConnection ? 'enabled' : 'disabled'}`);
     }
   });
 

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -56,10 +56,6 @@ commands.setNetworkConnection = async function (type) {
              `${shouldEnableAirplaneMode ? 'enabled' : 'disabled'}`);
   }
 
-  if (shouldEnableAirplaneMode && shouldEnableWifi === isWiFiEnabled) {
-    log.info('Not changing data connection, because airplane mode is enabled');
-    return;
-  }
   if (shouldEnableWifi === isWiFiEnabled && shouldEnableDataConnection === isDataEnabled) {
     log.info('Not changing data connection/Wi-Fi states, since they are already set to expected values');
     return;
@@ -72,11 +68,14 @@ commands.setNetworkConnection = async function (type) {
       log.info(`Not changing Wi-Fi state, since it is already ` +
                `${shouldEnableWifi ? 'enabled' : 'disabled'}`);
     }
-    if (shouldEnableDataConnection !== isDataEnabled) {
-      await this.adb.setDataState(shouldEnableDataConnection, this.isEmulator());
-    } else {
+
+    if (shouldEnableAirplaneMode) {
+      log.info('Not changing data connection state, because airplane mode is enabled');
+    } else if (shouldEnableDataConnection === isDataEnabled) {
       log.info(`Not changing data connection state, since it is already ` +
                `${shouldEnableDataConnection ? 'enabled' : 'disabled'}`);
+    } else {
+      await this.adb.setDataState(shouldEnableDataConnection, this.isEmulator());
     }
   });
 

--- a/test/unit/commands/network-specs.js
+++ b/test/unit/commands/network-specs.js
@@ -61,44 +61,48 @@ describe('Network', function () {
   });
   describe('setNetworkConnection', function () {
     beforeEach(async function () {
-      sandbox.stub(driver, 'getNetworkConnection').returns('res');
       sandbox.stub(driver, 'setWifiState');
       driver.isEmulator.returns(false);
     });
     it('should turn off wifi and data', async function () {
-      await driver.setNetworkConnection(0).should.become('res');
-      adb.setAirplaneMode.calledWithExactly(0).should.be.true;
-      adb.broadcastAirplaneMode.calledWithExactly(0).should.be.true;
-      driver.setWifiState.calledWithExactly(0).should.be.true;
-      adb.setDataState.calledWithExactly(0, false).should.be.true;
+      sandbox.stub(driver, 'getNetworkConnection').returns(6);
+      await driver.setNetworkConnection(0);
+      adb.setAirplaneMode.called.should.be.false;
+      adb.broadcastAirplaneMode.called.should.be.false;
+      driver.setWifiState.calledWithExactly(false).should.be.true;
+      adb.setDataState.calledWithExactly(false, false).should.be.true;
     });
     it('should turn on and broadcast airplane mode', async function () {
+      sandbox.stub(driver, 'getNetworkConnection').returns(0);
       await driver.setNetworkConnection(1);
-      adb.setAirplaneMode.calledWithExactly(1).should.be.true;
-      adb.broadcastAirplaneMode.calledWithExactly(1).should.be.true;
+      adb.setAirplaneMode.calledWithExactly(true).should.be.true;
+      adb.broadcastAirplaneMode.calledWithExactly(true).should.be.true;
       driver.setWifiState.called.should.be.false;
       adb.setDataState.called.should.be.false;
     });
     it('should turn on wifi', async function () {
+      sandbox.stub(driver, 'getNetworkConnection').returns(0);
       await driver.setNetworkConnection(2);
-      adb.setAirplaneMode.calledWithExactly(0).should.be.true;
-      adb.broadcastAirplaneMode.calledWithExactly(0).should.be.true;
-      driver.setWifiState.calledWithExactly(1).should.be.true;
-      adb.setDataState.calledWithExactly(0, false).should.be.true;
+      adb.setAirplaneMode.called.should.be.false;
+      adb.broadcastAirplaneMode.called.should.be.false;
+      driver.setWifiState.calledWithExactly(true).should.be.true;
+      adb.setDataState.called.should.be.false;
     });
     it('should turn on data', async function () {
+      sandbox.stub(driver, 'getNetworkConnection').returns(0);
       await driver.setNetworkConnection(4);
-      adb.setAirplaneMode.calledWithExactly(0).should.be.true;
-      adb.broadcastAirplaneMode.calledWithExactly(0).should.be.true;
-      driver.setWifiState.calledWithExactly(0).should.be.true;
-      adb.setDataState.calledWithExactly(1, false).should.be.true;
+      adb.setAirplaneMode.called.should.be.false;
+      adb.broadcastAirplaneMode.called.should.be.false;
+      driver.setWifiState.called.should.be.false;
+      adb.setDataState.calledWithExactly(true, false).should.be.true;
     });
     it('should turn on data and wifi', async function () {
+      sandbox.stub(driver, 'getNetworkConnection').returns(0);
       await driver.setNetworkConnection(6);
-      adb.setAirplaneMode.calledWithExactly(0).should.be.true;
-      adb.broadcastAirplaneMode.calledWithExactly(0).should.be.true;
-      driver.setWifiState.calledWithExactly(1).should.be.true;
-      adb.setDataState.calledWithExactly(1, false).should.be.true;
+      adb.setAirplaneMode.called.should.be.false;
+      adb.broadcastAirplaneMode.called.should.be.false;
+      driver.setWifiState.calledWithExactly(true).should.be.true;
+      adb.setDataState.calledWithExactly(true, false).should.be.true;
     });
   });
   describe('setWifiState', function () {


### PR DESCRIPTION
The previous approach was not really effective if it was only necessary to change the state of the particular system, for example WiFi only without touching the others via setConnection API.