### PR TITLE
Do not install unlock helper if skipUnlock is set to true

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -632,7 +632,7 @@ helpers.initDevice = async function (adb, opts) {
   if (opts.unicodeKeyboard) {
     defaultIME = await helpers.initUnicodeKeyboard(adb);
   }
-  if (_.isUndefined(opts.unlockType)) {
+  if (_.isUndefined(opts.unlockType) && !opts.skipUnlock) {
     await helpers.pushUnlock(adb);
   }
   return defaultIME;


### PR DESCRIPTION
This will help to save time for session init if `skipUnlock` capability is truth
