### PR TITLE
Avoid throwing an error if Appium Settings fails to provide geolocation values

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -126,7 +126,17 @@ commands.toggleFlightMode = async function () {
 
 commands.setGeoLocation = async function (location) {
   await this.adb.setGeoLocation(location, this.isEmulator());
-  return await this.getGeoLocation();
+  try {
+    return await this.getGeoLocation();
+  } catch (e) {
+    log.warn(`Could not get the current geolocation info: ${e.message}`);
+    log.warn(`Returning the default zero'ed values`);
+    return {
+      latitude: 0.0,
+      longitude: 0.0,
+      altitude: 0.0,
+    };
+  }
 };
 
 commands.getGeoLocation = async function () {


### PR DESCRIPTION
Geolocation providers require some time to get the actual info. Also, one doesn't always care about getting the current geolocation value geolocation is being set.