### PR TITLE
Add adbExecTimeout cap

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -135,12 +135,13 @@ helpers.getDeviceInfoFromCaps = async function (opts = {}) {
   // on instantiating on earlier (at this point, we have no udid)
   // we can only use this ADB object for commands that would not be confused
   // if multiple devices are connected
-  let adb = await ADB.createADB({
+  const adb = await ADB.createADB({
     javaVersion: opts.javaVersion,
     adbPort: opts.adbPort,
     remoteAdbHost: opts.remoteAdbHost,
     suppressKillServer: opts.suppressKillServer,
     clearDeviceLogsOnStart: opts.clearDeviceLogsOnStart,
+    adbExecTimeout: opts.adbExecTimeout,
   });
   let udid = opts.udid;
   let emPort = null;
@@ -209,13 +210,24 @@ helpers.getDeviceInfoFromCaps = async function (opts = {}) {
 };
 
 // returns a new adb instance with deviceId set
-helpers.createADB = async function (javaVersion, udid, emPort, adbPort, suppressKillServer, remoteAdbHost, clearDeviceLogsOnStart) {
-  let adb = await ADB.createADB({
+helpers.createADB = async function (opts = {}) {
+  const {
+    javaVersion,
+    udid,
+    emPort,
+    adbPort,
+    suppressKillServer,
+    remoteAdbHost,
+    clearDeviceLogsOnStart,
+    adbExecTimeout,
+  } = opts;
+  const adb = await ADB.createADB({
     javaVersion,
     adbPort,
     suppressKillServer,
     remoteAdbHost,
     clearDeviceLogsOnStart,
+    adbExecTimeout,
   });
 
   adb.setDeviceId(udid);

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -43,6 +43,9 @@ let commonCapConstraints = {
   remoteAdbHost: {
     isString: true
   },
+  adbExecTimeout: {
+    isNumber: true
+  },
   avd: {
     isString: true
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -124,13 +124,16 @@ class AndroidDriver extends BaseDriver {
       this.opts.emPort = emPort;
 
       // set up an instance of ADB
-      this.adb = await helpers.createADB(this.opts.javaVersion,
-                                         this.opts.udid,
-                                         this.opts.emPort,
-                                         this.opts.adbPort,
-                                         this.opts.suppressKillServer,
-                                         this.opts.remoteAdbHost,
-                                         this.opts.clearDeviceLogsOnStart);
+      this.adb = await helpers.createADB({
+        javaVersion: this.opts.javaVersion,
+        udid: this.opts.udid,
+        emPort: this.opts.emPort,
+        adbPort: this.opts.adbPort,
+        suppressKillServer: this.opts.suppressKillServer,
+        remoteAdbHost: this.opts.remoteAdbHost,
+        clearDeviceLogsOnStart: this.opts.clearDeviceLogsOnStart,
+        adbExecTimeout: this.opts.adbExecTimeout,
+      });
 
       if (this.helpers.isPackageOrBundle(this.opts.app)) {
         // user provided package instead of app for 'app' capability, massage options

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -262,13 +262,23 @@ describe('Android Helpers', function () {
       ADB.createADB.restore();
     });
     it('should create adb and set device id and emulator port', async function () {
-      await helpers.createADB("1.7", "111222", "111", "222", true, "remote_host", true);
+      await helpers.createADB({
+        javaVersion: '1.7',
+        udid: '111222',
+        emPort: '111',
+        adbPort: '222',
+        suppressKillServer: true,
+        remoteAdbHost: 'remote_host',
+        clearDeviceLogsOnStart: true,
+        adbExecTimeout: 50,
+      });
       ADB.createADB.calledWithExactly({
         javaVersion: "1.7",
         adbPort: "222",
         suppressKillServer: true,
         remoteAdbHost: "remote_host",
         clearDeviceLogsOnStart: true,
+        adbExecTimeout: 50,
       }).should.be.true;
       curDeviceId.should.equal("111222");
       emulatorPort.should.equal("111");


### PR DESCRIPTION
Add a capability `adbExecTimeout` to customize the amount of time we will wait for `adb` to run. Necessary on some slow systems where timeouts happen a lot (see, for instance, the Espresso driver on Travis).

The signature for `helpers.createADB()` is too long. Change to taking an options object rather than a list of arguments. That is a breaking change.