### PR TITLE
tweak android date format

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -28,7 +28,8 @@ commands.doSendKeys = async function (params) {
 commands.getDeviceTime = async function () {
   log.info('Attempting to capture android device date and time');
   try {
-    let out = await this.adb.shell(['date']);
+    // format: Sat Jun 09 2018 11:17:42 GTM+0900 (JST)
+    let out = await this.adb.shell(['date', '\"+%a\ %b\ %d\ %Y\ %X\ GTM%z\ \(%Z\)\"']);
     return out.trim();
   } catch (err) {
     log.errorAndThrow(`Could not capture device date and time: ${err}`);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -28,13 +28,12 @@ commands.doSendKeys = async function (params) {
 /**
  * Get device time
  * @return {String} Return value following iso-8601 format like `2018-06-09T16:21:54+0900`
- * @throws {Error} If the adb command doesn't return device date, error throes
+ * @throws {Error} If the adb command doesn't return device date
  */
 commands.getDeviceTime = async function () {
   log.info('Attempting to capture android device date and time');
   try {
-    let out = await this.adb.shell(['date', '+%Y-%m-%dT%T%z']);
-    return out.trim();
+    return (await this.adb.shell(['date', '+%Y-%m-%dT%T%z'])).trim();
   } catch (err) {
     log.errorAndThrow(`Could not capture device date and time: ${err}`);
   }

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -25,10 +25,14 @@ commands.doSendKeys = async function (params) {
   return await this.bootstrap.sendAction('setText', params);
 };
 
+/**
+ * Get device time
+ * @return {String} Return value following iso-8601 format like `2018-06-09T16:21:54+0900`
+ * @throws {Error} If the adb command doesn't return device date, error throes
+ */
 commands.getDeviceTime = async function () {
   log.info('Attempting to capture android device date and time');
   try {
-    // format: 2018-06-09T16:21:54+0900
     let out = await this.adb.shell(['date', '+%Y-%m-%dT%T%z']);
     return out.trim();
   } catch (err) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -28,8 +28,8 @@ commands.doSendKeys = async function (params) {
 commands.getDeviceTime = async function () {
   log.info('Attempting to capture android device date and time');
   try {
-    // format: Sat Jun 09 2018 11:17:42 GTM+0900 (JST)
-    let out = await this.adb.shell(['date', '\"+%a\ %b\ %d\ %Y\ %X\ GTM%z\ \(%Z\)\"']);
+    // format: 2018-06-09T16:21:54+0900
+    let out = await this.adb.shell(['date', '+%Y-%m-%dT%T%z']);
     return out.trim();
   } catch (err) {
     log.errorAndThrow(`Could not capture device date and time: ${err}`);

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -51,9 +51,9 @@ describe('General', function () {
   describe('getDeviceTime', function () {
     it('should return device time', async function () {
       sandbox.stub(driver.adb, 'shell');
-      driver.adb.shell.returns(' 11:12 ');
-      await driver.getDeviceTime().should.become('11:12');
-      driver.adb.shell.calledWithExactly(['date']).should.be.true;
+      driver.adb.shell.returns(' Sat Jun 09 2018 11:17:42 GTM+0900 (JST) ');
+      await driver.getDeviceTime().should.become('Sat Jun 09 2018 11:17:42 GTM+0900 (JST)');
+      driver.adb.shell.calledWithExactly(['date', '\"+%a\ %b\ %d\ %Y\ %X\ GTM%z\ \(%Z\)\"']).should.be.true;
     });
     it('should thorws error if shell command failed', async function () {
       sandbox.stub(driver.adb, 'shell').throws();

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -51,9 +51,9 @@ describe('General', function () {
   describe('getDeviceTime', function () {
     it('should return device time', async function () {
       sandbox.stub(driver.adb, 'shell');
-      driver.adb.shell.returns(' Sat Jun 09 2018 11:17:42 GTM+0900 (JST) ');
-      await driver.getDeviceTime().should.become('Sat Jun 09 2018 11:17:42 GTM+0900 (JST)');
-      driver.adb.shell.calledWithExactly(['date', '\"+%a\ %b\ %d\ %Y\ %X\ GTM%z\ \(%Z\)\"']).should.be.true;
+      driver.adb.shell.returns(' 2018-06-09T16:21:54+0900 ');
+      await driver.getDeviceTime().should.become('2018-06-09T16:21:54+0900');
+      driver.adb.shell.calledWithExactly(['date', '+%Y-%m-%dT%T%z']).should.be.true;
     });
     it('should thorws error if shell command failed', async function () {
       sandbox.stub(driver.adb, 'shell').throws();


### PR DESCRIPTION
addressed : https://github.com/appium/appium/issues/10832

I made sure the format worked with emulator OS 4, 5, 6, 7, 8 and real device with 6.

Wha do you think?

----

- iOS returns JS's `Date` (both real devices and simulators):
https://github.com/appium/appium-ios-driver/blob/17ac721c3c1cbefce28445a036daf1a50f4c6d80/lib/commands/general.js#L20 
- Android's `shell date` can format.

```
1|generic_x86:/ $ date --help
usage: date [-u] [-r FILE] [-d DATE] [+DISPLAY_FORMAT] [-D SET_FORMAT] [SET]

Set/get the current date/time. With no SET shows the current date.

Default SET format is "MMDDhhmm[[CC]YY][.ss]", that's (2 digits each)
month, day, hour (0-23), and minute. Optionally century, year, and second.
Also accepts "@UNIXTIME[.FRACTION]" as seconds since midnight Jan 1 1970.

-d	Show DATE instead of current time (convert date format)
-D	+FORMAT for SET or -d (instead of MMDDhhmm[[CC]YY][.ss])
-r	Use modification time of FILE instead of current date
-u	Use UTC instead of current timezone

+FORMAT specifies display format string using strftime(3) syntax:

%% literal %             %n newline              %t tab
%S seconds (00-60)       %M minute (00-59)       %m month (01-12)
%H hour (0-23)           %I hour (01-12)         %p AM/PM
%y short year (00-99)    %Y year                 %C century
%a short weekday name    %A weekday name         %u day of week (1-7, 1=mon)
%b short month name      %B month name           %Z timezone name
%j day of year (001-366) %d day of month (01-31) %e day of month ( 1-31)
%N nanosec (output only)

%U Week of year (0-53 start sunday)   %W Week of year (0-53 start monday)
%V Week of year (1-53 start monday, week < 4 days not part of this year)

%D = "%m/%d/%y"    %r = "%I : %M : %S %p"   %T = "%H:%M:%S"   %h = "%b"
%x locale date     %X locale time           %c locale date/time
```
