### PR TITLE
ensuring disable animation

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -249,10 +249,19 @@ class AndroidDriver extends BaseDriver {
 
     if (this.opts.disableWindowAnimation) {
       if (await this.adb.isAnimationOn()) {
-        if (await this.adb.getApiLevel() >= 28) { // API level 28 is Android P
+        const apiLevel = await this.adb.getApiLevel();
+
+        if (apiLevel >= 28) { // API level 28 is Android P
           // Don't forget to reset the relaxing in delete session
           log.warn('Relaxing hidden api policy to manage animation scale');
           await this.adb.setHiddenApiPolicy('1');
+        }
+
+        // Granting android.permission.SET_ANIMATION_SCALE is necessary to handle animations under API level 26
+        // Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
+        if (apiLevel <= 26) { // API level 26 is Android 8.0.
+          log.info('Granting android.permission.SET_ANIMATION_SCALE for under API level 26 device');
+          await this.adb.grantPermission('io.appium.settings', 'android.permission.SET_ANIMATION_SCALE');
         }
 
         log.info('Disabling window animation as it is requested by "disableWindowAnimation" capability');


### PR DESCRIPTION
I found we should have called `await this.adb.grantPermission('io.appium.settings', 'android.permission.SET_ANIMATION_SCALE');` for animation scale before changing animations.
https://github.com/appium/appium/pull/11640#issuecomment-438260477

I knew the setting app was granted permissions in the installation phase.
But I observed we must grant permission with the above command before changing animations...

After this change, I ensured the animation scale changed correctly on Android 4.4.