### PR TITLE
Use activateApp call to restore an app from the background

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -100,27 +100,33 @@ commands.background = async function (seconds) {
   await this.adb.goToHome();
   await B.delay(seconds * 1000);
 
-  let args;
+  let args = null;
   if (this._cachedActivityArgs && this._cachedActivityArgs[`${appPackage}/${appActivity}`]) {
     // the activity was started with `startActivity`, so use those args to restart
     args = this._cachedActivityArgs[`${appPackage}/${appActivity}`];
-  } else if ((appPackage === this.opts.appPackage && appActivity === this.opts.appActivity) ||
-    (appPackage === this.opts.appWaitPackage &&
-      (this.opts.appWaitActivity || '').split(',').includes(appActivity))) {
-    // the activity is the original session activity, so use the original args
-    args = {
-      pkg: this.opts.appPackage,
-      activity: this.opts.appActivity,
-      action: this.opts.intentAction,
-      category: this.opts.intentCategory,
-      flags: this.opts.intentFlags,
-      waitPkg: this.opts.appWaitPackage,
-      waitActivity: this.opts.appWaitActivity,
-      optionalIntentArguments: this.opts.optionalIntentArguments,
-      stopApp: false,
-      user: this.opts.userProfile,
-    };
-  } else {
+  } else if ([this.opts.appPackage, this.opts.appWaitPackage].includes(appPackage)) {
+    try {
+      log.debug(`Activating app '${appPackage}' in order to restore it`);
+      await this.activateApp(appPackage);
+      return true;
+    } catch (ign) {}
+    if ([this.opts.appActivity, ...((this.opts.appWaitActivity || '').split(','))].includes(appActivity)) {
+      // the activity is the original session activity, so use the original args
+      args = {
+        pkg: this.opts.appPackage,
+        activity: this.opts.appActivity,
+        action: this.opts.intentAction,
+        category: this.opts.intentCategory,
+        flags: this.opts.intentFlags,
+        waitPkg: this.opts.appWaitPackage,
+        waitActivity: this.opts.appWaitActivity,
+        optionalIntentArguments: this.opts.optionalIntentArguments,
+        stopApp: false,
+        user: this.opts.userProfile,
+      };
+    }
+  }
+  if (!args) {
     // the activity was started some other way, so use defaults
     args = {
       pkg: appPackage,

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -190,11 +190,13 @@ describe('General', function () {
         .returns({appPackage, appActivity});
       sandbox.stub(B, 'delay');
       sandbox.stub(driver.adb, 'startApp');
+      sandbox.stub(driver, 'activateApp');
       await driver.background(10);
       driver.adb.getFocusedPackageAndActivity.calledOnce.should.be.true;
       driver.adb.goToHome.calledOnce.should.be.true;
       B.delay.calledWithExactly(10000).should.be.true;
-      driver.adb.startApp.calledWithExactly(params).should.be.true;
+      driver.activateApp.calledWithExactly(appPackage).should.be.true;
+      driver.adb.startApp.should.be.notCalled;
     });
     it('should bring app to background and back if started after session init', async function () {
       const appPackage = 'newpkg';
@@ -211,11 +213,13 @@ describe('General', function () {
         .returns({appPackage, appActivity});
       sandbox.stub(B, 'delay');
       sandbox.stub(driver.adb, 'startApp');
+      sandbox.stub(driver, 'activateApp');
       await driver.background(10);
       driver.adb.getFocusedPackageAndActivity.calledOnce.should.be.true;
       driver.adb.goToHome.calledOnce.should.be.true;
       B.delay.calledWithExactly(10000).should.be.true;
       driver.adb.startApp.calledWithExactly(params).should.be.true;
+      driver.activateApp.should.be.notCalled;
     });
     it('should bring app to background and back if waiting for other pkg / activity', async function () { //eslint-disable-line
       const appPackage = 'somepkg';
@@ -236,11 +240,13 @@ describe('General', function () {
         .returns({appPackage: appWaitPackage, appActivity: appWaitActivity});
       sandbox.stub(B, 'delay');
       sandbox.stub(driver.adb, 'startApp');
+      sandbox.stub(driver, 'activateApp');
       await driver.background(10);
       driver.adb.getFocusedPackageAndActivity.calledOnce.should.be.true;
       driver.adb.goToHome.calledOnce.should.be.true;
       B.delay.calledWithExactly(10000).should.be.true;
-      driver.adb.startApp.calledWithExactly(params).should.be.true;
+      driver.activateApp.calledWithExactly(appWaitPackage).should.be.true;
+      driver.adb.startApp.should.be.notCalled;
     });
     it('should not bring app back if seconds are negative', async function () {
       sandbox.stub(driver.adb, 'goToHome');


### PR DESCRIPTION
Try to use `activateApp` endpoint while restoring the app from background and fall back to the old approach if this fails.