### PR TITLE
Add hidden api policy

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -249,6 +249,11 @@ class AndroidDriver extends BaseDriver {
 
     if (this.opts.disableWindowAnimation) {
       if (await this.adb.isAnimationOn()) {
+        if (parseInt(this.caps.platformVersion, 10) >= 28) {
+          log.warn('Relaxing hidden api policy to manage animation scale');
+          await this.adb.setHiddenApiPolicy('1');
+        }
+
         log.info('Disabling window animation as it is requested by "disableWindowAnimation" capability');
         await this.adb.setAnimationState(false);
         this._wasWindowAnimationDisabled = true;
@@ -408,6 +413,11 @@ class AndroidDriver extends BaseDriver {
     if (this._wasWindowAnimationDisabled) {
       log.info('Restoring window animation state');
       await this.adb.setAnimationState(true);
+
+      if (parseInt(this.caps.platformVersion, 10) >= 28) {
+        log.warn('Restoring hidden api policy to the device default configuration');
+        await this.adb.setDefaultHiddenApiPolicy();
+      }
     }
     if (this.opts.reboot) {
       let avdName = this.opts.avd.replace('@', '');

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -137,6 +137,7 @@ class AndroidDriver extends BaseDriver {
         adbExecTimeout: this.opts.adbExecTimeout,
       });
 
+      // Calls adb.getApiLevel() directory since this.caps.deviceApiLevel is defined in startAndroidSession
       if (await this.adb.getApiLevel() >= 23) {
         log.warn("Consider setting 'automationName' capability to " +
           "'uiautomator2' on Android >= 6, since UIAutomator framework " +
@@ -233,13 +234,14 @@ class AndroidDriver extends BaseDriver {
     // set up the device to run on (real or emulator, etc)
     this.defaultIME = await helpers.initDevice(this.adb, this.opts);
 
-    // set actual device name, udid, platform version, screen size, model and manufacturer details
+    // set actual device name, udid, platform version, screen size, model, manufacturer details and device API level.
     this.caps.deviceName = this.adb.curDeviceId;
     this.caps.deviceUDID = this.opts.udid;
     this.caps.platformVersion = await this.adb.getPlatformVersion();
     this.caps.deviceScreenSize = await this.adb.getScreenSize();
     this.caps.deviceModel = await this.adb.getModel();
     this.caps.deviceManufacturer = await this.adb.getManufacturer();
+    this.caps.deviceApiLevel = await this.adb.getApiLevel();
 
     // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
     if (this.opts.autoLaunch) {
@@ -249,7 +251,8 @@ class AndroidDriver extends BaseDriver {
 
     if (this.opts.disableWindowAnimation) {
       if (await this.adb.isAnimationOn()) {
-        if (parseInt(this.caps.platformVersion, 10) >= 28) { // API level 28 is Android P
+        if (this.caps.deviceApiLevel >= 28) { // API level 28 is Android P
+          // Don't forget to reset the relaxing in delete session
           log.warn('Relaxing hidden api policy to manage animation scale');
           await this.adb.setHiddenApiPolicy('1');
         }
@@ -413,13 +416,12 @@ class AndroidDriver extends BaseDriver {
     if (this._wasWindowAnimationDisabled) {
       log.info('Restoring window animation state');
       await this.adb.setAnimationState(true);
-    }
 
-    // This was necessary to change animation scale over Android P
-    // Calls below everytime to keep the api policy safe for the security
-    if (parseInt(this.caps.platformVersion, 10) >= 28) {
-      log.info('Restoring hidden api policy to the device default configuration');
-      await this.adb.setDefaultHiddenApiPolicy();
+      // This was necessary to change animation scale over Android P. We must reset the policy for the security.
+      if (this.caps.deviceApiLevel >= 28) {
+        log.info('Restoring hidden api policy to the device default configuration');
+        await this.adb.setDefaultHiddenApiPolicy();
+      }
     }
 
     if (this.opts.reboot) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -249,7 +249,7 @@ class AndroidDriver extends BaseDriver {
 
     if (this.opts.disableWindowAnimation) {
       if (await this.adb.isAnimationOn()) {
-        if (parseInt(this.caps.platformVersion, 10) >= 28) {
+        if (parseInt(this.caps.platformVersion, 10) >= 28) { // API level 28 is Android P
           log.warn('Relaxing hidden api policy to manage animation scale');
           await this.adb.setHiddenApiPolicy('1');
         }
@@ -413,12 +413,15 @@ class AndroidDriver extends BaseDriver {
     if (this._wasWindowAnimationDisabled) {
       log.info('Restoring window animation state');
       await this.adb.setAnimationState(true);
-
-      if (parseInt(this.caps.platformVersion, 10) >= 28) {
-        log.warn('Restoring hidden api policy to the device default configuration');
-        await this.adb.setDefaultHiddenApiPolicy();
-      }
     }
+
+    // This was necessary to change animation scale over Android P
+    // Calls below everytime to keep the api policy safe for the security
+    if (parseInt(this.caps.platformVersion, 10) >= 28) {
+      log.info('Restoring hidden api policy to the device default configuration');
+      await this.adb.setDefaultHiddenApiPolicy();
+    }
+
     if (this.opts.reboot) {
       let avdName = this.opts.avd.replace('@', '');
       log.debug(`closing emulator '${avdName}'`);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -137,7 +137,7 @@ class AndroidDriver extends BaseDriver {
         adbExecTimeout: this.opts.adbExecTimeout,
       });
 
-      // Calls adb.getApiLevel() directory since this.caps.deviceApiLevel is defined in startAndroidSession
+      // Calls adb.getApiLevel() directly since this.caps.deviceApiLevel is defined in startAndroidSession
       if (await this.adb.getApiLevel() >= 23) {
         log.warn("Consider setting 'automationName' capability to " +
           "'uiautomator2' on Android >= 6, since UIAutomator framework " +

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -137,7 +137,6 @@ class AndroidDriver extends BaseDriver {
         adbExecTimeout: this.opts.adbExecTimeout,
       });
 
-      // Calls adb.getApiLevel() directly since this.caps.deviceApiLevel is defined in startAndroidSession
       if (await this.adb.getApiLevel() >= 23) {
         log.warn("Consider setting 'automationName' capability to " +
           "'uiautomator2' on Android >= 6, since UIAutomator framework " +
@@ -234,14 +233,13 @@ class AndroidDriver extends BaseDriver {
     // set up the device to run on (real or emulator, etc)
     this.defaultIME = await helpers.initDevice(this.adb, this.opts);
 
-    // set actual device name, udid, platform version, screen size, model, manufacturer details and device API level.
+    // set actual device name, udid, platform version, screen size, model and manufacturer details.
     this.caps.deviceName = this.adb.curDeviceId;
     this.caps.deviceUDID = this.opts.udid;
     this.caps.platformVersion = await this.adb.getPlatformVersion();
     this.caps.deviceScreenSize = await this.adb.getScreenSize();
     this.caps.deviceModel = await this.adb.getModel();
     this.caps.deviceManufacturer = await this.adb.getManufacturer();
-    this.caps.deviceApiLevel = await this.adb.getApiLevel();
 
     // If the user sets autoLaunch to false, they are responsible for initAUT() and startAUT()
     if (this.opts.autoLaunch) {
@@ -251,7 +249,7 @@ class AndroidDriver extends BaseDriver {
 
     if (this.opts.disableWindowAnimation) {
       if (await this.adb.isAnimationOn()) {
-        if (this.caps.deviceApiLevel >= 28) { // API level 28 is Android P
+        if (await this.adb.getApiLevel() >= 28) { // API level 28 is Android P
           // Don't forget to reset the relaxing in delete session
           log.warn('Relaxing hidden api policy to manage animation scale');
           await this.adb.setHiddenApiPolicy('1');
@@ -418,7 +416,7 @@ class AndroidDriver extends BaseDriver {
       await this.adb.setAnimationState(true);
 
       // This was necessary to change animation scale over Android P. We must reset the policy for the security.
-      if (this.caps.deviceApiLevel >= 28) {
+      if (await this.adb.getApiLevel() >= 28) {
         log.info('Restoring hidden api policy to the device default configuration');
         await this.adb.setDefaultHiddenApiPolicy();
       }

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -196,6 +196,8 @@ describe('driver', function () {
       sandbox.stub(driver.adb, 'stopLogcat');
       sandbox.stub(driver.bootstrap, 'shutdown');
       sandbox.spy(log, 'debug');
+      driver.caps = {};
+      driver.caps.getPlatformVersion = "28.0";
     });
     afterEach(function () {
       sandbox.restore();

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -197,6 +197,7 @@ describe('driver', function () {
       sandbox.stub(driver.adb, 'stopLogcat');
       sandbox.stub(driver.adb, 'setAnimationState');
       sandbox.stub(driver.adb, 'setDefaultHiddenApiPolicy');
+      sandbox.stub(driver.adb, 'getApiLevel').returns(27);
       sandbox.stub(driver.bootstrap, 'shutdown');
       sandbox.spy(log, 'debug');
     });
@@ -228,14 +229,14 @@ describe('driver', function () {
     });
     it('should call setAnimationState to enable it with API Level 27', async function () {
       driver._wasWindowAnimationDisabled = true;
-      driver.caps.deviceApiLevel = 27;
       await driver.deleteSession();
       driver.adb.setAnimationState.calledOnce.should.be.true;
       driver.adb.setDefaultHiddenApiPolicy.calledOnce.should.be.false;
     });
     it('should call setAnimationState to enable it with API Level 28', async function () {
       driver._wasWindowAnimationDisabled = true;
-      driver.caps.deviceApiLevel = 28;
+      driver.adb.getApiLevel.restore();
+      sandbox.stub(driver.adb, 'getApiLevel').returns(28);
       await driver.deleteSession();
       driver.adb.setAnimationState.calledOnce.should.be.true;
       driver.adb.setDefaultHiddenApiPolicy.calledOnce.should.be.true;

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -449,8 +449,6 @@ describe('driver', function () {
       driver.adb.setHiddenApiPolicy.calledOnce.should.be.false;
       driver.adb.setAnimationState.calledOnce.should.be.false;
     });
-
-
   });
   describe('startChromeSession', function () {
     beforeEach(function () {


### PR DESCRIPTION
I forgot to add below for Android P..

- It needs for changing animation scale so far since `java.lang.NoSuchMethodException: setAnimationScales [class [F]` can happen.
    - It only needs when animation scale changes
    - But considering safe, I have called `setDefaultHiddenApiPolicy` every time