### PR TITLE
Re-word cap validation errors

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -703,10 +703,10 @@ helpers.validateDesiredCaps = function (caps) {
   if (caps.browserName) {
     if (caps.app) {
       // warn if the capabilities have both `app` and `browser, although this is common with selenium grid
-      logger.warn('The desired capabilities should generally not include both an app and a browserName');
+      logger.warn(`The desired capabilities should generally not include both an 'app' and a 'browserName'`);
     }
     if (caps.appPackage) {
-      logger.errorAndThrow(`The desired capabilities must include either 'appPackage' or 'browserName'`);
+      logger.errorAndThrow(`The desired should not include both of an 'appPackage' and a 'browserName'`);
     }
   }
 


### PR DESCRIPTION
* `capabilities must include either 'appPackage' or 'browserName'` suggests that it works fine if you have both
* Re-word it to say that you can only have one or the other (exclusive or)

(discovered through https://github.com/appium/appium-desktop/issues/624)