### PR TITLE
update getDeviceTime to use cross-platform format specifiers

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -47,7 +47,7 @@ commands.getDeviceTime = async function (format = DEFAULT_DEVICE_TIME) {
   const deviceTimestamp = (await this.adb.shell(['date', '+%Y-%m-%dT%T%z'])).trim();
   const parsedTimestamp = moment(deviceTimestamp, 'YYYY-MM-DDTHH:mm:ssZ');
   if (!parsedTimestamp.isValid()) {
-    log.warn(`Cannot parse the returned timestamp '${deviceTimestamp}'. Retuning as it`);
+    log.warn(`Cannot parse the returned timestamp '${deviceTimestamp}'. Returning as is`);
     return deviceTimestamp;
   }
   return parsedTimestamp.format(format);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -4,6 +4,7 @@ import { util } from 'appium-support';
 import B from 'bluebird';
 import log from '../logger';
 import { NATIVE_WIN } from '../webview-helpers';
+import moment from 'moment';
 
 
 let commands = {}, helpers = {}, extensions = {};
@@ -26,31 +27,15 @@ commands.doSendKeys = async function (params) {
 };
 
 /**
- * Get device time
- * @param {String} format A optional format for `adb shell date`. Available format is `+DISPLAY_FORMAT`.
- *                        `iso-8601`format is default like `2018-06-09T16:21:54+0900` by `'+%Y-%m-%dT%T%z'`.
+ * Retrieves the current device's timestamp.
  *
- *                        +DISPLAY_FORMAT specifies display format string using these escapes:
- *
- *                        %% literal %             %n newline              %t tab
- *                        %S seconds (00-60)       %M minute (00-59)       %m month (01-12)
- *                        %H hour (0-23)           %I hour (01-12)         %p AM/PM
- *                        %y short year (00-99)    %Y year                 %C century
- *                        %a short weekday name    %A weekday name         %u day of week (1-7, 1=mon)
- *                        %b short month name      %B month name           %Z timezone name
- *                        %j day of year (001-366) %d day of month (01-31) %e day of month ( 1-31)
- *                        %s seconds past the Epoch
- *
- *                        %U Week of year (0-53 start sunday)   %W Week of year (0-53 start monday)
- *                        %V Week of year (1-53 start monday, week < 4 days not part of this year)
- *
- *                        %D = "%m/%d/%y"    %r = "%I : %M : %S %p"   %T = "%H:%M:%S"   %h = "%b"
- *                        %x locale date     %X locale time           %c locale date/time
- *
- * @return {String} Return date formatted by `format`. `+%Y-%m-%dT%T%z` is by default.
- * @throws {Error} If the adb command doesn't return device date
+ * @param {string} format - The set of format specifiers. Read
+ *                          https://momentjs.com/docs/ to get the full list of supported
+ *                          datetime format specifiers. The default format is
+ *                          `YYYY-MM-DDTHH:mm:ssZ`, which complains to ISO-8601
+ * @returns Formatted datetime string or the raw command output if formatting fails
  */
-const DEFAULT_DEVICE_TIME = '+%Y-%m-%dT%T%z';
+const DEFAULT_DEVICE_TIME = 'YYYY-MM-DDTHH:mm:ssZ';
 commands.getDeviceTime = async function (format = DEFAULT_DEVICE_TIME) {
   log.info('Attempting to capture android device date and time');
 
@@ -59,11 +44,13 @@ commands.getDeviceTime = async function (format = DEFAULT_DEVICE_TIME) {
         `The current value is: ${format}`);
   }
 
-  try {
-    return (await this.adb.shell(['date', format])).trim();
-  } catch (err) {
-    log.errorAndThrow(`Could not capture device date and time: ${err}`);
+  const deviceTimestamp = (await this.adb.shell(['date', '+%Y-%m-%dT%T%z'])).trim();
+  const parsedTimestamp = moment(deviceTimestamp, 'YYYY-MM-DDTHH:mm:ssZ');
+  if (!parsedTimestamp.isValid()) {
+    log.warn(`Cannot parse the returned timestamp '${deviceTimestamp}'. Retuning as it`);
+    return deviceTimestamp;
   }
+  return parsedTimestamp.format(format);
 };
 
 commands.getPageSource = async function () {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -32,7 +32,7 @@ commands.doSendKeys = async function (params) {
  * @param {string} format - The set of format specifiers. Read
  *                          https://momentjs.com/docs/ to get the full list of supported
  *                          datetime format specifiers. The default format is
- *                          `YYYY-MM-DDTHH:mm:ssZ`, which complains to ISO-8601
+ *                          `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601
  * @returns Formatted datetime string or the raw command output if formatting fails
  */
 const DEFAULT_DEVICE_TIME = 'YYYY-MM-DDTHH:mm:ssZ';

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "io.appium.settings": "^2.4.0",
     "jimp": "^0.2.24",
     "lodash": "^4.17.4",
+    "moment": "^2.22.2",
     "portfinder": "^1.0.6",
     "shared-preferences-builder": "^0.0.4",
     "shell-quote": "^1.6.1",

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -63,7 +63,7 @@ describe('General', function () {
     });
     it('should thorws error if shell command failed', async function () {
       sandbox.stub(driver.adb, 'shell').throws();
-      await driver.getDeviceTime().should.be.rejectedWith(/Could not capture/);
+      await driver.getDeviceTime().should.be.rejected;
     });
     it('should thorws error if format is not string', async function () {
       sandbox.stub(driver.adb, 'shell').throws();

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -52,7 +52,7 @@ describe('General', function () {
     it('should return device time', async function () {
       sandbox.stub(driver.adb, 'shell');
       driver.adb.shell.returns(' 2018-06-09T16:21:54+0900 ');
-      await driver.getDeviceTime().should.become('2018-06-09T16:21:54+09:00');
+      await driver.getDeviceTime().should.become('2018-06-09T07:21:54+00:00');
       driver.adb.shell.calledWithExactly(['date', '+%Y-%m-%dT%T%z']).should.be.true;
     });
     it('should return device time with custom format', async function () {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -52,23 +52,23 @@ describe('General', function () {
     it('should return device time', async function () {
       sandbox.stub(driver.adb, 'shell');
       driver.adb.shell.returns(' 2018-06-09T16:21:54+0900 ');
-      await driver.getDeviceTime().should.become('2018-06-09T16:21:54+0900');
+      await driver.getDeviceTime().should.become('2018-06-09T16:21:54+09:00');
       driver.adb.shell.calledWithExactly(['date', '+%Y-%m-%dT%T%z']).should.be.true;
     });
     it('should return device time with custom format', async function () {
       sandbox.stub(driver.adb, 'shell');
-      driver.adb.shell.returns(' 2018-06-09 ');
-      await driver.getDeviceTime('+%Y-%m-%d').should.become('2018-06-09');
-      driver.adb.shell.calledWithExactly(['date', '+%Y-%m-%d']).should.be.true;
+      driver.adb.shell.returns(' 2018-06-09T16:21:54+0900 ');
+      await driver.getDeviceTime('YYYY-MM-DD').should.become('2018-06-09');
+      driver.adb.shell.calledWithExactly(['date', '+%Y-%m-%dT%T%z']).should.be.true;
     });
     it('should thorws error if shell command failed', async function () {
       sandbox.stub(driver.adb, 'shell').throws();
-      await driver.getDeviceTime().should.be.rejectedWith('Could not capture');
+      await driver.getDeviceTime().should.be.rejectedWith(/Could not capture/);
     });
     it('should thorws error if format is not string', async function () {
       sandbox.stub(driver.adb, 'shell').throws();
       await driver.getDeviceTime({}).should.be.rejectedWith(
-        'The format specifier is expected to be a valid string specifier like \'+%Y-%m-%dT%T%z\'.'
+        /The format specifier is expected to be a valid string specifier/
       );
     });
   });


### PR DESCRIPTION
Related to https://github.com/appium/appium-ios-driver/pull/282