### PR TITLE
Return the current connection state instead of undefined

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -58,7 +58,7 @@ commands.setNetworkConnection = async function (type) {
 
   if (shouldEnableWifi === isWiFiEnabled && shouldEnableDataConnection === isDataEnabled) {
     log.info('Not changing data connection/Wi-Fi states, since they are already set to expected values');
-    return;
+    return await this.getNetworkConnection();
   }
 
   await this.wrapBootstrapDisconnect(async () => {


### PR DESCRIPTION
this method is expected to return the resulting connection state rather than undefined.