### PR TITLE
grant animation scale permission after inistalling setting apk

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -464,10 +464,12 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
 
   await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID, 'Settings');
 
-  // Making sure granting android.permission.SET_ANIMATION_SCALE
-  // Read Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
-  logger.info('Granting android.permission.SET_ANIMATION_SCALE');
-  await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.SET_ANIMATION_SCALE');
+  if (await adb.getApiLevel() >= 23) { // Android 6+
+    // Making sure granting android.permission.SET_ANIMATION_SCALE
+    // Read Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
+    logger.info('Granting android.permission.SET_ANIMATION_SCALE');
+    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.SET_ANIMATION_SCALE');
+  }
 
   // Reinstall will stop the settings helper process anyway, so
   // there is no need to continue if the application is still running

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -473,12 +473,14 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
   }
 
   if (await adb.getApiLevel() < 23) { // Android 6- devices should granted permissions
-    // Making sure granting android.permission.SET_ANIMATION_SCALE
-    // Read Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
+    // Making sure granting permissions
+    // Read https://github.com/appium/appium/pull/11640#issuecomment-438260477 for more details
     logger.info('Granting android.permission.SET_ANIMATION_SCALE, CHANGE_CONFIGURATION, ACCESS_FINE_LOCATION by pm grant');
-    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.SET_ANIMATION_SCALE');
-    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.CHANGE_CONFIGURATION');
-    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.ACCESS_FINE_LOCATION');
+    await adb.grantPermissions(SETTINGS_HELPER_PKG_ID, [
+      'android.permission.SET_ANIMATION_SCALE',
+      'android.permission.CHANGE_CONFIGURATION',
+      'android.permission.ACCESS_FINE_LOCATION'
+    ]);
   }
 
   // launch io.appium.settings app due to settings failing to be set

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -464,6 +464,11 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
 
   await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID, 'Settings');
 
+  // Making sure granting android.permission.SET_ANIMATION_SCALE
+  // Read Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
+  logger.info('Granting android.permission.SET_ANIMATION_SCALE');
+  await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.SET_ANIMATION_SCALE');
+
   // Reinstall will stop the settings helper process anyway, so
   // there is no need to continue if the application is still running
   if (await adb.processExists(SETTINGS_HELPER_PKG_ID)) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -464,19 +464,21 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
 
   await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID, 'Settings');
 
-  if (await adb.getApiLevel() >= 23) { // Android 6+
-    // Making sure granting android.permission.SET_ANIMATION_SCALE
-    // Read Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
-    logger.info('Granting android.permission.SET_ANIMATION_SCALE');
-    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.SET_ANIMATION_SCALE');
-  }
-
   // Reinstall will stop the settings helper process anyway, so
   // there is no need to continue if the application is still running
   if (await adb.processExists(SETTINGS_HELPER_PKG_ID)) {
     logger.debug(`${SETTINGS_HELPER_PKG_ID} is already running. ` +
       `There is no need to reset its permissions.`);
     return;
+  }
+
+  if (await adb.getApiLevel() < 23) { // Android 6- devices should granted permissions
+    // Making sure granting android.permission.SET_ANIMATION_SCALE
+    // Read Read https://github.com/appium/appium/pull/11640#issuecomment-438260477
+    logger.info('Granting android.permission.SET_ANIMATION_SCALE, CHANGE_CONFIGURATION, ACCESS_FINE_LOCATION by pm grant');
+    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.SET_ANIMATION_SCALE');
+    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.CHANGE_CONFIGURATION');
+    await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.ACCESS_FINE_LOCATION');
   }
 
   // lauch io.appium.settings app due to settings failing to be set

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -481,7 +481,7 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
     await adb.grantPermission(SETTINGS_HELPER_PKG_ID, 'android.permission.ACCESS_FINE_LOCATION');
   }
 
-  // lauch io.appium.settings app due to settings failing to be set
+  // launch io.appium.settings app due to settings failing to be set
   // if the app is not launched prior to start the session on android 7+
   // see https://github.com/appium/appium/issues/8957
   try {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -472,9 +472,8 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
     return;
   }
 
-  if (await adb.getApiLevel() < 23) { // Android 6- devices should granted permissions
-    // Making sure granting permissions
-    // Read https://github.com/appium/appium/pull/11640#issuecomment-438260477 for more details
+  if (await adb.getApiLevel() < 23) { // Android 6- devices should have granted permissions
+    // https://github.com/appium/appium/pull/11640#issuecomment-438260477
     logger.info('Granting android.permission.SET_ANIMATION_SCALE, CHANGE_CONFIGURATION, ACCESS_FINE_LOCATION by pm grant');
     await adb.grantPermissions(SETTINGS_HELPER_PKG_ID, [
       'android.permission.SET_ANIMATION_SCALE',

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^6.25.0",
+    "appium-adb": "^6.27.0",
     "appium-base-driver": "^3.0.0",
     "appium-chromedriver": "^4.0.0",
     "appium-support": "^2.24.1",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -496,7 +496,7 @@ describe('Android Helpers', function () {
         .withExactArgs('io.appium.settings').once()
         .returns(true);
       mocks.adb.expects('getApiLevel').never();
-      mocks.adb.expects('grantPermission').never();
+      mocks.adb.expects('grantPermissions').never();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });
@@ -507,7 +507,7 @@ describe('Android Helpers', function () {
         .withExactArgs('io.appium.settings').once()
         .returns(true);
       mocks.adb.expects('getApiLevel').never();
-      mocks.adb.expects('grantPermission').never();
+      mocks.adb.expects('grantPermissions').never();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });
@@ -530,14 +530,9 @@ describe('Android Helpers', function () {
         .returns(false);
       mocks.adb.expects('getApiLevel').once()
         .returns(22);
-      mocks.adb.expects('grantPermission').once()
-        .withExactArgs('io.appium.settings', 'android.permission.SET_ANIMATION_SCALE')
-        .returns(true);
-      mocks.adb.expects('grantPermission').once()
-        .withExactArgs('io.appium.settings', 'android.permission.CHANGE_CONFIGURATION')
-        .returns(true);
-      mocks.adb.expects('grantPermission').once()
-        .withExactArgs('io.appium.settings', 'android.permission.ACCESS_FINE_LOCATION')
+      mocks.adb.expects('grantPermissions').once()
+        .withExactArgs('io.appium.settings',
+          ['android.permission.SET_ANIMATION_SCALE', 'android.permission.CHANGE_CONFIGURATION', 'android.permission.ACCESS_FINE_LOCATION'])
         .returns(true);
       mocks.adb.expects('startApp').once();
       await helpers.pushSettingsApp(adb);

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -489,20 +489,56 @@ describe('Android Helpers', function () {
     });
   }));
   describe('pushSettingsApp', withMocks({adb}, (mocks) => {
-    it('should skip granting permissions if the app is already running', async function () {
+    it('should skip granting permissions if the app is already running on over API level 23+ devices', async function () {
       mocks.adb.expects('installOrUpgrade').once()
         .returns(true);
       mocks.adb.expects('processExists')
-          .withExactArgs('io.appium.settings').once()
-          .returns(true);
+        .withExactArgs('io.appium.settings').once()
+        .returns(true);
+      mocks.adb.expects('getApiLevel').never();
+      mocks.adb.expects('grantPermission').never();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });
-    it('should launch settings app if it isnt running', async function () {
+    it('should not skip granting permissions if the app is already running on under API level 22 devices', async function () {
+      mocks.adb.expects('installOrUpgrade').once()
+        .returns(true);
+      mocks.adb.expects('processExists')
+        .withExactArgs('io.appium.settings').once()
+        .returns(true);
+      mocks.adb.expects('getApiLevel').never();
+      mocks.adb.expects('grantPermission').never();
+      await helpers.pushSettingsApp(adb);
+      mocks.adb.verify();
+    });
+    it('should launch settings app if it isnt running on over API level 23+ devices', async function () {
       mocks.adb.expects('installOrUpgrade').once()
         .returns(true);
       mocks.adb.expects('processExists').once()
         .returns(false);
+      mocks.adb.expects('getApiLevel').once()
+        .returns(23);
+      mocks.adb.expects('startApp').once();
+      await helpers.pushSettingsApp(adb);
+      mocks.adb.verify();
+    });
+
+    it('should launch settings app if it isnt running on under API level 22 devices', async function () {
+      mocks.adb.expects('installOrUpgrade').once()
+        .returns(true);
+      mocks.adb.expects('processExists').once()
+        .returns(false);
+      mocks.adb.expects('getApiLevel').once()
+        .returns(22);
+      mocks.adb.expects('grantPermission').once()
+        .withExactArgs('io.appium.settings', 'android.permission.SET_ANIMATION_SCALE')
+        .returns(true);
+      mocks.adb.expects('grantPermission').once()
+        .withExactArgs('io.appium.settings', 'android.permission.CHANGE_CONFIGURATION')
+        .returns(true);
+      mocks.adb.expects('grantPermission').once()
+        .withExactArgs('io.appium.settings', 'android.permission.ACCESS_FINE_LOCATION')
+        .returns(true);
       mocks.adb.expects('startApp').once();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();


### PR DESCRIPTION
Maybe, this way is simpler than _ensuring disable animation #464_ since this change fixes the animation issue in espresso-driver as well.

----

copy from #464 

I found we should have called `await this.adb.grantPermission('io.appium.settings', 'android.permission.SET_ANIMATION_SCALE');` for animation scale before changing animations.
https://github.com/appium/appium/pull/11640#issuecomment-438260477

I knew the setting app was granted permissions in the installation phase.
But I observed we must grant permission with the above command before changing animations...

After this change, I ensured the animation scale changed correctly on Android 4.4.