### PR TITLE
Calls helpers.ensureDeviceLocale if the opts has either language or locale

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -635,7 +635,9 @@ helpers.initDevice = async function (adb, opts) {
     await helpers.setMockLocationApp(adb, SETTINGS_HELPER_PKG_ID);
   }
 
-  await helpers.ensureDeviceLocale(adb, opts.language, opts.locale, opts.localeScript);
+  if (opts.language || opts.locale) {
+    await helpers.ensureDeviceLocale(adb, opts.language, opts.locale, opts.localeScript);
+  }
   await adb.startLogcat();
   if (opts.unicodeKeyboard) {
     return await helpers.initUnicodeKeyboard(adb);

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -673,12 +673,34 @@ describe('Android Helpers', function () {
       mocks.helpers.verify();
       mocks.adb.verify();
     });
+    it('should init device without locale and language', async function () {
+      const opts = {};
+      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('startLogcat').once();
+      mocks.helpers.expects('pushSettingsApp').once();
+      mocks.helpers.expects('ensureDeviceLocale').never();
+      mocks.helpers.expects('setMockLocationApp').withExactArgs(adb, 'io.appium.settings').once();
+      await helpers.initDevice(adb, opts);
+      mocks.helpers.verify();
+      mocks.adb.verify();
+    });
+    it('should init device with either locale or language', async function () {
+      const opts = {language: "en"};
+      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('startLogcat').once();
+      mocks.helpers.expects('pushSettingsApp').once();
+      mocks.helpers.expects('ensureDeviceLocale').withExactArgs(adb, opts.language, opts.locale, opts.localeScript).once();
+      mocks.helpers.expects('setMockLocationApp').withExactArgs(adb, 'io.appium.settings').once();
+      await helpers.initDevice(adb, opts);
+      mocks.helpers.verify();
+      mocks.adb.verify();
+    });
     it('should not install mock location on emulator', async function () {
       const opts = {avd: "avd"};
       mocks.adb.expects('waitForDevice').once();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
-      mocks.helpers.expects('ensureDeviceLocale').withArgs(adb).once();
+      mocks.helpers.expects('ensureDeviceLocale').never();
       mocks.helpers.expects('setMockLocationApp').never();
       await helpers.initDevice(adb, opts);
       mocks.helpers.verify();
@@ -689,7 +711,7 @@ describe('Android Helpers', function () {
       mocks.adb.expects('waitForDevice').once();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
-      mocks.helpers.expects('ensureDeviceLocale').once();
+      mocks.helpers.expects('ensureDeviceLocale').never();
       mocks.helpers.expects('setMockLocationApp').once();
       mocks.helpers.expects('initUnicodeKeyboard').withExactArgs(adb).once().returns("defaultIME");
       await helpers.initDevice(adb, opts).should.become("defaultIME");
@@ -701,7 +723,7 @@ describe('Android Helpers', function () {
       mocks.adb.expects('waitForDevice').once();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
-      mocks.helpers.expects('ensureDeviceLocale').once();
+      mocks.helpers.expects('ensureDeviceLocale').never();
       mocks.helpers.expects('setMockLocationApp').once();
       mocks.helpers.expects('initUnicodeKeyboard').never();
       should.not.exist(await helpers.initDevice(adb, opts));
@@ -713,7 +735,7 @@ describe('Android Helpers', function () {
       mocks.adb.expects('waitForDevice').once();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
-      mocks.helpers.expects('ensureDeviceLocale').once();
+      mocks.helpers.expects('ensureDeviceLocale').never();
       mocks.helpers.expects('setMockLocationApp').once();
       mocks.helpers.expects('initUnicodeKeyboard').never();
       await helpers.initDevice(adb, opts);


### PR DESCRIPTION
https://appium.slack.com/archives/C02956V3H/p1543739923001400

`language` or `locale` is mandatory. `localeScript` is option.
We can reduce warning messages for no `language` and no `locale` case.