### PR TITLE
Introduce skipDeviceInitialization capability

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -632,16 +632,16 @@ helpers.initDevice = async function (adb, opts) {
     logger.info(`'skipDeviceInitialization' is set. Skipping device initialization.`);
   } else {
     await adb.waitForDevice();
-
     // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+
     await helpers.pushSettingsApp(adb);
-    if (!opts.avd) {
-      await helpers.setMockLocationApp(adb, SETTINGS_HELPER_PKG_ID);
-    }
+  }
 
-    if (opts.language || opts.locale) {
-      await helpers.ensureDeviceLocale(adb, opts.language, opts.locale, opts.localeScript);
-    }
+  if (!opts.avd) {
+    await helpers.setMockLocationApp(adb, SETTINGS_HELPER_PKG_ID);
+  }
+
+  if (opts.language || opts.locale) {
+    await helpers.ensureDeviceLocale(adb, opts.language, opts.locale, opts.localeScript);
   }
 
   await adb.startLogcat();

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -628,7 +628,12 @@ helpers.verifyUnlock = async function (adb) {
 };
 
 helpers.initDevice = async function (adb, opts) {
+  if (opts.skipDeviceInitialization) {
+    logger.info(`'skipDeviceInitialization' is set. Skipping device initialization.`);
+    return await adb.defaultIME();
+  }
   await adb.waitForDevice();
+
   // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+
   await helpers.pushSettingsApp(adb);
   if (!opts.avd) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -630,19 +630,20 @@ helpers.verifyUnlock = async function (adb) {
 helpers.initDevice = async function (adb, opts) {
   if (opts.skipDeviceInitialization) {
     logger.info(`'skipDeviceInitialization' is set. Skipping device initialization.`);
-    return await adb.defaultIME();
-  }
-  await adb.waitForDevice();
+  } else {
+    await adb.waitForDevice();
 
-  // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+
-  await helpers.pushSettingsApp(adb);
-  if (!opts.avd) {
-    await helpers.setMockLocationApp(adb, SETTINGS_HELPER_PKG_ID);
+    // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+
+    await helpers.pushSettingsApp(adb);
+    if (!opts.avd) {
+      await helpers.setMockLocationApp(adb, SETTINGS_HELPER_PKG_ID);
+    }
+
+    if (opts.language || opts.locale) {
+      await helpers.ensureDeviceLocale(adb, opts.language, opts.locale, opts.localeScript);
+    }
   }
 
-  if (opts.language || opts.locale) {
-    await helpers.ensureDeviceLocale(adb, opts.language, opts.locale, opts.localeScript);
-  }
   await adb.startLogcat();
   if (opts.unicodeKeyboard) {
     return await helpers.initUnicodeKeyboard(adb);

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -181,6 +181,9 @@ let commonCapConstraints = {
   localeScript: {
     isString: true
   },
+  skipDeviceInitialization: {
+    isBoolean: true
+  }
 };
 
 let uiautomatorCapConstraints = {


### PR DESCRIPTION
New capability is introduced, which is named 'skipDeviceInitialization' to allow user for omitting phase of device initialization (waiting for device, pushing settings app, permissions). It allows to improve startup performance when device was already used for tests and all required things was setup. 