### PR TITLE
Add chromedriverUseSystemExecutable cap to pass to appium-chromedriver

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -279,6 +279,7 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
     executableDir: opts.chromedriverExecutableDir,
     mappingPath: opts.chromedriverChromeMappingFile,
     bundleId: opts.chromeBundleId,
+    useSystemExecutable: opts.chromedriverUseSystemExecutable,
   });
 
   // make sure there are chromeOptions

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -85,6 +85,9 @@ let commonCapConstraints = {
   chromedriverChromeMappingFile: {
     isString: true
   },
+  chromedriverUseSystemExecutable: {
+    isBoolean: true
+  },
   autoWebviewTimeout: {
     isNumber: true
   },


### PR DESCRIPTION
In `appium-chromedriver` this allows users to bypass the auto-configuration, without the need to pass in the `chromedriverExecutable` with the package path in it.