### PR TITLE
Improve the error message for the missing screen recording

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -131,7 +131,7 @@ async function scheduleScreenRecord (adb, recordingProperties) {
       {waitMs: RETRY_TIMEOUT, intervalMs: RETRY_PAUSE});
   } catch (e) {
     throw new Error(`The expected screen record file '${pathOnDevice}' does not exist after ${RETRY_TIMEOUT}ms. ` +
-      `Is ${SCREENRECORD_BINARY} utility available and functional on the device under test?`);
+      `Is ${SCREENRECORD_BINARY} utility available and operational on the device under test?`);
   }
 
   recordingProperties.records.push(pathOnDevice);

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -130,7 +130,8 @@ async function scheduleScreenRecord (adb, recordingProperties) {
     await waitForCondition(async () => await adb.fileExists(pathOnDevice),
       {waitMs: RETRY_TIMEOUT, intervalMs: RETRY_PAUSE});
   } catch (e) {
-    throw new Error(`The expected screen record file '${pathOnDevice}' does not exist after ${RETRY_TIMEOUT}ms`);
+    throw new Error(`The expected screen record file '${pathOnDevice}' does not exist after ${RETRY_TIMEOUT}ms. ` +
+      `Is ${SCREENRECORD_BINARY} utility available and functional on the device under test?`);
   }
 
   recordingProperties.records.push(pathOnDevice);


### PR DESCRIPTION
It is said that some phone manufacturers don't include `screenrecord` into the set of available binaries. 