### PR TITLE
include 23 to grant permissions for setting app

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -472,7 +472,7 @@ helpers.pushSettingsApp = async function (adb, throwError = false) {
     return;
   }
 
-  if (await adb.getApiLevel() < 23) { // Android 6- devices should have granted permissions
+  if (await adb.getApiLevel() <= 23) { // Android 6- devices should have granted permissions
     // https://github.com/appium/appium/pull/11640#issuecomment-438260477
     logger.info('Granting android.permission.SET_ANIMATION_SCALE, CHANGE_CONFIGURATION, ACCESS_FINE_LOCATION by pm grant');
     await adb.grantPermissions(SETTINGS_HELPER_PKG_ID, [

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -511,25 +511,25 @@ describe('Android Helpers', function () {
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });
-    it('should launch settings app if it isnt running on over API level 23+ devices', async function () {
+    it('should launch settings app if it isnt running on over API level 24 devices', async function () {
+      mocks.adb.expects('installOrUpgrade').once()
+        .returns(true);
+      mocks.adb.expects('processExists').once()
+        .returns(false);
+      mocks.adb.expects('getApiLevel').once()
+        .returns(24);
+      mocks.adb.expects('startApp').once();
+      await helpers.pushSettingsApp(adb);
+      mocks.adb.verify();
+    });
+
+    it('should launch settings app if it isnt running on under API level 23 devices', async function () {
       mocks.adb.expects('installOrUpgrade').once()
         .returns(true);
       mocks.adb.expects('processExists').once()
         .returns(false);
       mocks.adb.expects('getApiLevel').once()
         .returns(23);
-      mocks.adb.expects('startApp').once();
-      await helpers.pushSettingsApp(adb);
-      mocks.adb.verify();
-    });
-
-    it('should launch settings app if it isnt running on under API level 22 devices', async function () {
-      mocks.adb.expects('installOrUpgrade').once()
-        .returns(true);
-      mocks.adb.expects('processExists').once()
-        .returns(false);
-      mocks.adb.expects('getApiLevel').once()
-        .returns(22);
       mocks.adb.expects('grantPermissions').once()
         .withExactArgs('io.appium.settings',
           ['android.permission.SET_ANIMATION_SCALE', 'android.permission.CHANGE_CONFIGURATION', 'android.permission.ACCESS_FINE_LOCATION'])


### PR DESCRIPTION
I noticed this should have included API level 23 when I ran API level 23 emulator on my local...
https://github.com/appium/appium/pull/11640#issuecomment-438260477