### PR TITLE
Fix resource strings handling

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -497,16 +497,16 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
  *
  * @param {?string} language - Language abbreviation, for example 'fr'. The default language
  * is used if this argument is not defined.
- * @param {Object} adb - The adb mofdule instance.
+ * @param {Object} adb - The adb module instance.
  * @param {Object} opts - Driver options dictionary.
- * @returns {Object} The dictionary, where string resourtces identifiers are keys
+ * @returns {Object} The dictionary, where string resource identifiers are keys
  * along with their corresponding values for the given language or an empty object
  * if no matching resources were extracted.
  */
 helpers.pushStrings = async function (language, adb, opts) {
   const remoteDir = '/data/local/tmp';
   const stringsJson = 'strings.json';
-  const remoteFile = `${remoteDir}/${stringsJson}`;
+  const remoteFile = path.posix.resolve(remoteDir, stringsJson);
 
   // clean up remote string.json if present
   await adb.rimraf(remoteFile);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -159,16 +159,28 @@ commands.getStrings = async function (language) {
     log.info(`No language specified, returning strings for: ${language}`);
   }
 
+  // Clients require the resulting mapping to have both keys
+  // and values of type string
+  const preprocessStringsMap = (mapping) => {
+    const result = {};
+    for (const [key, value] of _.toPairs(mapping)) {
+      result[key] = _.isString(value) ? value : JSON.stringify(value);
+    }
+    return result;
+  };
+
   if (this.apkStrings[language]) {
     // Return cached strings
-    return this.apkStrings[language];
+    return preprocessStringsMap(this.apkStrings[language]);
   }
 
-  // TODO: This is mutating the current language, but it's how appium currently works
   this.apkStrings[language] = await androidHelpers.pushStrings(language, this.adb, this.opts);
-  await this.bootstrap.sendAction('updateStrings');
+  if (this.bootstrap) {
+    // TODO: This is mutating the current language, but it's how appium currently works
+    await this.bootstrap.sendAction('updateStrings');
+  }
 
-  return this.apkStrings[language];
+  return preprocessStringsMap(this.apkStrings[language]);
 };
 
 commands.launchApp = async function () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -60,15 +60,17 @@ class AndroidDriver extends BaseDriver {
     try {
       let [sessionId, caps] = await super.createSession(...args);
 
-      let serverDetails = {platform: 'LINUX',
-                           webStorageEnabled: false,
-                           takesScreenshot: true,
-                           javascriptEnabled: true,
-                           databaseEnabled: false,
-                           networkConnectionEnabled: true,
-                           locationContextEnabled: false,
-                           warnings: {},
-                           desired: this.caps};
+      let serverDetails = {
+        platform: 'LINUX',
+        webStorageEnabled: false,
+        takesScreenshot: true,
+        javascriptEnabled: true,
+        databaseEnabled: false,
+        networkConnectionEnabled: true,
+        locationContextEnabled: false,
+        warnings: {},
+        desired: this.caps
+      };
 
       this.caps = Object.assign(serverDetails, this.caps);
 
@@ -343,8 +345,10 @@ class AndroidDriver extends BaseDriver {
       await this.adb.uninstallApk(this.opts.appPackage);
     }
     await helpers.installApk(this.adb, this.opts);
-    this.apkStrings[this.opts.language] = await helpers.pushStrings(
-        this.opts.language, this.adb, this.opts);
+    const apkStringsForLanguage = await helpers.pushStrings(this.opts.language, this.adb, this.opts);
+    if (this.opts.language) {
+      this.apkStrings[this.opts.language] = apkStringsForLanguage;
+    }
 
     // This must run after installing the apk, otherwise it would cause the
     // install to fail. And before running the app.


### PR DESCRIPTION
This fixes the result of `getStrings` API call, since client libs expect `Map<String, String>` as the resulting type and we might put a list there if the particular resource value has plural options