### PR TITLE
Add pageLoadStrategy capability now supported by chromedriver

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -172,6 +172,9 @@ let commonCapConstraints = {
   allowTestPackages: {
     isBoolean: true
   },
+  pageLoadStrategy: {
+    isString: true
+  }
 };
 
 let uiautomatorCapConstraints = {


### PR DESCRIPTION
webdriver standard, currently only supported by chromedriver and firefox.
https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/PageLoadStrategy.html