### PR TITLE
fix TypeError: this.shell is not a function

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -402,21 +402,21 @@ commands.mobileChangePermissions = async function (opts = {}) {
     log.errorAndThrow(`'permissions' argument is required`);
   }
 
+  let actionFunc;
   switch (_.toLower(action)) {
     case PERMISSION_ACTION.GRANT:
-      for (const permission of (_.isArray(permissions) ? permissions : [permissions])) {
-        await this.adb.grantPermission(appPackage, permission);
-      }
+      actionFunc = (appPackage, permission) => this.adb.grantPermission(appPackage, permission);
       break;
     case PERMISSION_ACTION.REVOKE:
-      for (const permission of (_.isArray(permissions) ? permissions : [permissions])) {
-        await this.adb.revokePermission(appPackage, permission);
-      }
+      actionFunc = (appPackage, permission) => this.adb.revokePermission(appPackage, permission);
       break;
     default:
       log.errorAndThrow(`Unknown action '${action}'. ` +
         `Only ${JSON.stringify(_.values(PERMISSION_ACTION))} actions are supported`);
       break;
+  }
+  for (const permission of (_.isArray(permissions) ? permissions : [permissions])) {
+    await actionFunc(appPackage, permission);
   }
 };
 
@@ -448,18 +448,23 @@ commands.mobileGetPermissions = async function (opts = {}) {
     appPackage = this.opts.appPackage,
   } = opts;
 
+  let actionFunc;
   switch (_.toLower(type)) {
     case PERMISSIONS_TYPE.REQUESTED:
-      return await this.adb.getReqPermissions(appPackage);
+      actionFunc = (appPackage) => this.adb.getReqPermissions(appPackage);
+      break;
     case PERMISSIONS_TYPE.GRANTED:
-      return await this.adb.getGrantedPermissions(appPackage);
+      actionFunc = (appPackage) => this.adb.getGrantedPermissions(appPackage);
+      break;
     case PERMISSIONS_TYPE.DENIED:
-      return await this.adb.getDeniedPermissions(appPackage);
+      actionFunc = (appPackage) => this.adb.getDeniedPermissions(appPackage);
+      break;
     default:
       log.errorAndThrow(`Unknown permissions type '${type}'. ` +
         `Only ${JSON.stringify(_.values(PERMISSIONS_TYPE))} types are supported`);
       break;
   }
+  return await actionFunc(appPackage);
 };
 
 Object.assign(extensions, commands, helpers);

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -402,21 +402,21 @@ commands.mobileChangePermissions = async function (opts = {}) {
     log.errorAndThrow(`'permissions' argument is required`);
   }
 
-  let actionFunc;
   switch (_.toLower(action)) {
     case PERMISSION_ACTION.GRANT:
-      actionFunc = this.adb.grantPermission;
+      for (const permission of (_.isArray(permissions) ? permissions : [permissions])) {
+        await this.adb.grantPermission(appPackage, permission);
+      }
       break;
     case PERMISSION_ACTION.REVOKE:
-      actionFunc = this.adb.revokePermission;
+      for (const permission of (_.isArray(permissions) ? permissions : [permissions])) {
+        await this.adb.revokePermission(appPackage, permission);
+      }
       break;
     default:
       log.errorAndThrow(`Unknown action '${action}'. ` +
         `Only ${JSON.stringify(_.values(PERMISSION_ACTION))} actions are supported`);
       break;
-  }
-  for (const permission of (_.isArray(permissions) ? permissions : [permissions])) {
-    await actionFunc(appPackage, permission);
   }
 };
 
@@ -448,23 +448,18 @@ commands.mobileGetPermissions = async function (opts = {}) {
     appPackage = this.opts.appPackage,
   } = opts;
 
-  let actionFunc;
   switch (_.toLower(type)) {
     case PERMISSIONS_TYPE.REQUESTED:
-      actionFunc = this.adb.getReqPermissions;
-      break;
+      return await this.adb.getReqPermissions(appPackage);
     case PERMISSIONS_TYPE.GRANTED:
-      actionFunc = this.adb.getGrantedPermissions;
-      break;
+      return await this.adb.getGrantedPermissions(appPackage);
     case PERMISSIONS_TYPE.DENIED:
-      actionFunc = this.adb.getDeniedPermissions;
-      break;
+      return await this.adb.getDeniedPermissions(appPackage);
     default:
       log.errorAndThrow(`Unknown permissions type '${type}'. ` +
         `Only ${JSON.stringify(_.values(PERMISSIONS_TYPE))} types are supported`);
       break;
   }
-  return await actionFunc(appPackage);
 };
 
 Object.assign(extensions, commands, helpers);


### PR DESCRIPTION
Below issue happened when they were called by `await actionFunc(appPackage);` style.

```
[HTTP] {"script":"mobile: getPermissions","args":[{"type":"granted","appPackage":"io.appium.android.apis"}]}
[debug] [W3C (5a10109b)] Calling AppiumDriver.execute() with args: ["mobile: getPermissions",[{"type":"granted","appPackage":"io.appium.android.apis"}],"5a10109b-71fc-4b25-a27f-96b6d903ecc9"]
[debug] [ADB] Retrieving granted permissions
[debug] [W3C (5a10109b)] Encountered internal error running command: TypeError: this.shell is not a function
[debug] [W3C (5a10109b)]     at shell (/Users/kazu/GitHub/appium/node_modules/appium-adb/lib/tools/adb-commands.js:314:42)
[debug] [W3C (5a10109b)]     at Generator.next (<anonymous>)
[debug] [W3C (5a10109b)]     at asyncGeneratorStep (/Users/kazu/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
[debug] [W3C (5a10109b)]     at _next (/Users/kazu/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
[debug] [W3C (5a10109b)]     at /Users/kazu/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:32:7
[debug] [W3C (5a10109b)]     at new Promise (<anonymous>)
[debug] [W3C (5a10109b)]     at /Users/kazu/GitHub/appium/node_modules/@babel/runtime/helpers/asyncToGenerator.js:21:12
[debug] [W3C (5a10109b)]     at /Users/kazu/GitHub/appium/node_modules/appium-adb/lib/tools/adb-commands.js:312:1
[debug] [W3C (5a10109b)]     at AndroidUiautomator2Driver.actionFunc [as mobileGetPermissions] (/Users/kazu/GitHub/appium/node_modules/appium-android-driver/lib/commands/general.js:467:16)
[debug] [W3C (5a10109b)]     at AndroidUiautomator2Driver.extensions.executeMobile (/Users/kazu/GitHub/appium/node_modules/appium-uiautomator2-driver/lib/commands/general.js:127:16)
[debug] [W3C (5a10109b)]     at AndroidUiautomator2Driver.executeMobile [as execute] (/Users/kazu/GitHub/appium/node_modules/appium-android-driver/lib/commands/execute.js:9:23)
[debug] [W3C (5a10109b)]     at curCommandCancellable._bluebird.default.resolve.then (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/lib/basedriver/driver.js:291:18)
[debug] [W3C (5a10109b)]     at tryCatcher (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/node_modules/bluebird/js/main/util.js:26:23)
[debug] [W3C (5a10109b)]     at Promise._settlePromiseFromHandler (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/node_modules/bluebird/js/main/promise.js:510:31)
[debug] [W3C (5a10109b)]     at Promise._settlePromiseAt (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/node_modules/bluebird/js/main/promise.js:584:18)
[debug] [W3C (5a10109b)]     at Promise._settlePromiseAtPostResolution (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/node_modules/bluebird/js/main/promise.js:248:10)
[debug] [W3C (5a10109b)]     at Async._drainQueue (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/node_modules/bluebird/js/main/async.js:128:12)
[debug] [W3C (5a10109b)]     at Async._drainQueues (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/node_modules/bluebird/js/main/async.js:133:10)
[debug] [W3C (5a10109b)]     at Immediate.Async.drainQueues (/Users/kazu/GitHub/appium/node_modules/appium-base-driver/node_modules/bluebird/js/main/async.js:15:14)
[debug] [W3C (5a10109b)]     at processImmediate (timers.js:637:19)
[HTTP] <-- POST /wd/hub/session/5a10109b-71fc-4b25-a27f-96b6d903ecc9/execute/sync 500 77 ms - 535
[HTTP]
```

Do you have better idea?