### PR TITLE
Make sure geolocation values are cast to float

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -12,7 +12,8 @@ const DATA_MASK = 0b100;
 // to trick JSON generation and send a float value instead of an integer,
 // This allows strictly-typed clients, like Java, to properly
 // parse it. Otherwise float 0.0 is always represented as integer 0 in JS.
-const GEO_EPSILON = 1e-15;
+// The value must not be greater than DBL_EPSILON (http://www.cplusplus.com/reference/cfloat/)
+const GEO_EPSILON = 1e-10;
 
 commands.getNetworkConnection = async function getNetworkConnection () {
   log.info('Getting network connection');

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -13,7 +13,7 @@ const DATA_MASK = 0b100;
 // This allows strictly-typed clients, like Java, to properly
 // parse it. Otherwise float 0.0 is always represented as integer 0 in JS.
 // The value must not be greater than DBL_EPSILON (https://opensource.apple.com/source/Libc/Libc-498/include/float.h)
-const GEO_EPSILON = 1e-16;
+const GEO_EPSILON = Number.MIN_VALUE;
 
 commands.getNetworkConnection = async function getNetworkConnection () {
   log.info('Getting network connection');

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -2,13 +2,17 @@ import log from '../logger';
 import _ from 'lodash';
 import { errors } from 'appium-base-driver';
 import B from 'bluebird';
-import { util } from 'appium-support';
 
 let commands = {}, helpers = {}, extensions = {};
 
 const AIRPLANE_MODE_MASK = 0b001;
 const WIFI_MASK = 0b010;
 const DATA_MASK = 0b100;
+// The value close to zero, but not zero, is needed
+// to trick JSON generation and send a float value instead of an integer,
+// This allows strictly-typed clients, like Java, to properly
+// parse it. Otherwise float 0.0 is always represented as integer 0 in JS.
+const GEO_EPSILON = 1e-15;
 
 commands.getNetworkConnection = async function getNetworkConnection () {
   log.info('Getting network connection');
@@ -132,9 +136,9 @@ commands.setGeoLocation = async function setGeoLocation (location) {
     log.warn(`Could not get the current geolocation info: ${e.message}`);
     log.warn(`Returning the default zero'ed values`);
     return {
-      latitude: 0.0,
-      longitude: 0.0,
-      altitude: 0.0,
+      latitude: GEO_EPSILON,
+      longitude: GEO_EPSILON,
+      altitude: GEO_EPSILON,
     };
   }
 };
@@ -142,9 +146,9 @@ commands.setGeoLocation = async function setGeoLocation (location) {
 commands.getGeoLocation = async function getGeoLocation () {
   const {latitude, longitude, altitude} = await this.adb.getGeoLocation();
   return {
-    latitude: parseFloat(latitude) || 0.0,
-    longitude: parseFloat(longitude) || 0.0,
-    altitude: parseFloat(altitude) || 0.0,
+    latitude: parseFloat(latitude) || GEO_EPSILON,
+    longitude: parseFloat(longitude) || GEO_EPSILON,
+    altitude: parseFloat(altitude) || GEO_EPSILON,
   };
 };
 

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -12,8 +12,8 @@ const DATA_MASK = 0b100;
 // to trick JSON generation and send a float value instead of an integer,
 // This allows strictly-typed clients, like Java, to properly
 // parse it. Otherwise float 0.0 is always represented as integer 0 in JS.
-// The value must not be greater than DBL_EPSILON (http://www.cplusplus.com/reference/cfloat/)
-const GEO_EPSILON = 1e-10;
+// The value must not be greater than DBL_EPSILON (https://opensource.apple.com/source/Libc/Libc-498/include/float.h)
+const GEO_EPSILON = 1e-16;
 
 commands.getNetworkConnection = async function getNetworkConnection () {
   log.info('Getting network connection');

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -142,9 +142,9 @@ commands.setGeoLocation = async function setGeoLocation (location) {
 commands.getGeoLocation = async function getGeoLocation () {
   const {latitude, longitude, altitude} = await this.adb.getGeoLocation();
   return {
-    latitude: parseFloat(latitude),
-    longitude: parseFloat(longitude),
-    altitude: parseFloat(util.hasValue(altitude) ? altitude : 0),
+    latitude: parseFloat(latitude) || 0.0,
+    longitude: parseFloat(longitude) || 0.0,
+    altitude: parseFloat(altitude) || 0.0,
   };
 };
 


### PR DESCRIPTION
I was surprised, but in JS `parseFloat('0.0') === 0`. And Java requires these values to be of type [double](https://discuss.appium.io/t/appium-1-9-1-issues-setting-location-on-android-device/23955/36). @imurchie Do you have any better ideas of how the cast to float zero can be implemented?