### PR TITLE
add uninstall timeout

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -13,6 +13,7 @@ import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK,
 import { EOL } from 'os';
 
 const PACKAGE_INSTALL_TIMEOUT = 90000; // milliseconds
+const PACKAGE_UNINSTALL_TIMEOUT = 20000; // milliseconds
 const CHROME_BROWSER_PACKAGE_ACTIVITY = {
   chrome: {
     pkg: 'com.android.chrome',
@@ -308,6 +309,7 @@ helpers.resetApp = async function (adb, opts = {}) {
     fastReset,
     fullReset,
     androidInstallTimeout = PACKAGE_INSTALL_TIMEOUT,
+    androidUninstallTimeout = PACKAGE_UNINSTALL_TIMEOUT,
     autoGrantPermissions,
     allowTestPackages
   } = opts;
@@ -347,7 +349,9 @@ helpers.resetApp = async function (adb, opts = {}) {
 
   logger.debug(`Running full reset on '${appPackage}' (reinstall)`);
   if (isInstalled) {
-    await adb.uninstallApk(appPackage);
+    await adb.uninstallApk(appPackage, {
+      timeout: androidUninstallTimeout
+    });
   }
   await adb.install(app, {
     grantPermissions: autoGrantPermissions,
@@ -420,14 +424,14 @@ helpers.installOtherApks = async function (otherApps, adb, opts) {
  * @param {Array<string>} appPackages An array of package names to uninstall. If this includes `'*'`, uninstall all of 3rd party apps
  * @param {Array<string>} filterPackages An array of packages does not uninstall when `*` is provided as `appPackages`
  */
-helpers.uninstallOtherPackages = async function (adb, appPackages, filterPackages = []) {
+helpers.uninstallOtherPackages = async function (adb, appPackages, filterPackages = [], timeout = PACKAGE_UNINSTALL_TIMEOUT) {
   if (appPackages.includes('*')) {
     logger.debug('Uninstall third party packages');
     appPackages = await this.getThirdPartyPackages(adb, filterPackages);
   }
 
   logger.debug(`Uninstalling packages: ${appPackages}`);
-  await B.all(appPackages.map((appPackage) => adb.uninstallApk(appPackage)));
+  await B.all(appPackages.map((appPackage) => adb.uninstallApk(appPackage, {timeout})));
 };
 
 /**
@@ -774,5 +778,5 @@ helpers.validateDesiredCaps = function (caps) {
 helpers.bootstrap = Bootstrap;
 helpers.unlocker = unlocker;
 
-export { helpers, SETTINGS_HELPER_PKG_ID };
+export { helpers, SETTINGS_HELPER_PKG_ID, PACKAGE_UNINSTALL_TIMEOUT, PACKAGE_INSTALL_TIMEOUT };
 export default helpers;

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -37,6 +37,9 @@ let commonCapConstraints = {
   androidInstallTimeout: {
     isNumber: true
   },
+  androidUninstallTimeout: {
+    isNumber: true
+  },
   adbPort: {
     isNumber: true
   },

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,7 +1,7 @@
 import { BaseDriver, DeviceSettings } from 'appium-base-driver';
 import desiredConstraints from './desired-caps';
 import commands from './commands/index';
-import { helpers, SETTINGS_HELPER_PKG_ID } from './android-helpers';
+import { helpers, SETTINGS_HELPER_PKG_ID, PACKAGE_UNINSTALL_TIMEOUT, PACKAGE_INSTALL_TIMEOUT } from './android-helpers';
 import log from './logger';
 import _ from 'lodash';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
@@ -87,7 +87,8 @@ class AndroidDriver extends BaseDriver {
         fullReset: false,
         autoLaunch: true,
         adbPort: DEFAULT_ADB_PORT,
-        androidInstallTimeout: 90000,
+        androidInstallTimeout: PACKAGE_INSTALL_TIMEOUT,
+        androidUninstallTimeout: PACKAGE_UNINSTALL_TIMEOUT
       };
       _.defaults(this.opts, defaultOpts);
       this.useUnlockHelperApp = _.isUndefined(this.caps.unlockType);
@@ -329,7 +330,8 @@ class AndroidDriver extends BaseDriver {
       await helpers.uninstallOtherPackages(
         this.adb,
         helpers.parseArray(this.opts.uninstallOtherPackages),
-        [SETTINGS_HELPER_PKG_ID]
+        [SETTINGS_HELPER_PKG_ID],
+        this.opts.androidUninstallTimeout
       );
     }
 
@@ -357,7 +359,9 @@ class AndroidDriver extends BaseDriver {
       return;
     }
     if (!this.opts.skipUninstall) {
-      await this.adb.uninstallApk(this.opts.appPackage);
+      await this.adb.uninstallApk(this.opts.appPackage, {
+        timeout: this.opts.androidUninstallTimeout
+      });
     }
     await helpers.installApk(this.adb, this.opts);
     const apkStringsForLanguage = await helpers.pushStrings(this.opts.language, this.adb, this.opts);
@@ -407,7 +411,9 @@ class AndroidDriver extends BaseDriver {
       }
       await this.adb.goToHome();
       if (this.opts.fullReset && !this.opts.skipUninstall && !this.appOnDevice) {
-        await this.adb.uninstallApk(this.opts.appPackage);
+        await this.adb.uninstallApk(this.opts.appPackage, {
+          timeout: this.opts.androidUninstallTimeout
+        });
       }
       await this.bootstrap.shutdown();
       this.bootstrap = null;

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -367,7 +367,7 @@ describe('Android Helpers', function () {
       mocks.adb.expects('install').once().withArgs(localApkPath);
       mocks.adb.expects('forceStop').withExactArgs(pkg).once();
       mocks.adb.expects('isAppInstalled').once().withExactArgs(pkg).returns(true);
-      mocks.adb.expects('uninstallApk').once().withExactArgs(pkg);
+      mocks.adb.expects('uninstallApk').once().withExactArgs(pkg, { timeout: 20000 });
       await helpers.resetApp(adb, {app: localApkPath, appPackage: pkg});
       mocks.adb.verify();
     });


### PR DESCRIPTION
- Add `androidUninstallTimeout` as same as `androidInstallTimeout` to handle uninstallation timeout.
    - a part of https://github.com/appium/appium/issues/12227
    - We have no argument for uninstalling method, for now.


I'd like to add this option to below if this can merge:

- https://github.com/appium/appium-uiautomator2-driver/search?q=uninstallApk&unscoped_q=uninstallApk
- https://github.com/appium/appium-espresso-driver/search?q=uninstallApk&unscoped_q=uninstallApk
- https://github.com/appium/appium-adb/blob/d995ddc16395921efbd4da583ad2cd6086bcb19c/lib/tools/apk-utils.js#L327
    - add timeoutCapName