### PR TITLE
screen off before wake up to clean text field, avoid no element crash

### DIFF
--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -8,9 +8,9 @@ const PASSWORD_UNLOCK = 'password';
 const PATTERN_UNLOCK = 'pattern';
 const FINGERPRINT_UNLOCK = 'fingerprint';
 const UNLOCK_TYPES = [PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK];
-const KEYCODE_NUMPAD_ENTER = '66';
-const KEYCODE_POWER = '26';
-const KEYCODE_WAKEUP = '224'; // Can work over API Level 20
+const KEYCODE_NUMPAD_ENTER = 66;
+const KEYCODE_POWER = 26;
+const KEYCODE_WAKEUP = 224; // Can work over API Level 20
 const UNLOCK_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
 const INPUT_KEYS_WAIT_TIME = 100;
@@ -122,7 +122,8 @@ helpers.pinUnlock = async function (adb, driver, capabilities) {
       await driver.click(util.unwrapElement(el));
     }
   }
-  // Some devices accept the entered key automatically
+  // Some devices accept the entered key without enter key.
+  // When I rushed commands without this wait before pressKeyCode, rarely UI2 sever crashed.
   await sleep(UNLOCK_WAIT_TIME);
   if (await adb.isScreenLocked()) {
     await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -122,8 +122,8 @@ helpers.pinUnlock = async function (adb, driver, capabilities) {
       await driver.click(util.unwrapElement(el));
     }
   }
-  // Some devices accept the entered key without enter key.
-  // When I rushed commands without this wait before pressKeyCode, rarely UI2 sever crashed.
+  // Some devices accept entering the code without pressing the Enter key
+  // When I rushed commands without this wait before pressKeyCode, rarely UI2 sever crashed
   await sleep(UNLOCK_WAIT_TIME);
   if (await adb.isScreenLocked()) {
     await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -9,6 +9,8 @@ const PATTERN_UNLOCK = 'pattern';
 const FINGERPRINT_UNLOCK = 'fingerprint';
 const UNLOCK_TYPES = [PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK];
 const KEYCODE_NUMPAD_ENTER = '66';
+const KEYCODE_POWER = '26';
+const KEYCODE_WAKEUP = '224'; // Can work over API Level 20
 const UNLOCK_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
 const INPUT_KEYS_WAIT_TIME = 100;
@@ -41,7 +43,10 @@ helpers.isValidKey = function (type, key) {
 
 helpers.dismissKeyguard = async function (driver, adb) {
   logger.info('Waking up the device to unlock it');
-  await adb.keyevent('224');
+  // Screen off once to force pre-inputted text field clean after wake-up
+  // Just screen on if the screen defaults off
+  await driver.pressKeyCode(KEYCODE_POWER);
+  await driver.pressKeyCode(KEYCODE_WAKEUP);
   let isKeyboardShown = await driver.isKeyboardShown();
   if (isKeyboardShown) {
     await driver.hideKeyboard();
@@ -117,10 +122,12 @@ helpers.pinUnlock = async function (adb, driver, capabilities) {
       await driver.click(util.unwrapElement(el));
     }
   }
-  const el = await driver.findElOrEls('xpath', "//*[contains(@resource-id, 'id/key_enter')]", false);
-  await driver.click(util.unwrapElement(el));
-  // Waits a bit for the device to be unlocked
+  // Some devices accept the entered key automatically
   await sleep(UNLOCK_WAIT_TIME);
+  if (await adb.isScreenLocked()) {
+    await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);
+    await sleep(UNLOCK_WAIT_TIME);
+  }
 };
 
 helpers.passwordUnlock = async function (adb, driver, capabilities) {

--- a/test/unit/unlock-helper-specs.js
+++ b/test/unit/unlock-helper-specs.js
@@ -7,7 +7,7 @@ import AndroidDriver from '../../lib/driver';
 import * as asyncbox from 'asyncbox';
 import ADB from 'appium-adb';
 
-const KEYCODE_NUMPAD_ENTER = '66';
+const KEYCODE_NUMPAD_ENTER = 66;
 const INPUT_KEYS_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
 const UNLOCK_WAIT_TIME = 100;
@@ -63,8 +63,8 @@ describe('Unlock Helpers', function () {
   describe('dismissKeyguard', withMocks({driver, adb, asyncbox, helpers}, (mocks) => {
     it('should hide keyboard if keyboard is shown', async function () {
       mocks.driver.expects('isKeyboardShown').returns(true);
-      mocks.driver.expects('pressKeyCode').withExactArgs('224').once();
-      mocks.driver.expects('pressKeyCode').withExactArgs('26').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs(224).once();
+      mocks.driver.expects('pressKeyCode').withExactArgs(26).once();
       mocks.driver.expects('hideKeyboard').once();
       mocks.asyncbox.expects('sleep').withExactArgs(HIDE_KEYBOARD_WAIT_TIME).once();
       mocks.adb.expects('shell').once();
@@ -78,8 +78,8 @@ describe('Unlock Helpers', function () {
     });
     it('should dismiss notifications and dissmiss keyguard via swipping up', async function () {
       mocks.driver.expects('isKeyboardShown').returns(false);
-      mocks.driver.expects('pressKeyCode').withExactArgs('224').once();
-      mocks.driver.expects('pressKeyCode').withExactArgs('26').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs(224).once();
+      mocks.driver.expects('pressKeyCode').withExactArgs(26).once();
       mocks.adb.expects('shell')
         .withExactArgs(['service', 'call', 'notification', '1']).once();
       mocks.adb.expects('back').once();
@@ -92,8 +92,8 @@ describe('Unlock Helpers', function () {
     });
     it('should dissmiss keyguard via dismiss-keyguard shell command if API level > 21', async function () {
       mocks.driver.expects('isKeyboardShown').returns(false);
-      mocks.driver.expects('pressKeyCode').withExactArgs('224').once();
-      mocks.driver.expects('pressKeyCode').withExactArgs('26').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs(224).once();
+      mocks.driver.expects('pressKeyCode').withExactArgs(26).once();
       mocks.adb.expects('shell').onCall(0).returns('');
       mocks.adb.expects('back').once();
       mocks.adb.expects('getApiLevel').returns(22);
@@ -172,7 +172,7 @@ describe('Unlock Helpers', function () {
         .withExactArgs('id', 'com.android.systemui:id/digit_text', true)
         .returns(els);
       mocks.adb.expects('isScreenLocked').returns(true);
-      mocks.driver.expects('pressKeyCode').withExactArgs('66').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs(66).once();
       for (let e of els) {
         mocks.driver.expects('getAttribute').withExactArgs('text', e.ELEMENT)
           .returns(e.ELEMENT.toString());

--- a/test/unit/unlock-helper-specs.js
+++ b/test/unit/unlock-helper-specs.js
@@ -61,9 +61,10 @@ describe('Unlock Helpers', function () {
     });
   });
   describe('dismissKeyguard', withMocks({driver, adb, asyncbox, helpers}, (mocks) => {
-    it('should hide keyboard if keyboard is snown', async function () {
+    it('should hide keyboard if keyboard is shown', async function () {
       mocks.driver.expects('isKeyboardShown').returns(true);
-      mocks.adb.expects('keyevent').withExactArgs('224').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs('224').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs('26').once();
       mocks.driver.expects('hideKeyboard').once();
       mocks.asyncbox.expects('sleep').withExactArgs(HIDE_KEYBOARD_WAIT_TIME).once();
       mocks.adb.expects('shell').once();
@@ -77,7 +78,8 @@ describe('Unlock Helpers', function () {
     });
     it('should dismiss notifications and dissmiss keyguard via swipping up', async function () {
       mocks.driver.expects('isKeyboardShown').returns(false);
-      mocks.adb.expects('keyevent').withExactArgs('224').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs('224').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs('26').once();
       mocks.adb.expects('shell')
         .withExactArgs(['service', 'call', 'notification', '1']).once();
       mocks.adb.expects('back').once();
@@ -90,7 +92,8 @@ describe('Unlock Helpers', function () {
     });
     it('should dissmiss keyguard via dismiss-keyguard shell command if API level > 21', async function () {
       mocks.driver.expects('isKeyboardShown').returns(false);
-      mocks.adb.expects('keyevent').withExactArgs('224').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs('224').once();
+      mocks.driver.expects('pressKeyCode').withExactArgs('26').once();
       mocks.adb.expects('shell').onCall(0).returns('');
       mocks.adb.expects('back').once();
       mocks.adb.expects('getApiLevel').returns(22);
@@ -168,14 +171,13 @@ describe('Unlock Helpers', function () {
       mocks.driver.expects('findElOrEls')
         .withExactArgs('id', 'com.android.systemui:id/digit_text', true)
         .returns(els);
-      mocks.driver.expects('findElOrEls')
-        .withExactArgs('xpath', "//*[contains(@resource-id, 'id/key_enter')]", false)
-        .returns({ELEMENT: 100});
+      mocks.adb.expects('isScreenLocked').returns(true);
+      mocks.driver.expects('pressKeyCode').withExactArgs('66').once();
       for (let e of els) {
         mocks.driver.expects('getAttribute').withExactArgs('text', e.ELEMENT)
           .returns(e.ELEMENT.toString());
       }
-      mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).once();
+      mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).twice();
       sandbox.stub(driver, 'click');
 
       await helpers.pinUnlock(adb, driver, caps);
@@ -185,7 +187,6 @@ describe('Unlock Helpers', function () {
       driver.click.getCall(2).args[0].should.equal(5);
       driver.click.getCall(3).args[0].should.equal(7);
       driver.click.getCall(4).args[0].should.equal(9);
-      driver.click.getCall(5).args[0].should.equal(100);
 
       mocks.helpers.verify();
       mocks.driver.verify();
@@ -201,9 +202,7 @@ describe('Unlock Helpers', function () {
           .withExactArgs('id', `com.android.keyguard:id/key${pin}`, false)
           .returns({ELEMENT: parseInt(pin, 10)});
       }
-      mocks.driver.expects('findElOrEls')
-        .withExactArgs('xpath', "//*[contains(@resource-id, 'id/key_enter')]", false)
-        .returns({ELEMENT: 100});
+      mocks.adb.expects('isScreenLocked').returns(false);
       mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).once();
       sandbox.stub(driver, 'click');
 
@@ -214,7 +213,6 @@ describe('Unlock Helpers', function () {
       driver.click.getCall(2).args[0].should.equal(5);
       driver.click.getCall(3).args[0].should.equal(7);
       driver.click.getCall(4).args[0].should.equal(9);
-      driver.click.getCall(5).args[0].should.equal(100);
 
       mocks.helpers.verify();
       mocks.driver.verify();


### PR DESCRIPTION
When I tried to pin unlock:

- some devices approve after entering pin-code, 4 digits, automatically.
    - Then, clicking element raises an exception
- pin failed if pin text field already has texts before starting to input digits
- some devices have a different enter button for pin code such as Samsung devices

<img src="https://user-images.githubusercontent.com/5511591/52218294-aef9ca00-28dd-11e9-9e66-a7078d783355.png" width=300>

To avoid the error, I did:

- Call `KEYCODE_POWER` before wake up
    - If the text field has texts, the texts will be clean after wake up
    - If the screen already off, the screen will be on. Calling wakeup after that does not affect device state
- Calling `KEYCODE_NUMPAD_ENTER` when we tap enter key
    - It can work for Samsung devices and some other devices I can test
        - The keycode equals to clicking `id/key_enter`
- Calling `KEYCODE_NUMPAD_ENTER` after checking screen lock

---

I tested:

- emulators: API 20, 21, 26
- real devices: API 22, 25, Samsung device

They worked well than before. I'm not sure this can cover all of android devices though...
(I have no mush Chinese devices, for example..)