### PR TITLE
Retry installation of Unicode IME helper

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -11,8 +11,8 @@ import Bootstrap from 'appium-android-bootstrap';
 import B from 'bluebird';
 
 import ADB from 'appium-adb';
-import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK } from './unlock-helpers';
-
+import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK,
+  PATTERN_UNLOCK, FINGERPRINT_UNLOCK } from './unlock-helpers';
 
 const PACKAGE_INSTALL_TIMEOUT = 90000; // milliseconds
 const CHROME_BROWSER_PACKAGE_ACTIVITY = {
@@ -49,6 +49,7 @@ const SETTINGS_HELPER_PKG_ID = 'io.appium.settings';
 const SETTINGS_HELPER_PKG_ACTIVITY = ".Settings";
 const UNLOCK_HELPER_PKG_ID = 'io.appium.unlock';
 const UNLOCK_HELPER_PKG_ACTIVITY = ".Unlock";
+const UNICODE_IME_PKG_ID = 'io.appium.android.ime';
 
 let helpers = {};
 
@@ -400,13 +401,18 @@ helpers.installOtherApks = async function (otherApps, adb, opts) {
 helpers.initUnicodeKeyboard = async function (adb) {
   logger.debug('Enabling Unicode keyboard support');
   logger.debug("Pushing unicode ime to device...");
-  await adb.install(unicodeIMEPath, {replace: false});
+  try {
+    await adb.install(unicodeIMEPath, {replace: false});
+  } catch (err) {
+    await adb.uninstallApk(UNICODE_IME_PKG_ID);
+    await adb.install(unicodeIMEPath, {replace: false});
+  }
 
   // get the default IME so we can return back to it later if we want
   let defaultIME = await adb.defaultIME();
 
   logger.debug(`Unsetting previous IME ${defaultIME}`);
-  const appiumIME = 'io.appium.android.ime/.UnicodeIME';
+  const appiumIME = `${UNICODE_IME_PKG_ID}/.UnicodeIME`;
   logger.debug(`Setting IME to '${appiumIME}'`);
   await adb.enableIME(appiumIME);
   await adb.setIME(appiumIME);

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -404,6 +404,7 @@ helpers.initUnicodeKeyboard = async function (adb) {
   try {
     await adb.install(unicodeIMEPath, {replace: false});
   } catch (err) {
+    logger.info(`Performing full reinstall of ${UNICODE_IME_PKG_ID} as a possible fix for: ${err.message}`);
     await adb.uninstallApk(UNICODE_IME_PKG_ID);
     await adb.install(unicodeIMEPath, {replace: false});
   }


### PR DESCRIPTION
See https://discuss.appium.io/t/unicodeime-debug-apk-failure-install-failed-already-exists-attempt-to-re-install-io-appium-android-ime-without-first-uninstalling/21270 for more details.

Uninstalling the app from the device first sometimes helps to resolve the problem.