### PR TITLE
Use `am start` instead of `monkey` to start the Settings helper

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -8,8 +8,9 @@ import { path as settingsApkPath } from 'io.appium.settings';
 import Bootstrap from './bootstrap';
 import B from 'bluebird';
 import ADB from 'appium-adb';
-import { default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK,
-         PATTERN_UNLOCK, FINGERPRINT_UNLOCK } from './unlock-helpers';
+import {
+  default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK,
+  PATTERN_UNLOCK, FINGERPRINT_UNLOCK } from './unlock-helpers';
 import { EOL } from 'os';
 
 const PACKAGE_INSTALL_TIMEOUT = 90000; // milliseconds
@@ -532,38 +533,25 @@ helpers.pushSettingsApp = async function pushSettingsApp (adb, throwError = fals
   // if the app is not launched prior to start the session on android 7+
   // see https://github.com/appium/appium/issues/8957
   try {
-    logger.debug(`Activating '${SETTINGS_HELPER_PKG_ID}'`);
-    const monkeyOutput = await adb.shell([
-      'monkey',
-      '-p', SETTINGS_HELPER_PKG_ID,
-      '-c', 'android.intent.category.LAUNCHER',
-      '1'
-    ]);
-    logger.debug(`Command stdout: ${monkeyOutput}`);
-  } catch (e) {
-    logger.debug(e.message);
-  }
-  try {
+    await adb.startApp({
+      pkg: SETTINGS_HELPER_PKG_ID,
+      activity: SETTINGS_HELPER_MAIN_ACTIVITY,
+      action: 'android.intent.action.MAIN',
+      category: 'android.intent.category.LAUNCHER',
+      stopApp: false,
+      waitForLaunch: false,
+    });
+
     await waitForCondition(async () => await adb.processExists(SETTINGS_HELPER_PKG_ID), {
       waitMs: 5000,
       intervalMs: 300,
     });
-  } catch (e) {
-    logger.debug(`Cannot activate '${SETTINGS_HELPER_PKG_ID}'. Falling back to startApp call`);
-    try {
-      await adb.startApp({
-        pkg: SETTINGS_HELPER_PKG_ID,
-        activity: SETTINGS_HELPER_MAIN_ACTIVITY,
-        action: 'android.intent.action.MAIN',
-        category: 'android.intent.category.LAUNCHER',
-        flags: '0x10200000',
-        stopApp: true,
-      });
-    } catch (err) {
-      logger.warn(`Failed to launch settings app: ${err.message}`);
-      if (throwError) {
-        throw err;
-      }
+  } catch (err) {
+    const message = `Failed to launch Appium Settings app: ${err.message}`;
+    err.message = message;
+    logger.warn(message);
+    if (throwError) {
+      throw err;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^7.7.0",
+    "appium-adb": "^7.8.0",
     "appium-base-driver": "^3.15.5",
     "appium-chromedriver": "^4.8.0",
     "appium-support": "^2.25.0",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -508,16 +508,10 @@ describe('Android Helpers', function () {
         .onCall(1).returns(true);
       mocks.adb.expects('getApiLevel').once()
         .returns(24);
-      mocks.adb.expects('shell').once()
-        .withExactArgs(['monkey',
-          '-p', 'io.appium.settings',
-          '-c', 'android.intent.category.LAUNCHER',
-          '1'])
-        .returns('');
+      mocks.adb.expects('startApp').once();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });
-
     it('should launch settings app if it isnt running on under API level 23 devices', async function () {
       mocks.adb.expects('installOrUpgrade').once()
         .returns(true);
@@ -530,12 +524,7 @@ describe('Android Helpers', function () {
         .withExactArgs('io.appium.settings',
           ['android.permission.SET_ANIMATION_SCALE', 'android.permission.CHANGE_CONFIGURATION', 'android.permission.ACCESS_FINE_LOCATION'])
         .returns(true);
-      mocks.adb.expects('shell').once()
-        .withExactArgs(['monkey',
-          '-p', 'io.appium.settings',
-          '-c', 'android.intent.category.LAUNCHER',
-          '1'])
-        .returns('');
+      mocks.adb.expects('startApp').once();
       await helpers.pushSettingsApp(adb);
       mocks.adb.verify();
     });


### PR DESCRIPTION
Monkey tool does not respect orientation settings and thus can be harmful while running automated tests on real devices.