### PR TITLE
add try/catch to avoid error by pullApk in pushString

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -506,11 +506,11 @@ helpers.pushStrings = async function (language, adb, opts) {
   // clean up remote string.json if present
   await adb.rimraf(remoteFile);
 
-  let app = '';
+  let app;
   try {
     app = opts.app || await adb.pullApk(opts.appPackage, opts.tmpDir);
   } catch (err) {
-    logger.debug(`Failed to pull an apk from '${opts.appPackage}' to '${opts.tmpDir}'. Original error: ${err.message}`);
+    logger.info(`Failed to pull an apk from '${opts.appPackage}' to '${opts.tmpDir}'. Original error: ${err.message}`);
   }
 
   if (_.isEmpty(opts.appPackage) || !(await fs.exists(app))) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -506,7 +506,12 @@ helpers.pushStrings = async function (language, adb, opts) {
   // clean up remote string.json if present
   await adb.rimraf(remoteFile);
 
-  const app = opts.app || await adb.pullApk(opts.appPackage, opts.tmpDir);
+  let app = '';
+  try {
+    app = opts.app || await adb.pullApk(opts.appPackage, opts.tmpDir);
+  } catch (err) {
+    logger.debug(`Failed to pull an apk from '${opts.appPackage}' to '${opts.tmpDir}'. Original error: ${err.message}`);
+  }
 
   if (_.isEmpty(opts.appPackage) || !(await fs.exists(app))) {
     logger.debug(`No app or package specified. Returning empty strings`);

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -506,8 +506,17 @@ describe('Android Helpers', function () {
     });
   }));
   describe('pushStrings', withMocks({adb, fs}, (mocks) => {
-    const opts = {app: 'app', tmpDir: '/tmp_dir', appPackage: 'pkg'};
+    it('should return {} because of no app, no package and no app in the target device', async function () {
+      const opts = {tmpDir: '/tmp_dir', appPackage: 'pkg'};
+      mocks.adb.expects('rimraf').withExactArgs(`${REMOTE_TEMP_PATH}/strings.json`).once();
+      mocks.adb.expects('pullApk').withExactArgs(opts.appPackage, opts.tmpDir)
+        .throws(`adb: error: remote object ${opts.appPackage} does not exist`);
+      (await helpers.pushStrings('en', adb, opts)).should.be.deep.equal({});
+      mocks.adb.verify();
+      mocks.fs.verify();
+    });
     it('should extracts string.xml and converts it to string.json and pushes it', async function () {
+      const opts = {app: 'app', tmpDir: '/tmp_dir', appPackage: 'pkg'};
       mocks.adb.expects('rimraf').withExactArgs(`${REMOTE_TEMP_PATH}/strings.json`).once();
       mocks.fs.expects('exists').withExactArgs(opts.app).returns(true);
       mocks.fs.expects('rimraf').once();
@@ -518,6 +527,7 @@ describe('Android Helpers', function () {
       mocks.adb.verify();
     });
     it('should delete remote strings.json if app is not present', async function () {
+      const opts = {app: 'app', tmpDir: '/tmp_dir', appPackage: 'pkg'};
       mocks.adb.expects('rimraf').withExactArgs(`${REMOTE_TEMP_PATH}/strings.json`).once();
       mocks.fs.expects('exists').withExactArgs(opts.app).returns(false);
       (await helpers.pushStrings('en', adb, opts)).should.be.deep.equal({});
@@ -525,6 +535,7 @@ describe('Android Helpers', function () {
       mocks.fs.verify();
     });
     it('should push an empty json object if app does not have strings.xml', async function () {
+      const opts = {app: 'app', tmpDir: '/tmp_dir', appPackage: 'pkg'};
       mocks.adb.expects('rimraf').withExactArgs(`${REMOTE_TEMP_PATH}/strings.json`).once();
       mocks.fs.expects('exists').withExactArgs(opts.app).returns(true);
       mocks.fs.expects('rimraf').once();


### PR DESCRIPTION
Fix https://github.com/appium/appium/issues/11403#issuecomment-423881464

According to https://github.com/appium/appium/issues/11403#issuecomment-423881464 , `adb.pullApk` can raise an error. 

In this PR, I've added try/catch to ignore the error if `adb.pullApk` raises an error. The `app` keeps empty in the case.

I ensured this change fix the issue: https://github.com/appium/appium/issues/11403#issuecomment-423932704

---

related commit is https://github.com/appium/appium-android-driver/commit/187c66950ea430fd84704d21035c009cb4bebbc0#diff-97eeab6ebf462ba97a11ee0221ddaf13R509