### PR TITLE
stop chromedriver proxies when reset command is called. fixes #12083

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -3,6 +3,7 @@ import log from '../logger';
 import Chromedriver from 'appium-chromedriver';
 import PortFinder from 'portfinder';
 import B from 'bluebird';
+import { util } from 'appium-support';
 import { errors } from 'appium-base-driver';
 import { default as webviewHelpers,
          NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN } from '../webview-helpers';
@@ -37,20 +38,21 @@ commands.getContexts = async function () {
 };
 
 commands.setContext = async function (name) {
-  if (name === null) {
+  if (!util.hasValue(name)) {
     name = this.defaultContextName();
   } else if (name === WEBVIEW_WIN) {
     // handle setContext "WEBVIEW"
     name = this.defaultWebviewName();
   }
+  // if we're already in the context we want, do nothing
+  if (name === this.curContext) {
+    return;
+  }
+
   let contexts = await this.getContexts();
   // if the context we want doesn't exist, fail
   if (!_.includes(contexts, name)) {
     throw new errors.NoSuchContextError();
-  }
-  // if we're already in the context we want, do nothing
-  if (name === this.curContext) {
-    return;
   }
 
   await this.switchContext(name);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -3,7 +3,6 @@ import androidHelpers from '../android-helpers';
 import { util } from 'appium-support';
 import B from 'bluebird';
 import log from '../logger';
-import { NATIVE_WIN } from '../webview-helpers';
 import moment from 'moment';
 import { waitForCondition } from 'asyncbox';
 
@@ -227,8 +226,7 @@ commands.startActivity = async function (appPackage, appActivity,
 commands.reset = async function () {
   await androidHelpers.resetApp(this.adb, Object.assign({}, this.opts, {fastReset: true}));
   // reset context since we don't know what kind on context we will end up after app launch.
-  this.curContext = NATIVE_WIN;
-
+  await this.setContext();
   return await this.isChromeSession ? this.startChromeSession() : this.startAUT();
 };
 
@@ -258,8 +256,7 @@ commands.setUrl = async function (uri) {
 commands.closeApp = async function () {
   await this.adb.forceStop(this.opts.appPackage);
   // reset context since we don't know what kind on context we will end up after app launch.
-  this.curContext = NATIVE_WIN;
-  await this.stopChromedriverProxies();
+  await this.setContext();
 };
 
 commands.getDisplayDensity = async function () {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -51,6 +51,9 @@ class AndroidDriver extends BaseDriver {
     for (let [cmd, fn] of _.toPairs(commands)) {
       AndroidDriver.prototype[cmd] = fn;
     }
+
+    // needs to be after the line which assigns commands to AndroidDriver.prototype, so that `this.defaultContextName` is defined.
+    this.curContext = this.defaultContextName();
   }
 
   async createSession (...args) {
@@ -98,8 +101,6 @@ class AndroidDriver extends BaseDriver {
       }
       this.opts.fastReset = !this.opts.fullReset && !this.opts.noReset;
       this.opts.skipUninstall = this.opts.fastReset || this.opts.noReset;
-
-      this.curContext = this.defaultContextName();
 
       if (this.isChromeSession) {
         log.info("We're going to run a Chrome-based session");


### PR DESCRIPTION
The same exact command is already being called on `closeApp`: https://github.com/appium/appium-android-driver/blob/master/lib/commands/general.js#L262

A side note: should both of these commands respect the `recreateChromeDriverSessions` desired capability? Then we should call `suspendChromedriverProxy` instead of `stopChromedriverProxies` like here:
https://github.com/appium/appium-android-driver/blob/master/lib/commands/context.js#L71