### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: android
 dist: precise
+addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+      packages:
+        - g++-4.9
 android:
   components:
     # use the latest revision of Android SDK Tools
@@ -25,6 +31,7 @@ env:
     - ANDROID_EMU_NAME=test
     - ANDROID_EMU_TARGET=android-21
     - ANDROID_EMU_ABI=armeabi-v7a
+    - CC=gcc-4.9 CXX=g++-4.9
   matrix:
     - TEST=unit RECURSIVE=--recursive START_EMU=0
     - TEST=functional

--- a/test/functional/commands/keyboard/keyboard-e2e-specs.js
+++ b/test/functional/commands/keyboard/keyboard-e2e-specs.js
@@ -130,6 +130,8 @@ let languageTests = [
 ];
 
 describe('keyboard', function () {
+  this.retries(3);
+
   describe('ascii', function () {
     let driver;
     before(async function () {
@@ -168,8 +170,6 @@ describe('keyboard', function () {
       }
 
       it('should be able to clear a password field', async function () {
-        this.retries(3);
-
         let els = await driver.findElements('class name', EDITTEXT_CLASS);
         let el = els[1].ELEMENT;
 


### PR DESCRIPTION
`appium-support` requires, as a sub-dependency, `buffertools`, which doesn't build on the standard Android Travis platform. So update, and use, a C++11 compatible gcc.