### PR TITLE
Do not apply implicit wait if looking for multiple elements

### DIFF
--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -23,7 +23,7 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
     throw new Error('Must provide a selector when finding elements');
   }
 
-  let params = {
+  const params = {
     strategy,
     selector,
     context,
@@ -31,7 +31,7 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
   };
 
   let element;
-  let doFind = async () => {
+  const doFind = async () => {
     try {
       element = await this.doFindElementOrEls(params);
     } catch (err) {
@@ -56,20 +56,17 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
     return !_.isEmpty(element);
   };
 
+  if (mult) {
+    // Do not apply implicit wait if looking for multiple elements
+    return await doFind();
+  }
+
   try {
     await this.implicitWaitForCondition(doFind);
   } catch (err) {
-    if (err.message && err.message.match(/Condition unmet/)) {
-      // only get here if we are looking for multiple elements
-      // condition was not met setting res to empty array
-      element = [];
-    } else {
+    if (!(err.message && err.message.match(/Condition unmet/))) {
       throw err;
     }
-  }
-
-  if (mult) {
-    return element;
   }
   if (_.isEmpty(element)) {
     throw new errors.NoSuchElementError();

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -32,7 +32,7 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
 
   if (mult) {
     // Do not apply implicit wait if looking for multiple elements
-    return await this.doFindElementOrEls(params);
+    return (await this.doFindElementOrEls(params) || []);
   }
 
   let element;

--- a/lib/commands/find.js
+++ b/lib/commands/find.js
@@ -30,6 +30,11 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
     multiple: mult
   };
 
+  if (mult) {
+    // Do not apply implicit wait if looking for multiple elements
+    return await this.doFindElementOrEls(params);
+  }
+
   let element;
   const doFind = async () => {
     try {
@@ -55,12 +60,6 @@ helpers.findElOrEls = async function (strategy, selector, mult, context = '') {
     // we want to return false if we want to potentially try again
     return !_.isEmpty(element);
   };
-
-  if (mult) {
-    // Do not apply implicit wait if looking for multiple elements
-    return await doFind();
-  }
-
   try {
     await this.implicitWaitForCondition(doFind);
   } catch (err) {

--- a/test/functional/commands/actions-e2e-specs.js
+++ b/test/functional/commands/actions-e2e-specs.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import AndroidDriver from '../../..';
 import _ from 'lodash';
+import { retryInterval } from 'asyncbox';
 import DEFAULT_CAPS from '../desired';
 
 
@@ -31,8 +32,11 @@ describe('actions', function () {
     it('should replace existing value in a text field', async function () {
       this.retries(4);
 
-      let el = _.last(await driver.findElements('class name', 'android.widget.EditText'));
-      el.should.exist;
+      let el;
+      await retryInterval(3, 1000, async () => {
+        el = _.last(await driver.findElements('class name', 'android.widget.EditText'));
+        el.should.exist;
+      });
       await driver.setValue('original value', el.ELEMENT);
       await driver.getText(el.ELEMENT).should.eventually.equal('original value');
 

--- a/test/functional/commands/find/find-basic-e2e-specs.js
+++ b/test/functional/commands/find/find-basic-e2e-specs.js
@@ -79,13 +79,12 @@ describe('Find - basic', function () {
     before(async function () {
       await driver.implicitWait(implicitWait);
     });
-    it('should respect implicit wait with multiple elements', async function () {
+    it('should not respect implicit wait with multiple elements', async function () {
       let beforeMs = Date.now();
       await driver.findElements('id', 'there_is_nothing_called_this')
         .should.eventually.have.length(0);
       let afterMs = Date.now();
-      (afterMs - beforeMs).should.be.below(implicitWait + 5000);
-      (afterMs - beforeMs).should.be.above(implicitWait);
+      (afterMs - beforeMs).should.be.below(implicitWait);
     });
     it('should respect implicit wait with a single element', async function () {
       let beforeMs = Date.now();


### PR DESCRIPTION
WebDrivers also don't not do this in browsers for a reason. Also, multiple elements lookup is used to verify that an element is NOT present on screen, which might create significant delays with the previous implementation if implicit wait is defined.