### PR TITLE
Add redirect message to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+**Warning:**
+
+These issues are not tracked. Please create new issues in the main Appium
+repository: https://github.com/appium/appium/issues/new


### PR DESCRIPTION
Greenkeeper requires repos to have issues turned on, but we still do not want to have to patrol all the issue-trackers. Hopefully this will keep the issues on package repos to a minimum (understanding that people will ignore this because... I honestly don't know why).