### PR TITLE
retry installHelperApp once

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -477,7 +477,7 @@ helpers.setMockLocationApp = async function setMockLocationApp (adb, app) {
 };
 
 helpers.installHelperApp = async function installHelperApp (adb, apkPath, packageId) {
-  // Rarely adb push or adb install takes much time to do them:
+  // Sometimes adb push or adb instal take more time than expected to install an app
   // e.g. https://github.com/appium/io.appium.settings/issues/40#issuecomment-476593174
   await retry(2, async function retryInstallHelperApp () {
     await adb.installOrUpgrade(apkPath, packageId, {grantPermissions: true});
@@ -488,8 +488,8 @@ helpers.installHelperApp = async function installHelperApp (adb, apkPath, packag
  * Pushes and installs io.appium.settings app.
  * Throws an error if the setting app is required
  *
- * @param {Object} adb - The adb module instance.
- * @param {boolean} throwError - Whether throw error or not
+ * @param {Adb} adb - The adb module instance.
+ * @param {boolean} throwError[false] - Whether throw error or not
  * @throws {Error} If throwError is true and something happens in installation step
  */
 helpers.pushSettingsApp = async function pushSettingsApp (adb, throwError = false) {
@@ -502,7 +502,9 @@ helpers.pushSettingsApp = async function pushSettingsApp (adb, throwError = fals
       throw err;
     }
 
-    logger.debug(`Failed to install settings app: ${err.message}`);
+    logger.warn(`Ignored error while installing ${settingsApkPath} fails: ` +
+                `'${err.message}'. Features require the apk such as toggle WiFi ` +
+                'and getting location could raise an error.');
   }
 
   // Reinstall will stop the settings helper process anyway, so
@@ -675,21 +677,16 @@ helpers.initDevice = async function initDevice (adb, opts) {
     await adb.waitForDevice();
     // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+
 
-    if (opts.language
-      || opts.locale
-      || opts.localeScript
-      || opts.unicodeKeyboard
-      || opts.disableWindowAnimation
-      || !opts.skipUnlock) {
-      // The settings app is necessary to configure them
-      await helpers.pushSettingsApp(adb, true);
-    } else {
-      // Some feature such as location/wifi are not necessary for all users,
-      // but they require the settings app. So, try to configure it while Appium
-      // does not throw error even they fail.
-      await helpers.pushSettingsApp(adb);
-    }
-    }
+    // Some feature such as location/wifi are not necessary for all users,
+    // but they require the settings app. So, try to configure it while Appium
+    // does not throw error even they fail.
+    const shouldThrowError = opts.language
+                          || opts.locale
+                          || opts.localeScript
+                          || opts.unicodeKeyboard
+                          || opts.disableWindowAnimation
+                          || !opts.skipUnlock;
+    await helpers.pushSettingsApp(adb, shouldThrowError);
   }
 
   if (!opts.avd) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -502,9 +502,10 @@ helpers.pushSettingsApp = async function pushSettingsApp (adb, throwError = fals
       throw err;
     }
 
-    logger.warn(`Ignored error while installing ${settingsApkPath} fails: ` +
-                `'${err.message}'. Features require the apk such as toggle WiFi ` +
-                'and getting location could raise an error.');
+    logger.warn(`Ignored error while installing '${settingsApkPath}': ` +
+                `'${err.message}'. Features that rely on this helper ` +
+                'require the apk such as toggle WiFi and getting location ' +
+                'will raise an error if you try to use them.');
   }
 
   // Reinstall will stop the settings helper process anyway, so
@@ -679,7 +680,7 @@ helpers.initDevice = async function initDevice (adb, opts) {
 
     // Some feature such as location/wifi are not necessary for all users,
     // but they require the settings app. So, try to configure it while Appium
-    // does not throw error even they fail.
+    // does not throw error even if they fail.
     const shouldThrowError = opts.language
                           || opts.locale
                           || opts.localeScript

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -476,7 +476,7 @@ helpers.setMockLocationApp = async function setMockLocationApp (adb, app) {
   }
 };
 
-helpers.installHelperApp = async function installHelperApp (adb, apkPath, packageId, appName) {
+helpers.installHelperApp = async function installHelperApp (adb, apkPath, packageId) {
   // Rarely adb push or adb install takes much time to do them:
   // e.g. https://github.com/appium/io.appium.settings/issues/40#issuecomment-476593174
   await retry(2, async function retryInstallHelperApp () {
@@ -487,7 +487,7 @@ helpers.installHelperApp = async function installHelperApp (adb, apkPath, packag
 helpers.pushSettingsApp = async function pushSettingsApp (adb, throwError = false) {
   logger.debug('Pushing settings apk to device...');
 
-  await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID, 'Settings');
+  await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID);
 
   // Reinstall will stop the settings helper process anyway, so
   // there is no need to continue if the application is still running

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -477,15 +477,19 @@ helpers.setMockLocationApp = async function setMockLocationApp (adb, app) {
 };
 
 helpers.installHelperApp = async function installHelperApp (adb, apkPath, packageId, appName) {
-  try {
-    await adb.installOrUpgrade(apkPath, packageId, {grantPermissions: true});
-  } catch (err) {
-    logger.warn(`Ignored error while installing Appium ${appName} helper: ` +
-                `'${err.message}'. Manually uninstalling the application ` +
-                `with package id '${packageId}' may help. Expect some Appium ` +
-                `features may not work as expected unless this problem is ` +
-                `fixed.`);
-  }
+  // Rarely adb push or adb install takes much time to do them:
+  // e.g. https://github.com/appium/io.appium.settings/issues/40#issuecomment-476593174
+  await retry(2, async function retryInstallHelperApp () {
+    try {
+      await adb.installOrUpgrade(apkPath, packageId, {grantPermissions: true});
+    } catch (err) {
+      throw new Error(`Failed to install Appium ${appName} helper: ` +
+        `'${err.message}'. Manually uninstalling the application ` +
+        `with package id '${packageId}' may help. Expect some Appium ` +
+        `features may not work as expected unless this problem is ` +
+        `fixed.`);
+    }
+  });
 };
 
 helpers.pushSettingsApp = async function pushSettingsApp (adb, throwError = false) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -484,10 +484,26 @@ helpers.installHelperApp = async function installHelperApp (adb, apkPath, packag
   });
 };
 
+/**
+ * Pushes and installs io.appium.settings app.
+ * Throws an error if the setting app is required
+ *
+ * @param {Object} adb - The adb module instance.
+ * @param {boolean} throwError - Whether throw error or not
+ * @throws {Error} If throwError is true and something happens in installation step
+ */
 helpers.pushSettingsApp = async function pushSettingsApp (adb, throwError = false) {
   logger.debug('Pushing settings apk to device...');
 
-  await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID);
+  try {
+    await helpers.installHelperApp(adb, settingsApkPath, SETTINGS_HELPER_PKG_ID, throwError);
+  } catch (err) {
+    if (throwError) {
+      throw err;
+    }
+
+    logger.debug(`Failed to install settings app: ${err.message}`);
+  }
 
   // Reinstall will stop the settings helper process anyway, so
   // there is no need to continue if the application is still running
@@ -658,7 +674,21 @@ helpers.initDevice = async function initDevice (adb, opts) {
   } else {
     await adb.waitForDevice();
     // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+
-    await helpers.pushSettingsApp(adb);
+
+    if (opts.language
+      || opts.locale
+      || opts.localeScript
+      || opts.unicodeKeyboard
+      || opts.disableWindowAnimation) {
+      // Settings app is necessary to configure them
+      await helpers.pushSettingsApp(adb, true);
+    } else {
+      // Some feature such as location/wifi are not necessary for all users,
+      // but they requires settings app. So, try to configure it while Appium
+      // does not throw error even they fail.
+      await helpers.pushSettingsApp(adb);
+    }
+    }
   }
 
   if (!opts.avd) {

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -480,15 +480,7 @@ helpers.installHelperApp = async function installHelperApp (adb, apkPath, packag
   // Rarely adb push or adb install takes much time to do them:
   // e.g. https://github.com/appium/io.appium.settings/issues/40#issuecomment-476593174
   await retry(2, async function retryInstallHelperApp () {
-    try {
-      await adb.installOrUpgrade(apkPath, packageId, {grantPermissions: true});
-    } catch (err) {
-      throw new Error(`Failed to install Appium ${appName} helper: ` +
-        `'${err.message}'. Manually uninstalling the application ` +
-        `with package id '${packageId}' may help. Expect some Appium ` +
-        `features may not work as expected unless this problem is ` +
-        `fixed.`);
-    }
+    await adb.installOrUpgrade(apkPath, packageId, {grantPermissions: true});
   });
 };
 

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -679,12 +679,13 @@ helpers.initDevice = async function initDevice (adb, opts) {
       || opts.locale
       || opts.localeScript
       || opts.unicodeKeyboard
-      || opts.disableWindowAnimation) {
-      // Settings app is necessary to configure them
+      || opts.disableWindowAnimation
+      || !opts.skipUnlock) {
+      // The settings app is necessary to configure them
       await helpers.pushSettingsApp(adb, true);
     } else {
       // Some feature such as location/wifi are not necessary for all users,
-      // but they requires settings app. So, try to configure it while Appium
+      // but they require the settings app. So, try to configure it while Appium
       // does not throw error even they fail.
       await helpers.pushSettingsApp(adb);
     }


### PR DESCRIPTION
Reduce the probability of https://github.com/appium/io.appium.settings/issues/40#issuecomment-476593174 .
The issue happened when Appium failed to install io.appium.settings app in session creation.

I also happened once on Android P.
But once it happened, I could not reproduce it again.
so, retry once is pretty much, I think.

In this PR,

- retry once only installing helper app
- raise an error instead of just puting warning to raise error to users properly.
    - If this error happens, users never can run test correctly. Thus, raising error is pretty enough, I believe.

This happened in https://github.com/appium/appium-adb/blob/b6ac33cac7f7a37a4f9dd0a516ef3694444500c5/lib/tools/apk-utils.js#L629 . 

---

- Error in `push`
```
[debug] [ADB] 'io.appium.settings' is not installed
[debug] [ADB] App '/Users/kazu/GitHub/appium/node_modules/io.appium.settings/apks/settings_apk-debug.apk' is not installed
[debug] [ADB] Installing '/Users/kazu/GitHub/appium/node_modules/io.appium.settings/apks/settings_apk-debug.apk'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell ls -t -1 /data/local/tmp/appium_cache'
[debug] [ADB] The count of applications in the cache: 0
[ADB] Caching the application at '/Users/kazu/GitHub/appium/node_modules/io.appium.settings/apks/settings_apk-debug.apk' to '/data/local/tmp/appium_cache/728413456b86856a2003edeb524d6bd577ca6418.apk'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 push /Users/kazu/GitHub/appium/node_modules/io.appium.settings/apks/settings_apk-debug.apk /data/local/tmp/appium_cache/728413456b86856a2003edeb524d6bd577ca6418.apk'
[AndroidDriver] Ignored error while installing Appium Settings helper: 'Error executing adbExec. Original error: 'Command '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 push /Users/kazu/GitHub/appium/node_modules/io.appium.settings/apks/settings_apk-debug.apk /data/local/tmp/appium_cache/728413456b86856a2003edeb524d6bd577ca6418.apk' exited with code 1'; Stderr: ''; Code: '1''. Manually uninstalling the application with package id 'io.appium.settings' may help. Expect some Appium features may not work as expected unless this problem is fixed.
[debug] [ADB] Getting IDs of all 'io.appium.settings' processes
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell 'pgrep --help; echo $?''
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell pgrep -f \^io\\.appium\\.settings\$'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell am start -W -n io.appium.settings/.Settings -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -f 0x10200000'
[AndroidDriver] Failed to launch settings app: Cannot start the 'io.appium.settings' application. Visit https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/android/activity-startup.md for troubleshooting. Original error: Activity name '.Settings' used to start the app doesn't exist or cannot be launched! Make sure it exists and is a launchable activity
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell appops set io.appium.settings android\:mock_location allow'
```

- Raises an error when changing IME failed (because of no settings app)
```
[debug] [ADB] Requested locale is equal to current locale: 'en-us'
[debug] [Logcat] Starting logcat capture
[debug] [AndroidDriver] Enabling Unicode keyboard support
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell settings get secure default_input_method'
[debug] [AndroidDriver] Unsetting previous IME com.touchtype.swiftkey/com.touchtype.KeyboardService
[debug] [AndroidDriver] Setting IME to 'io.appium.settings/.UnicodeIME'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell ime enable io.appium.settings/.UnicodeIME'
[debug] [UiAutomator2] Deleting UiAutomator2 session
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell am force-stop io.appium.android.apis'
[debug] [Logcat] Stopping logcat capture
[debug] [ADB] Removing forwarded port socket connection: 8200
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 forward --remove tcp\:8200'
[UiAutomator2] Unable to remove port forward 'Error executing adbExec. Original error: 'Command '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 forward --remove tcp\:8200' exited with code 1'; Stderr: 'adb: error: listener 'tcp:8200' not found'; Code: '1''
[UiAutomator2] Restoring hidden api policy to the device default configuration
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell settings delete global hidden_api_policy_pre_p_apps'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell settings delete global hidden_api_policy_p_apps'
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1553597143496 (19:45:43 GMT+0900 (Japan Standard Time))
[debug] [W3C] Encountered internal error running command: Error executing adbExec. Original error: 'Command '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell ime enable io.appium.settings/.UnicodeIME' exited with code 255'; Stderr: 'Exception occurred while executing:
[debug] [W3C] java.lang.IllegalArgumentException: Unknown id: com.touchtype.swiftkey/com.touchtype.KeyboardService
[debug] [W3C] 	at com.android.server.InputMethodManagerService.setInputMethodEnabledLocked(InputMethodManagerService.java:3991)
[debug] [W3C] 	at com.android.server.InputMethodManagerService.handleShellCommandEnableDisableInputMethod(InputMethodManagerService.java:4962)
[debug] [W3C] 	at com.android.server.InputMethodManagerService.access$1600(InputMethodManagerService.java:181)
[debug] [W3C] 	at com.android.server.InputMethodManagerService$ShellCommandImpl.onCommand(InputMethodManagerService.java:4753)
[debug] [W3C] 	at android.os.ShellCommand.exec(ShellCommand.java:103)
[debug] [W3C] 	at com.android.server.InputMethodManagerService.onShellCommand(InputMethodManagerService.java:4719)
[debug] [W3C] 	at android.os.Binder.shellCommand(Binder.java:634)
[debug] [W3C] 	at android.os.Binder.onTransact(Binder.java:532)
[debug] [W3C] 	at com.android.internal.view.IInputMethodManager$Stub.onTransact(IInputMethodManager.java:486)
[debug] [W3C] 	at com.android.server.InputMethodManagerService.onTransact(InputMethodManagerService.java:1497)
[debug] [W3C] 	at android.os.Binder.execTransact(Binder.java:731)'; Code: '255'
[debug] [W3C] Error: Command '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s DRGGAM4870408836 shell ime enable io.appium.settings/.UnicodeIME' exited with code 255
[debug] [W3C]     at ChildProcess.proc.on.code (/Users/kazu/GitHub/appium/node_modules/teen_process/lib/exec.js:94:19)
[debug] [W3C]     at ChildProcess.emit (events.js:197:13)
[debug] [W3C]     at maybeClose (internal/child_process.js:978:16)
[debug] [W3C]     at Process.ChildProcess._handle.onexit (internal/child_process.js:265:5)
[HTTP] <-- POST /wd/hub/session 500 1896 ms - 3161
[HTTP]
[HTTP] --> POST /wd/hub/session
```

