### PR TITLE
support loggingPrefs capability for chrome sessions

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -320,7 +320,7 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
 
     // don't overwrite other logging prefs that have been sent in if they exist
     caps.loggingPrefs = caps.loggingPrefs ?
-      Object.extend({}, caps.loggingPrefs, newPref) :
+      Object.assign({}, caps.loggingPrefs, newPref) :
       newPref;
   }
   if (opts.browserName === 'chromium-webview') {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -310,8 +310,18 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
   if (opts.chromeAndroidProcess) {
     caps.chromeOptions.androidProcess = opts.chromeAndroidProcess;
   }
+  if (opts.loggingPrefs) {
+    caps.loggingPrefs = opts.loggingPrefs;
+  }
   if (opts.enablePerformanceLogging) {
-    caps.loggingPrefs = {performance: 'ALL'};
+    log.warn(`The 'enablePerformanceLogging' cap is deprecated; simply use ` +
+             `the 'loggingPrefs' cap instead, with a 'performance' key set to 'ALL'`);
+    const newPref = {performance: 'ALL'};
+
+    // don't overwrite other logging prefs that have been sent in if they exist
+    caps.loggingPrefs = caps.loggingPrefs ?
+      Object.extend({}, caps.loggingPrefs, newPref) :
+      newPref;
   }
   if (opts.browserName === 'chromium-webview') {
     caps.chromeOptions.androidActivity = opts.appActivity;


### PR DESCRIPTION
we did not previously support the `loggingPrefs` capability for chrome sessions.