### PR TITLE
Check other apps versions before reinstalling them

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -317,10 +317,9 @@ helpers.installOtherApks = async function (otherApps, adb, opts) {
   // Install all of the APK's asynchronously
   await B.all(otherApps.map((otherApp) => {
     logger.debug(`Installing app: ${otherApp}`);
-    return adb.install(otherApp, {
+    return adb.installOrUpgrade(otherApp, null, {
       grantPermissions: autoGrantPermissions,
       timeout: androidInstallTimeout,
-      replace: true,
     });
   }));
 };

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -405,21 +405,20 @@ describe('Android Helpers', function () {
     const expectedADBInstallOpts = {
       grantPermissions: undefined,
       timeout: opts.androidInstallTimeout,
-      replace: true,
     };
 
-    it('should not call adb.install if otherApps is empty', async function () {
-      mocks.adb.expects('install').never();
+    it('should not call adb.installOrUpgrade if otherApps is empty', async function () {
+      mocks.adb.expects('installOrUpgrade').never();
       await helpers.installOtherApks([], adb, opts);
       mocks.adb.verify();
     });
-    it('should call adb.install once if otherApps has one item', async function () {
-      mocks.adb.expects('install').once().withArgs(fakeApk, expectedADBInstallOpts);
+    it('should call adb.installOrUpgrade once if otherApps has one item', async function () {
+      mocks.adb.expects('installOrUpgrade').once().withArgs(fakeApk, null, expectedADBInstallOpts);
       await helpers.installOtherApks([fakeApk], adb, opts);
       mocks.adb.verify();
     });
-    it('should call adb.install twice if otherApps has two item', async function () {
-      mocks.adb.expects('install').twice();
+    it('should call adb.installOrUpgrade twice if otherApps has two item', async function () {
+      mocks.adb.expects('installOrUpgrade').twice();
       await helpers.installOtherApks([fakeApk, otherFakeApk], adb, opts);
       mocks.adb.verify();
     });


### PR DESCRIPTION
Usually third party apps only need to be reinstalled if there are new versions of them, which speeds up session initialization.