### PR TITLE
fix issue in find element error handling, so implicit wait can work

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { errors } from 'appium-base-driver';
+import { errors, isErrorType } from 'appium-base-driver';
 
 
 let helpers = {}, extensions = {};
@@ -38,14 +38,14 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
 
       // if the error that comes back is from a proxied request, we need to
       // unwrap it to its actual protocol error first
-      if (_.isFunction(err.getActualError)) {
+      if (isErrorType(err, errors.ProxyRequestError)) {
         err = err.getActualError(); // eslint-disable-line no-ex-assign
       }
 
       // now we have to inspect the error to determine if it is a no such
       // element error, based on the shape of the error object from
       // appium-base-driver
-      if (err.jsonwpCode === 7 || err.error === "no such element") {
+      if (isErrorType(err, errors.NoSuchElementError)) {
         // we are fine with this, just indicate a retry
         return false;
       }

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -35,7 +35,17 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
     try {
       element = await this.doFindElementOrEls(params);
     } catch (err) {
-      if (err instanceof errors.NoSuchElementError) {
+
+      // if the error that comes back is from a proxied request, we need to
+      // unwrap it to its actual protocol error first
+      if (_.isFunction(err.getActualError)) {
+        err = err.getActualError(); // eslint-disable-line no-ex-assign
+      }
+
+      // now we have to inspect the error to determine if it is a no such
+      // element error, based on the shape of the error object from
+      // appium-base-driver
+      if (err.jsonwpCode === 7 || err.error === "no such element") {
         // we are fine with this, just indicate a retry
         return false;
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "appium-adb": "^6.8.0",
     "appium-android-bootstrap": "^2.11.0",
     "appium-android-ime": "^2.0.0",
-    "appium-base-driver": "^2.26.0",
+    "appium-base-driver": "^2.32.1",
     "appium-chromedriver": "^4.0.0",
     "appium-support": "^2.13.0",
     "appium-unlock": "^2.0.0",


### PR DESCRIPTION
cc @mykola-mokhnach: unfortunately we can't do `instanceof` checks where the LHS could be an instance of a class from a different version of a module as the RHS.