### PR TITLE
add ability for users to send in additional chromedriver args

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -277,6 +277,7 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
     port: opts.chromeDriverPort,
     executable: opts.chromedriverExecutable,
     adb,
+    cmdArgs: opts.chromedriverArgs,
     verbose: !!opts.showChromedriverLog,
     executableDir: opts.chromedriverExecutableDir,
     mappingPath: opts.chromedriverChromeMappingFile,

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -76,6 +76,9 @@ let commonCapConstraints = {
   chromeDriverPort: {
     isNumber: true
   },
+  chromedriverArgs: {
+    isObject: true,
+  },
   chromedriverExecutable: {
     isString: true
   },


### PR DESCRIPTION
So that folks can send in cli flags to chromedriver.

Also, noticed that unit tests are broken on master for me, something to do with unlock specs?