### PR TITLE
Add a capability to adjust the limit of the remote cache

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -63,6 +63,7 @@ helpers.createBaseADB = async function createBaseADB (opts = {}) {
     keystorePassword,
     keyAlias,
     keyPassword,
+    remoteAppsCacheLimit,
   } = opts;
   return await ADB.createADB({
     adbPort,
@@ -75,6 +76,7 @@ helpers.createBaseADB = async function createBaseADB (opts = {}) {
     keystorePassword,
     keyAlias,
     keyPassword,
+    remoteAppsCacheLimit,
   });
 };
 

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -189,6 +189,9 @@ let commonCapConstraints = {
   },
   skipDeviceInitialization: {
     isBoolean: true
+  },
+  remoteAppsCacheLimit: {
+    isNumber: true
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^7.0.0",
+    "appium-adb": "^7.6.0",
     "appium-base-driver": "^3.0.0",
     "appium-chromedriver": "^4.8.0",
     "appium-support": "^2.25.0",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -273,6 +273,7 @@ describe('Android Helpers', function () {
         keystorePassword: '123456',
         keyAlias: 'keyAlias',
         keyPassword: 'keyPassword',
+        remoteAppsCacheLimit: 5,
       });
       ADB.createADB.calledWithExactly({
         adbPort: '222',
@@ -285,6 +286,7 @@ describe('Android Helpers', function () {
         keystorePassword: '123456',
         keyAlias: 'keyAlias',
         keyPassword: 'keyPassword',
+        remoteAppsCacheLimit: 5,
       }).should.be.true;
       curDeviceId.should.equal('111222');
       emulatorPort.should.equal('111');


### PR DESCRIPTION
The default count of max apps in the remote cache is 10 per ADB instance. If this value is equal or less than zero then the remote cache will be disabled and application install will be performed with the old good `adb install` call