### PR TITLE
Add warning for apppackage, appactivity and appwaitpackages

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -236,10 +236,25 @@ helpers.createADB = async function (opts = {}) {
 };
 
 helpers.validatePackageActivityName = function (name) {
-  let result = /([^a-zA-Z0-9_\.])+/.exec(name);
+  let result = /([^a-zA-Z0-9_.*])+/.exec(name);
   if (result) {
     logger.warn(`'${name}' is expected to only include latin letters, digits, underscore and dot characters.`);
-    logger.warn(`'${name}' <- the first position is ${result.index}. '${result}' are included.`);
+    logger.warn(`'${name.substring(0, result.index + 1)}' <- the first position is ${result.index}.`);
+  }
+};
+
+helpers.validatePackageActivityNames = function (appPackage, appActivity, appWaitPackage, appWaitActivity) {
+  if (appWaitPackage) {
+    this.validatePackageActivityName(appWaitPackage);
+  }
+  if (appWaitActivity) {
+    this.validatePackageActivityName(appWaitActivity);
+  }
+  if (appPackage) {
+    this.validatePackageActivityName(appPackage);
+  }
+  if (appActivity) {
+    this.validatePackageActivityName(appActivity);
   }
 };
 
@@ -250,16 +265,9 @@ helpers.getLaunchInfo = async function (adb, opts) {
     return;
   }
 
-  if (!appWaitPackage) {
-    this.validatePackageActivityName(appWaitPackage);
-  }
-  if (!appWaitActivity) {
-    this.validatePackageActivityName(appWaitActivity);
-  }
+  this.validatePackageActivityNames(appPackage, appActivity, appWaitPackage, appWaitActivity);
 
   if (appPackage && appActivity) {
-    this.validatePackageActivityName(appPackage);
-    this.validatePackageActivityName(appActivity);
     return;
   }
 

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -239,11 +239,13 @@ helpers.validatePackageActivityName = function (name) {
   let result = /([^\w.*])+/.exec(name);
   if (result) {
     logger.warn(`'${name}' is expected to only include latin letters, digits, underscore and dot characters.`);
-    logger.warn(`'${name.substring(0, result.index + 1)}' <- the first position is ${result.index}.`);
+    logger.warn(`'${name.substring(0, result.index + 1)}' <- the first non-matching character occurrence is at index ${result.index}.`);
   }
 };
 
-helpers.validatePackageActivityNames = function (appPackage, appActivity, appWaitPackage, appWaitActivity) {
+helpers.validatePackageActivityNames = function (opts) {
+  let {appPackage, appActivity, appWaitPackage, appWaitActivity} = opts;
+
   if (appWaitPackage) {
     this.validatePackageActivityName(appWaitPackage);
   }
@@ -265,7 +267,7 @@ helpers.getLaunchInfo = async function (adb, opts) {
     return;
   }
 
-  this.validatePackageActivityNames(appPackage, appActivity, appWaitPackage, appWaitActivity);
+  this.validatePackageActivityNames(opts);
 
   if (appPackage && appActivity) {
     return;

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -266,6 +266,10 @@ helpers.getLaunchInfo = async function (adb, opts) {
   }
   if (!appWaitActivity) {
     appWaitActivity = appActivity;
+  } else {
+    if (!new RegExp(/^[a-zA-Z0-9_\.]+$/).test(appWaitActivity)) {
+      logger.warn(`appWaitActivity, "${appWaitActivity}", should be ^[a-zA-Z0-9_\.]+$`);
+    }
   }
   logger.debug(`Parsed package and activity are: ${apkPackage}/${apkActivity}`);
   return {appPackage, appWaitPackage, appActivity, appWaitActivity};

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -236,7 +236,7 @@ helpers.createADB = async function (opts = {}) {
 };
 
 helpers.validatePackageActivityName = function (name) {
-  let result = /([^a-zA-Z0-9_.*])+/.exec(name);
+  let result = /([^\w.*])+/.exec(name);
   if (result) {
     logger.warn(`'${name}' is expected to only include latin letters, digits, underscore and dot characters.`);
     logger.warn(`'${name.substring(0, result.index + 1)}' <- the first position is ${result.index}.`);

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -235,20 +235,31 @@ helpers.createADB = async function (opts = {}) {
   return adb;
 };
 
+helpers.validatePackageActivityName = function (name) {
+  let result = /([^a-zA-Z0-9_\.])+/.exec(name);
+  if (result) {
+    logger.warn(`'${name}' is expected to only include latin letters, digits, underscore and dot characters.`);
+    logger.warn(`'${name}' <- the first position is ${result.index}. '${result}' are included.`);
+  }
+};
+
 helpers.getLaunchInfo = async function (adb, opts) {
   let {app, appPackage, appActivity, appWaitPackage, appWaitActivity} = opts;
   if (!app) {
     logger.warn("No app sent in, not parsing package/activity");
     return;
   }
-  if (appPackage && appActivity) {
-    if (!new RegExp(/^[a-zA-Z0-9_\.]+$/).test(appPackage)) {
-      logger.warn(`appPackage, "${appPackage}", should be ^[a-zA-Z0-9_\.]+$`);
-    }
-    if (!new RegExp(/^[a-zA-Z0-9_\.]+$/).test(appActivity)) {
-      logger.warn(`appActivity, "${appActivity}", should be ^[a-zA-Z0-9_\.]+$`);
-    }
 
+  if (!appWaitPackage) {
+    this.validatePackageActivityName(appWaitPackage);
+  }
+  if (!appWaitActivity) {
+    this.validatePackageActivityName(appWaitActivity);
+  }
+
+  if (appPackage && appActivity) {
+    this.validatePackageActivityName(appPackage);
+    this.validatePackageActivityName(appActivity);
     return;
   }
 
@@ -266,10 +277,6 @@ helpers.getLaunchInfo = async function (adb, opts) {
   }
   if (!appWaitActivity) {
     appWaitActivity = appActivity;
-  } else {
-    if (!new RegExp(/^[a-zA-Z0-9_\.]+$/).test(appWaitActivity)) {
-      logger.warn(`appWaitActivity, "${appWaitActivity}", should be ^[a-zA-Z0-9_\.]+$`);
-    }
   }
   logger.debug(`Parsed package and activity are: ${apkPackage}/${apkActivity}`);
   return {appPackage, appWaitPackage, appActivity, appWaitActivity};

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -242,6 +242,13 @@ helpers.getLaunchInfo = async function (adb, opts) {
     return;
   }
   if (appPackage && appActivity) {
+    if (!new RegExp(/^[a-zA-Z0-9_\.]+$/).test(appPackage)) {
+      logger.warn(`appPackage, "${appPackage}", should be ^[a-zA-Z0-9_\.]+$`);
+    }
+    if (!new RegExp(/^[a-zA-Z0-9_\.]+$/).test(appActivity)) {
+      logger.warn(`appActivity, "${appActivity}", should be ^[a-zA-Z0-9_\.]+$`);
+    }
+
     return;
   }
 

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -235,28 +235,20 @@ helpers.createADB = async function (opts = {}) {
   return adb;
 };
 
-helpers.validatePackageActivityName = function (name) {
-  let result = /([^\w.*])+/.exec(name);
-  if (result) {
-    logger.warn(`'${name}' is expected to only include latin letters, digits, underscore and dot characters.`);
-    logger.warn(`'${name.substring(0, result.index + 1)}' <- the first non-matching character occurrence is at index ${result.index}.`);
-  }
-};
-
 helpers.validatePackageActivityNames = function (opts) {
-  let {appPackage, appActivity, appWaitPackage, appWaitActivity} = opts;
+  for (const key of ['appPackage', 'appActivity', 'appWaitPackage', 'appWaitActivity']) {
+    const name = opts[key];
+    if (!name) {
+      continue;
+    }
 
-  if (appWaitPackage) {
-    this.validatePackageActivityName(appWaitPackage);
-  }
-  if (appWaitActivity) {
-    this.validatePackageActivityName(appWaitActivity);
-  }
-  if (appPackage) {
-    this.validatePackageActivityName(appPackage);
-  }
-  if (appActivity) {
-    this.validatePackageActivityName(appActivity);
+    const match = /([^\w.*])+/.exec(name);
+    if (!match) {
+      continue;
+    }
+
+    logger.warn(`'${name}' is expected to only include latin letters, digits, underscore, dot and asterisk characters.`);
+    logger.warn(`'${name.substring(0, match.index + 1)}' <- the first non-matching character occurrence is at index ${match.index}.`);
   }
 };
 

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -301,6 +301,12 @@ describe('Android Helpers', function () {
         appActivity: "act"});
       mocks.adb.verify();
     });
+    it('should print warn when all parameters are already present but the format is odd', async function () {
+      // It only prints warn message
+      mocks.adb.expects('packageAndLaunchActivityFromManifest').never();
+      await helpers.getLaunchInfo(adb, {app: "foo", appPackage: "bar ", appWaitPackage: "*", appActivity: "act ", appWaitActivity: ". "});
+      mocks.adb.verify();
+    });
     it('should print warn when appPackage & appActivity are already present but the format is odd', async function () {
       // It only prints warn message
       mocks.adb.expects('packageAndLaunchActivityFromManifest').never();

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -304,13 +304,13 @@ describe('Android Helpers', function () {
     it('should print warn when all parameters are already present but the format is odd', async function () {
       // It only prints warn message
       mocks.adb.expects('packageAndLaunchActivityFromManifest').never();
-      await helpers.getLaunchInfo(adb, {app: "foo", appPackage: "bar ", appWaitPackage: "*", appActivity: "act ", appWaitActivity: ". "});
+      await helpers.getLaunchInfo(adb, {app: "foo", appPackage: "bar ", appWaitPackage: "*", appActivity: "a_act", appWaitActivity: ". "});
       mocks.adb.verify();
     });
     it('should print warn when appPackage & appActivity are already present but the format is odd', async function () {
       // It only prints warn message
       mocks.adb.expects('packageAndLaunchActivityFromManifest').never();
-      await helpers.getLaunchInfo(adb, {app: "foo", appPackage: "bar ", appActivity: "act "});
+      await helpers.getLaunchInfo(adb, {app: "foo", appPackage: "bar", appActivity: "a_act "});
       mocks.adb.verify();
     });
     it('should return package and launch activity from manifest', async function () {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -301,6 +301,12 @@ describe('Android Helpers', function () {
         appActivity: "act"});
       mocks.adb.verify();
     });
+    it('should print warn when appPackage & appActivity are already present but the format is odd', async function () {
+      // It only prints warn message
+      mocks.adb.expects('packageAndLaunchActivityFromManifest').never();
+      await helpers.getLaunchInfo(adb, {app: "foo", appPackage: "bar ", appActivity: "act "});
+      mocks.adb.verify();
+    });
     it('should return package and launch activity from manifest', async function () {
       mocks.adb.expects('packageAndLaunchActivityFromManifest').withExactArgs('foo')
         .returns({apkPackage: 'pkg', apkActivity: 'ack'});


### PR DESCRIPTION
This is just a suggestion.

----

I got feedback from some Appium users in Japan who faced wrong package/activity name.
We can see `Bad component name: com.android.vending` if we inserted a space in `appActivity` for example. For users, it's difficult to estimate the case.

I know the error message by adb command is a common thing for Android developers though. But in the case, users should take much time to dig into adb command world.

```
error: [MJSONWP] Encountered internal error running command: Error: Error occured while starting App. Original error: Error executing adbExec. Original error: 'Command '/Users/itonozomi/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell am start -W -n 'com.android.vending /.AssetBrowserActivity' -S -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -f 0x10200000' exited with code 255'; Stderr: 'Exception occurred while executing:
error: [MJSONWP] java.lang.IllegalArgumentException: Bad component name: com.android.vending
error: [MJSONWP] 	at android.content.Intent.parseCommandArgs(Intent.java:6417)
```

For Appium users, I'd like to try to show more helpful error message than simple adb command error message. I won't insert this kind of messages too much so only insert in initialising.I found it follows https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html . So, roughly, I've added warning messages using `RegExp` like the below.

## What I did
So, what about adding warning message?
(This is warning message. So, if some illegal name happens, Appium should work leaving some warning messages.