### PR TITLE
add comma for package validation to relax the logic

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -243,12 +243,12 @@ helpers.validatePackageActivityNames = function (opts) {
       continue;
     }
 
-    const match = /([^\w.*])+/.exec(name);
+    const match = /([^\w.*,])+/.exec(name);
     if (!match) {
       continue;
     }
 
-    logger.warn(`'${name}' is expected to only include latin letters, digits, underscore, dot and asterisk characters.`);
+    logger.warn(`'${name}' is expected to only include latin letters, digits, underscore, dot, comma and asterisk characters.`);
     logger.warn(`'${name.substring(0, match.index + 1)}' <- the first non-matching character occurrence is at index ${match.index}.`);
   }
 };

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -248,8 +248,8 @@ helpers.validatePackageActivityNames = function (opts) {
       continue;
     }
 
-    logger.warn(`'${name}' is expected to only include latin letters, digits, underscore, dot, comma and asterisk characters.`);
-    logger.warn(`'${name.substring(0, match.index + 1)}' <- the first non-matching character occurrence is at index ${match.index}.`);
+    logger.warn(`Capability '${key}' is expected to only include latin letters, digits, underscore, dot, comma and asterisk characters.`);
+    logger.warn(`Current value '${name}' has non-matching character at index ${match.index}: '${name.substring(0, match.index + 1)}'`);
   }
 };
 

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -301,6 +301,11 @@ describe('Android Helpers', function () {
         appActivity: "act"});
       mocks.adb.verify();
     });
+    it('should return when all parameters are already present', async function () {
+      mocks.adb.expects('packageAndLaunchActivityFromManifest').never();
+      await helpers.getLaunchInfo(adb, {app: "foo", appPackage: "bar", appWaitPackage: "*", appActivity: "app.activity", appWaitActivity: "app.nameA,app.nameB"});
+      mocks.adb.verify();
+    });
     it('should print warn when all parameters are already present but the format is odd', async function () {
       // It only prints warn message
       mocks.adb.expects('packageAndLaunchActivityFromManifest').never();


### PR DESCRIPTION
https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/caps.md allows to use `,` in `appWaitActivity`.

https://github.com/appium/appium/issues/11101#issuecomment-407682259