### PR TITLE
Handle `mobile:` calls in non-native context

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -1,15 +1,25 @@
 import _ from 'lodash';
-import { errors } from 'appium-base-driver';
+import { errors, BaseDriver } from 'appium-base-driver';
+import logger from '../logger';
 
 let extensions = {};
 
 extensions.execute = async function execute (script, args) {
   if (script.match(/^mobile:/)) {
+    logger.info(`Executing native command '${script}'`);
     script = script.replace(/^mobile:/, '').trim();
     return await this.executeMobile(script, _.isArray(args) ? args[0] : args);
   }
-
-  throw new errors.NotImplementedError();
+  if (!this.isWebContext()) {
+    throw new errors.NotImplementedError();
+  }
+  const endpoint = this.chromedriver.jwproxy.downstreamProtocol === BaseDriver.DRIVER_PROTOCOL.MJSONWP
+    ? '/execute'
+    : '/execute/sync';
+  return await this.chromedriver.jwproxy.command(endpoint, 'POST', {
+    script,
+    args,
+  });
 };
 
 extensions.executeMobile = async function executeMobile (mobileCommand, opts = {}) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -24,6 +24,8 @@ const NO_PROXY = [
   ['POST', new RegExp('^/session/[^/]+/touch/multi/perform')],
   ['POST', new RegExp('^/session/[^/]+/orientation')],
   ['GET', new RegExp('^/session/[^/]+/orientation')],
+  ['POST', new RegExp('^/session/[^/]+/execute')],
+  ['POST', new RegExp('^/session/[^/]+/execute/sync')],
 ];
 
 class AndroidDriver extends BaseDriver {

--- a/test/unit/driver-specs.js
+++ b/test/unit/driver-specs.js
@@ -156,11 +156,15 @@ describe('driver', function () {
     });
     it('should proxy screenshot if nativeWebScreenshot is off', async function () {
       await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: false});
-      driver.getProxyAvoidList().should.have.length(8);
+      driver.getProxyAvoidList()
+        .some((x) => x[1].toString().includes('/screenshot'))
+        .should.be.false;
     });
     it('should not proxy screenshot if nativeWebScreenshot is on', async function () {
       await driver.createSession({platformName: 'Android', deviceName: 'device', browserName: 'chrome', nativeWebScreenshot: true});
-      driver.getProxyAvoidList().should.have.length(9);
+      driver.getProxyAvoidList()
+        .some((x) => x[1].toString().includes('/screenshot'))
+        .should.be.true;
     });
     it('should set networkSpeed before launching app', async function () {
       sandbox.stub(driver, 'isEmulator').returns(true);


### PR DESCRIPTION
Partially addresses https://github.com/appium/appium/issues/12407

It makes sense to always assume that scripts starting with `mobile:` magic always target the native context even if the current one is the web one.