### PR TITLE
Use existing chrome if noReset is true

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -219,7 +219,9 @@ helpers.dismissChromeWelcome = async function dismissChromeWelcome () {
 helpers.startChromeSession = async function startChromeSession () {
   log.info('Starting a chrome-based browser session');
   let opts = _.cloneDeep(this.opts);
-  opts.chromeUseRunningApp = false;
+
+  // if we are specifically not resetting, use the running app
+  opts.chromeUseRunningApp = !!opts.noReset;
 
   const knownPackages = [
     'org.chromium.chrome.shell',


### PR DESCRIPTION
If `noReset` is set to `true`, use an existing Chrome. Without this a temporary profile is used for each session, so everything is new.

If `noReset` is `false` or not defined, it sill stay as `false`.