### PR TITLE
Move keyboard tests earlier in the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ env:
     - TEST=unit RECURSIVE=--recursive START_EMU=0
     - TEST=functional
     - TEST=functional/bootstrap
-    - TEST=functional/commands
     - TEST=functional/commands/keyboard
+    - TEST=functional/commands
     - TEST=functional/commands/basic
     - TEST=functional/commands/find
     - TEST=functional/commands/touch

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ env:
     - TEST=functional
     - TEST=functional/bootstrap
     - TEST=functional/commands
+    - TEST=functional/commands/keyboard
     - TEST=functional/commands/basic
     - TEST=functional/commands/find
-    - TEST=functional/commands/keyboard
     - TEST=functional/commands/touch
 before_script:
   # node stuff


### PR DESCRIPTION
The current order always ends with the keyboard tests running alone. Move them earlier to maximize parallel running.