### PR TITLE
call tempDir from appium-support to respect --temp

### DIFF
--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -179,7 +179,7 @@ commands.pullFile = async function pullFile (remotePath) {
                         `Original error: ${e.message}`);
     }
   }
-  const localFile = tempDir.path({prefix: 'appium', suffix: '.tmp'});
+  const localFile = await tempDir.path({prefix: 'appium', suffix: '.tmp'});
   try {
     await this.adb.pull(_.isString(tmpDestination) ? tmpDestination : remotePath, localFile);
     const data = await fs.readFile(localFile);
@@ -199,7 +199,7 @@ commands.pushFile = async function pushFile (remotePath, base64Data) {
     log.errorAndThrow(`It is expected that remote path points to a file and not to a folder. ` +
                       `'${remotePath}' is given instead`);
   }
-  const localFile = tempDir.path({prefix: 'appium', suffix: '.tmp'});
+  const localFile = await tempDir.path({prefix: 'appium', suffix: '.tmp'});
   if (_.isArray(base64Data)) {
     // some clients (ahem) java, send a byte array encoding utf8 characters
     // instead of a string, which would be infinitely better!
@@ -251,7 +251,7 @@ commands.pushFile = async function pushFile (remotePath, base64Data) {
 };
 
 commands.pullFolder = async function pullFolder (remotePath) {
-  let localFolder = tempDir.path({prefix: 'appium'});
+  let localFolder = await tempDir.path({prefix: 'appium'});
   await this.adb.pull(remotePath, localFolder);
   return (await zip.toInMemoryZip(localFolder)).toString('base64');
 };
@@ -313,7 +313,7 @@ commands.networkSpeed = async function networkSpeed (networkSpeed) {
 };
 
 helpers.getScreenshotDataWithAdbShell = async function getScreenshotDataWithAdbShell (adb, opts) {
-  const localFile = tempDir.path({prefix: 'appium', suffix: '.png'});
+  const localFile = await tempDir.path({prefix: 'appium', suffix: '.png'});
   if (await fs.exists(localFile)) {
     await fs.unlink(localFile);
   }

--- a/lib/commands/actions.js
+++ b/lib/commands/actions.js
@@ -1,7 +1,6 @@
 import androidHelpers from '../android-helpers';
 import _ from 'lodash';
-import temp from 'temp';
-import { fs, util, zip } from 'appium-support';
+import { fs, util, zip, tempDir} from 'appium-support';
 import path from 'path';
 import log from '../logger';
 import B from 'bluebird';
@@ -180,7 +179,7 @@ commands.pullFile = async function pullFile (remotePath) {
                         `Original error: ${e.message}`);
     }
   }
-  const localFile = temp.path({prefix: 'appium', suffix: '.tmp'});
+  const localFile = tempDir.path({prefix: 'appium', suffix: '.tmp'});
   try {
     await this.adb.pull(_.isString(tmpDestination) ? tmpDestination : remotePath, localFile);
     const data = await fs.readFile(localFile);
@@ -200,7 +199,7 @@ commands.pushFile = async function pushFile (remotePath, base64Data) {
     log.errorAndThrow(`It is expected that remote path points to a file and not to a folder. ` +
                       `'${remotePath}' is given instead`);
   }
-  const localFile = temp.path({prefix: 'appium', suffix: '.tmp'});
+  const localFile = tempDir.path({prefix: 'appium', suffix: '.tmp'});
   if (_.isArray(base64Data)) {
     // some clients (ahem) java, send a byte array encoding utf8 characters
     // instead of a string, which would be infinitely better!
@@ -252,7 +251,7 @@ commands.pushFile = async function pushFile (remotePath, base64Data) {
 };
 
 commands.pullFolder = async function pullFolder (remotePath) {
-  let localFolder = temp.path({prefix: 'appium'});
+  let localFolder = tempDir.path({prefix: 'appium'});
   await this.adb.pull(remotePath, localFolder);
   return (await zip.toInMemoryZip(localFolder)).toString('base64');
 };
@@ -314,7 +313,7 @@ commands.networkSpeed = async function networkSpeed (networkSpeed) {
 };
 
 helpers.getScreenshotDataWithAdbShell = async function getScreenshotDataWithAdbShell (adb, opts) {
-  const localFile = temp.path({prefix: 'appium', suffix: '.png'});
+  const localFile = tempDir.path({prefix: 'appium', suffix: '.png'});
   if (await fs.exists(localFile)) {
     await fs.unlink(localFile);
   }

--- a/lib/commands/coverage.js
+++ b/lib/commands/coverage.js
@@ -1,5 +1,4 @@
-import temp from 'temp';
-import { fs } from 'appium-support';
+import { fs, tempDir } from 'appium-support';
 import log from '../logger';
 
 
@@ -12,7 +11,7 @@ async function unlinkFile (file) {
 }
 
 commands.endCoverage = async function endCoverage (intentToBroadcast, ecOnDevicePath) {
-  let localFile = temp.path({prefix: 'appium', suffix: '.ec'});
+  let localFile = tempDir.path({prefix: 'appium', suffix: '.ec'});
   await unlinkFile(localFile);
 
   let b64data = '';

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "shell-quote": "^1.6.1",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.9.0",
-    "temp": "^0.9.0",
     "ws": "^7.0.0",
     "yargs": "^13.1.0"
   },

--- a/test/unit/commands/actions-specs.js
+++ b/test/unit/commands/actions-specs.js
@@ -281,7 +281,7 @@ describe('Actions', function () {
         [tempDir]: {},
       });
 
-      // Stub temp.path to use an in-memory filepath
+      // Stub tempDir.path to use an in-memory filepath
       tempPathStub = sinon.stub(support.tempDir, 'path').returns(tempDir);
     });
 

--- a/test/unit/commands/actions-specs.js
+++ b/test/unit/commands/actions-specs.js
@@ -6,7 +6,6 @@ import path from 'path';
 import mockFS from 'mock-fs';
 import AndroidDriver from '../../..';
 import * as support from 'appium-support';
-import temp from 'temp';
 import ADB from 'appium-adb';
 import jimp from 'jimp';
 import helpers from '../../../lib/commands/actions';
@@ -198,7 +197,7 @@ describe('Actions', function () {
   describe('pullFile', function () {
     it('should be able to pull file from device', async function () {
       let localFile = 'local/tmp_file';
-      sandbox.stub(temp, 'path').returns(localFile);
+      sandbox.stub(support.tempDir, 'path').returns(localFile);
       sandbox.stub(driver.adb, 'pull');
       sandbox.stub(support.fs, 'readFile').withArgs(localFile).returns('appium');
       sandbox.stub(support.fs, 'exists').withArgs(localFile).returns(true);
@@ -214,7 +213,7 @@ describe('Actions', function () {
       const packageId = 'com.myapp';
       const remotePath = 'path/in/container';
       const tmpPath = '/data/local/tmp/container';
-      sandbox.stub(temp, 'path').returns(localFile);
+      sandbox.stub(support.tempDir, 'path').returns(localFile);
       sandbox.stub(driver.adb, 'pull');
       sandbox.stub(driver.adb, 'shell');
       sandbox.stub(support.fs, 'readFile').withArgs(localFile).returns('appium');
@@ -233,7 +232,7 @@ describe('Actions', function () {
     it('should be able to push file to device', async function () {
       let localFile = 'local/tmp_file';
       let content = 'appium';
-      sandbox.stub(temp, 'path').returns(localFile);
+      sandbox.stub(support.tempDir, 'path').returns(localFile);
       sandbox.stub(driver.adb, 'push');
       sandbox.stub(driver.adb, 'shell');
       sandbox.stub(support.fs, 'writeFile');
@@ -251,7 +250,7 @@ describe('Actions', function () {
       const packageId = 'com.myapp';
       const remotePath = 'path/in/container';
       const tmpPath = '/data/local/tmp/container';
-      sandbox.stub(temp, 'path').returns(localFile);
+      sandbox.stub(support.tempDir, 'path').returns(localFile);
       sandbox.stub(driver.adb, 'push');
       sandbox.stub(driver.adb, 'shell');
       sandbox.stub(support.fs, 'writeFile');
@@ -283,7 +282,7 @@ describe('Actions', function () {
       });
 
       // Stub temp.path to use an in-memory filepath
-      tempPathStub = sinon.stub(temp, 'path').returns(tempDir);
+      tempPathStub = sinon.stub(support.tempDir, 'path').returns(tempDir);
     });
 
     after(function () {
@@ -453,7 +452,7 @@ describe('Actions', function () {
     const png = '/path/sc.png';
     const localFile = 'local_file';
     beforeEach(function () {
-      sandbox.stub(temp, 'path');
+      sandbox.stub(support.tempDir, 'path');
       sandbox.stub(support.fs, 'exists');
       sandbox.stub(support.fs, 'unlink');
       sandbox.stub(driver.adb, 'shell');
@@ -461,7 +460,7 @@ describe('Actions', function () {
       sandbox.stub(path.posix, 'resolve');
       sandbox.stub(jimp, 'read');
       sandbox.stub(driver.adb, 'fileSize');
-      temp.path.returns(localFile);
+      support.tempDir.path.returns(localFile);
       support.fs.exists.withArgs(localFile).returns(true);
       support.fs.unlink.withArgs(localFile).returns(true);
       path.posix.resolve.withArgs(defaultDir, 'screenshot.png').returns(png);

--- a/test/unit/commands/recordscreen-specs.js
+++ b/test/unit/commands/recordscreen-specs.js
@@ -2,8 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import AndroidDriver from '../../..';
 import { withMocks } from 'appium-test-support';
-import { fs } from 'appium-support';
-import temp from 'temp';
+import { fs, tempDir } from 'appium-support';
 import ADB from 'appium-adb';
 
 
@@ -16,7 +15,7 @@ driver.adb = adb;
 describe('recording the screen', function () {
   this.timeout(60000);
 
-  describe('basic', withMocks({adb, driver, fs, temp}, (mocks) => {
+  describe('basic', withMocks({adb, driver, fs, tempDir}, (mocks) => {
     it('should fail to recording the screen on an older emulator', async function () {
       mocks.driver.expects('isEmulator').returns(true);
       mocks.adb.expects('getApiLevel').returns(26);


### PR DESCRIPTION
related to https://github.com/appium/appium-support/pull/112
To respect `--tmp` arg by the PR, `temp.path` should be `tempDir.path`.