### PR TITLE
Update java version retrieval logic

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -53,7 +53,6 @@ helpers.createBaseADB = async function (opts = {}) {
   // filter out any unwanted options sent in
   // this list should be updated as ADB takes more arguments
   const {
-    javaVersion,
     adbPort,
     suppressKillServer,
     remoteAdbHost,
@@ -66,7 +65,6 @@ helpers.createBaseADB = async function (opts = {}) {
     keyPassword,
   } = opts;
   return await ADB.createADB({
-    javaVersion,
     adbPort,
     suppressKillServer,
     remoteAdbHost,
@@ -80,26 +78,21 @@ helpers.createBaseADB = async function (opts = {}) {
   });
 };
 
-helpers.parseJavaVersion = function (stderr) {
-  let lines = stderr.split('\n');
-  for (let line of lines) {
-    if (new RegExp(/(java|openjdk) version/).test(line)) {
-      return line.split(' ')[2].replace(/"/g, '');
-    }
-  }
-  return null;
-};
-
 helpers.getJavaVersion = async function (logVersion = true) {
-  let {stderr} = await exec('java', ['-version']);
-  let javaVer = helpers.parseJavaVersion(stderr);
-  if (javaVer === null) {
-    throw new Error('Could not get the Java version. Is Java installed?');
+  let stderr;
+  try {
+    ({stderr} = await exec('java', ['-version']));
+  } catch (e) {
+    throw new Error(`Could not get the Java version. Is Java installed? Original error: ${e.stderr}`);
+  }
+  const versionMatch = /(java|openjdk)\s+version.+?([0-9._]+)/i.exec(stderr);
+  if (!versionMatch) {
+    throw new Error(`Could not parse Java version. Is Java installed? Original output: ${stderr}`);
   }
   if (logVersion) {
-    logger.info(`Java version is: ${javaVer}`);
+    logger.info(`Java version is: ${versionMatch[2]}`);
   }
-  return javaVer;
+  return versionMatch[2];
 };
 
 helpers.prepareEmulator = async function (adb, opts) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -87,9 +87,6 @@ class AndroidDriver extends BaseDriver {
         androidInstallTimeout: 90000,
       };
       _.defaults(this.opts, defaultOpts);
-      if (!this.opts.javaVersion) {
-        this.opts.javaVersion = await helpers.getJavaVersion();
-      }
       this.useUnlockHelperApp = _.isUndefined(this.caps.unlockType);
 
       // not user visible via caps
@@ -127,7 +124,6 @@ class AndroidDriver extends BaseDriver {
 
       // set up an instance of ADB
       this.adb = await helpers.createADB({
-        javaVersion: this.opts.javaVersion,
         udid: this.opts.udid,
         emPort: this.opts.emPort,
         adbPort: this.opts.adbPort,

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -18,19 +18,6 @@ chai.use(chaiAsPromised);
 
 describe('Android Helpers', function () {
   let adb = new ADB();
-  describe('parseJavaVersion', function () {
-    it('should correctly parse java version', function () {
-      helpers.parseJavaVersion(`java version "1.8.0_40"
-        Java(TM) SE Runtime Environment (build 1.8.0_40-b27)`).should
-        .be.equal('1.8.0_40');
-    });
-    it('should return null if it cannot parse java verstion', function () {
-      should.not.exist(helpers.parseJavaVersion('foo bar'));
-    });
-    it('should parse OpenJDK versioning', function () {
-      helpers.parseJavaVersion('openjdk version 1.8').should.be.equal('1.8');
-    });
-  });
 
   describe('getJavaVersion', withMocks({teen_process}, (mocks) => {
     it('should correctly get java version', async function () {
@@ -39,7 +26,7 @@ describe('Android Helpers', function () {
       (await helpers.getJavaVersion()).should.equal('1.8.0_40');
       mocks.teen_process.verify();
     });
-    it('should return null if it cannot parse java verstion', async function () {
+    it('should throw if cannot parse java verstion', async function () {
       mocks.teen_process.expects('exec').withExactArgs('java', ['-version'])
         .returns({stderr: 'foo bar'});
       await helpers.getJavaVersion().should.eventually.be.rejectedWith('Java');

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -261,7 +261,6 @@ describe('Android Helpers', function () {
     });
     it('should create adb and set device id and emulator port', async function () {
       await helpers.createADB({
-        javaVersion: '1.7',
         udid: '111222',
         emPort: '111',
         adbPort: '222',
@@ -276,7 +275,6 @@ describe('Android Helpers', function () {
         keyPassword: 'keyPassword',
       });
       ADB.createADB.calledWithExactly({
-        javaVersion: '1.7',
         adbPort: '222',
         suppressKillServer: true,
         remoteAdbHost: 'remote_host',

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -129,10 +129,6 @@ describe('driver', function () {
       driver.opts.udid = '01234567889';
       driver.isEmulator().should.equal(false);
     });
-    it('should get java version if none is provided', async function () {
-      await driver.createSession({platformName: 'Android', deviceName: 'device', app: '/path/to/some.apk'});
-      driver.opts.javaVersion.should.exist;
-    });
     it('should get browser package details if browserName is provided', async function () {
       sandbox.spy(helpers, 'getChromePkg');
       await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'Chrome'});

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -150,15 +150,6 @@ describe('driver', function () {
       await driver.createSession({platformName: 'Android', deviceName: 'device', appPackage: 'some.app.package'});
       driver.caps.webStorageEnabled.should.exist;
     });
-    it('should delete a session on failure', async function () {
-      // Force an error to make sure deleteSession gets called
-      sandbox.stub(helpers, 'getJavaVersion').throws();
-      sandbox.stub(driver, 'deleteSession');
-      try {
-        await driver.createSession({platformName: 'Android', deviceName: 'device', appPackage: 'some.app.package'});
-      } catch (ign) {}
-      driver.deleteSession.calledOnce.should.be.true;
-    });
     it('should pass along adbPort capability to ADB', async function () {
       await driver.createSession({platformName: 'Android', deviceName: 'device', appPackage: 'some.app.package', adbPort: 1111});
       driver.adb.adbPort.should.equal(1111);


### PR DESCRIPTION
It turns out that `javaVersion` ADB argument is not used anywhere in that module. So there is no need to have this call in depending drivers.