### PR TITLE
allow chrome automation even when AUT also has a webview

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -115,7 +115,13 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context)
   } else {
     let opts = _.cloneDeep(this.opts);
     opts.chromeUseRunningApp = true;
-    if (opts.extractChromeAndroidPackageFromContextName) {
+
+    // if requested, tell chromedriver to attach to the android package we have
+    // associated with the context name, rather than the package of the AUT.
+    // And turn this on by default for chrome--if chrome pops up with a webview
+    // and someone wants to switch to it, we should let chromedriver connect to
+    // chrome rather than staying stuck on the AUT
+    if (opts.extractChromeAndroidPackageFromContextName || context === `${WEBVIEW_BASE}chrome`) {
       let androidPackage = context.match(`${WEBVIEW_BASE}(.+)`);
       if (androidPackage && androidPackage.length > 0) {
         opts.chromeAndroidPackage = androidPackage[1];
@@ -333,7 +339,16 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
   if (opts.pageLoadStrategy) {
     caps.pageLoadStrategy = opts.pageLoadStrategy;
   }
+  if (caps.chromeOptions.androidPackage === 'chrome') {
+    // if we have extracted package from context name, it could come in as bare
+    // "chrome", and so we should make sure the details are correct, including
+    // not using an activity or process id
+    caps.chromeOptions.androidPackage = 'com.android.chrome';
+    delete caps.chromeOptions.androidActivity;
+    delete caps.chromeOptions.androidProcess;
+  }
   caps = webviewHelpers.decorateChromeOptions(caps, opts, curDeviceId);
+  log.debug(`Before starting chromedriver, androidPackage is ${caps.chromeOptions.androidPackage}`);
   await chromedriver.start(caps);
   return chromedriver;
 };

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -339,7 +339,8 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
   if (opts.pageLoadStrategy) {
     caps.pageLoadStrategy = opts.pageLoadStrategy;
   }
-  if (caps.chromeOptions.androidPackage === 'chrome') {
+  const pkg = caps.chromeOptions.androidPackage;
+  if ((pkg && pkg.toLowerCase()) === 'chrome') {
     // if we have extracted package from context name, it could come in as bare
     // "chrome", and so we should make sure the details are correct, including
     // not using an activity or process id


### PR DESCRIPTION
There was a bug, in the following situation:

1. User opens up AUT which has a webview
2. AUT triggers Chrome to open
3. User gets list of contexts. Now the context list correctly says [AUT, chrome]
4. User selects chrome context ("WEBVIEW_chrome")
5. User thinks they are automating the chrome context, but actually they're still automating the AUT webview (title, source, etc..., all come from the AUT webview)

This was because, whenever we set up chromedriver, we always used the AUT's android package for chromedriver to attach to.

This PR special cases the chrome webview so that we can correctly attach to its android package from chromedriver. It also makes it so this works even when the user isn't using the (extremely long) `extractChromeAndroidPackageFromContextName` capability.