### PR TITLE
Avoid deleting the app on installApp call

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -2,7 +2,7 @@ import { waitForCondition } from 'asyncbox';
 import { util } from 'appium-support';
 import log from '../logger';
 
-const APP_EXTENSION = '.apk';
+const APP_EXTENSIONS = ['.apk', '.apks'];
 // These constants are in sync with
 // https://developer.apple.com/documentation/xctest/xcuiapplicationstate/xcuiapplicationstaterunningbackground?language=objc
 const APP_STATE_NOT_INSTALLED = 0;
@@ -153,7 +153,7 @@ commands.terminateApp = async function (appId, options = {}) {
  * @throws {Error} if the given apk does not exist or is not reachable
  */
 commands.installApp = async function (appPath, options = {}) {
-  const localPath = await this.helpers.configureApp(appPath, APP_EXTENSION);
+  const localPath = await this.helpers.configureApp(appPath, APP_EXTENSIONS);
   await this.adb.install(localPath, options);
 };
 

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -154,13 +154,7 @@ commands.terminateApp = async function (appId, options = {}) {
  */
 commands.installApp = async function (appPath, options = {}) {
   const localPath = await this.helpers.configureApp(appPath, APP_EXTENSION);
-  try {
-    await this.adb.install(localPath, options);
-  } finally {
-    if (localPath !== appPath) {
-      await fs.rimraf(localPath);
-    }
-  }
+  await this.adb.install(localPath, options);
 };
 
 

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -1,5 +1,5 @@
 import { waitForCondition } from 'asyncbox';
-import { fs, util } from 'appium-support';
+import { util } from 'appium-support';
 import log from '../logger';
 
 const APP_EXTENSION = '.apk';


### PR DESCRIPTION
Since Appium 1.11 caching works properly for `configureApp` calls, so there is no need to delete applications explicitly.
Fixes https://github.com/appium/appium/issues/12318