### PR TITLE
Do not consider app as temporary if relative app path is provided

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -152,7 +152,8 @@ class AndroidDriver extends BaseDriver {
       if (this.opts.app) {
         // find and copy, or download and unzip an app url or path
         this.opts.app = await this.helpers.configureApp(this.opts.app, APP_EXTENSION);
-        this.opts.appIsTemp = caps.app !== this.opts.app; // did we make a temporary copy?
+        this.opts.appIsTemp = this.opts.app && await fs.exists(this.opts.app)
+          && !await util.isSameDestination(caps.app, this.opts.app);
         await this.checkAppPresent();
       } else if (this.appOnDevice) {
         // the app isn't an actual app file but rather something we want to

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "appium-adb": "^6.27.0",
     "appium-base-driver": "^3.0.0",
     "appium-chromedriver": "^4.8.0",
-    "appium-support": "^2.24.1",
+    "appium-support": "^2.25.0",
     "asyncbox": "^2.0.4",
     "bluebird": "^3.4.7",
     "io.appium.settings": "^2.10.0",


### PR DESCRIPTION
The same fix as for https://github.com/appium/appium-xcuitest-driver/pull/841