### PR TITLE
feat: add 'ensureWebviewsHavePages' cap

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -33,7 +33,8 @@ commands.getContexts = async function getContexts () {
   } else {
     // otherwise we use ADB to figure out which webviews are available
     webviews = await webviewHelpers.getWebviews(this.adb,
-      this.opts.androidDeviceSocket);
+      this.opts.androidDeviceSocket, this.opts.ensureWebviewsHavePages,
+      this.opts.webviewDevtoolsPort);
   }
   this.contexts = _.union([NATIVE_WIN], webviews);
   log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -32,9 +32,7 @@ commands.getContexts = async function getContexts () {
     webviews = [CHROMIUM_WIN];
   } else {
     // otherwise we use ADB to figure out which webviews are available
-    webviews = await webviewHelpers.getWebviews(this.adb,
-      this.opts.androidDeviceSocket, this.opts.ensureWebviewsHavePages,
-      this.opts.webviewDevtoolsPort);
+    webviews = await webviewHelpers.getWebviews(this.adb, this.opts);
   }
   this.contexts = _.union([NATIVE_WIN], webviews);
   log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -73,6 +73,12 @@ let commonCapConstraints = {
   keyPassword: {
     isString: true
   },
+  webviewDevtoolsPort: {
+    isNumber: true
+  },
+  ensureWebviewsHavePages: {
+    isBoolean: true
+  },
   // this one is deprecated
   chromeDriverPort: {
     isNumber: true

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -24,7 +24,7 @@ let helpers = {};
  *
  * @param {object} adb - an ADB instance
  *
- * @return {Array} - a list of webview process names (including the leading
+ * @return {Array.<string>} - a list of webview process names (including the leading
  * '@')
  */
 async function getPotentialWebviewProcs (adb) {
@@ -43,6 +43,12 @@ async function getPotentialWebviewProcs (adb) {
 }
 
 /**
+ * @typedef {Object} WebviewProc
+ * @property {string} proc - The webview process name (as returned by
+ * getPotentialWebviewProcs
+ * @property {string} webview - The actual webview context name
+ */
+/**
  * This function retrieves a list of system processes that look like webviews,
  * and returns them along with the webview context name appropriate for it.
  * If we pass in a deviceSocket, we only attempt to find webviews which match
@@ -52,8 +58,7 @@ async function getPotentialWebviewProcs (adb) {
  * @param {object} adb - an ADB instance
  * @param {string} deviceSocket - the explictly-named device socket to use
  *
- * @return {Array} - a list of objects of the form
- * {proc: <proc-name>, webview: <webview-name>}
+ * @return {Array.<WebviewProc>}
  */
 // TODO: some of this function probably belongs in appium-adb?
 async function webviewsFromProcs (adb, deviceSocket) {
@@ -92,8 +97,7 @@ async function webviewsFromProcs (adb, deviceSocket) {
  * pages, because such processes can't be automated by chromedriver anyway.
  *
  * @param {object} adb - an ADB instance
- * @param {object} wp - a 'webview-proc' object (as returned by
- * webviewsFromProcs), containing a 'proc' and 'webview' field.
+ * @param {WebviewProc} wp - the webview to check
  * @param {number} webviewDevtoolsPort - the local port to use for the check
  *
  * @return {boolean} - whether or not the webview has pages
@@ -202,6 +206,14 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
 };
 
 /**
+ * @typedef {Object} GetWebviewsOpts
+ * @property {string} androidDeviceSocket - device socket name
+ * @property {boolean} ensureWebviewsHavePages - whether to check for webview
+ * page presence
+ * @property {number} webviewDevtoolsPort - port to use for webview page
+ * presence check (if not the default of 9222).
+ */
+/**
  * Get a list of available webviews by introspecting processes with adb, where
  * webviews are listed. It's possible to pass in a 'deviceSocket' arg, which
  * limits the webview possibilities to the one running on the Chromium devtools
@@ -215,14 +227,9 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
  * should be used for this communication.
  *
  * @param {object} adb - an ADB instance
- * @param {object} opts - an object with zero or more of the following fields:
- *  - androidDeviceSocket {string} - device socket name
- *  - ensureWebviewsHavePages {boolean} - whether to check for webview page
- *    presence
- *  - webviewDevtoolsPort {number} - port to use for webview page presence
- *    check (if not the default of 9222).
+ * @param {GetWebviewOpts} opts
  *
- * @return {Array} - a list of webview names
+ * @return {Array.<string>} - a list of webview names
  */
 helpers.getWebviews = async function getWebviews (adb, {
   androidDeviceSocket = null,
@@ -235,9 +242,9 @@ helpers.getWebviews = async function getWebviews (adb, {
 
   if (ensureWebviewsHavePages) {
     logger.info('Retrieved potential webviews; will filter out ones with no active pages');
-    webviewProcs = await asyncfilter(webviewProcs, async (wp) => {
-      return await webviewHasPages(adb, wp, webviewDevtoolsPort);
-    }, false /*ensure serial operation*/);
+    webviewProcs = await asyncfilter(webviewProcs,
+      async (wp) => await webviewHasPages(adb, wp, webviewDevtoolsPort),
+      false /*ensure serial operation*/);
   } else {
     logger.info('Not checking whether webviews have active pages; use the ' +
                 "'ensureWebviewsHavePages' cap to turn this check on");

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import logger from './logger';
-import { asyncmap } from 'asyncbox';
+import request from 'request-promise';
+import { asyncmap, asyncfilter } from 'asyncbox';
 
 const NATIVE_WIN = 'NATIVE_APP';
 const WEBVIEW_WIN = 'WEBVIEW';
@@ -12,48 +13,97 @@ const CROSSWALK_SOCKET_SUFFIX = '_devtools_remote';
 const CROSSWALK_REGEXP_STRING = `(\\S*)${CROSSWALK_SOCKET_SUFFIX}`;
 const CROSSWALK_REGEXP = new RegExp(`@${CROSSWALK_REGEXP_STRING}`);
 const CROSSWALK_PROCESS_REGEXP = new RegExp(WEBVIEW_BASE + CROSSWALK_REGEXP_STRING);
+const DEFAULT_WEBVIEW_DEVTOOLS_PORT = 9222;
 
 
 let helpers = {};
 
 // This function gets a list of android system processes and returns ones
-// that look like webviews, with the appropriate webview prefix and their PID.
-// If we pass in a deviceSocket, we only attempt to find webviews which match
-// that socket name (this is for apps which embed Chromium, which isn't the
-// same as chrome-backed webviews)
-// TODO: some of this function belongs in appium-adb
-async function webviewsFromProcs (adb, deviceSocket) {
-  let webviews = [];
-  let out = await adb.shell(['cat', '/proc/net/unix']);
+// that look like webviews
+async function getPotentialWebviewProcs (adb) {
+  const procs = [];
+  const out = await adb.shell(['cat', '/proc/net/unix']);
   for (let line of out.split('\n')) {
     line = line.trim();
+    let regexMatch;
+    if ((regexMatch = (line.match(WEBVIEW_REGEXP) || line.match(CROSSWALK_REGEXP)))) {
+      procs.push(regexMatch[0]);
+    }
+  }
 
-    if (deviceSocket) {
-      if (line.indexOf(`@${deviceSocket}`) === line.length - deviceSocket.length - 1) {
-        if (deviceSocket === 'chrome_devtools_remote') {
-          webviews.push(CHROMIUM_WIN);
-          continue;
-        }
-      }
+  // sometimes the webview process shows up multiple times per app
+  return _.uniq(procs);
+}
+
+// This function retrieves a list of system processes that look like webviews,
+// and returns them along with the webview context name appropriate for it.
+// If we pass in a deviceSocket, we only attempt to find webviews which match
+// that socket name (this is for apps which embed Chromium, which isn't the
+// same as chrome-backed webviews). Returns a list of objects of the form
+// {proc: <proc-name>, webview: <webview-name>}
+// TODO: some of this function probably belongs in appium-adb?
+async function webviewsFromProcs (adb, deviceSocket) {
+  const procs = await getPotentialWebviewProcs(adb);
+  const webviews = [];
+  for (const proc of procs) {
+    if (deviceSocket === 'chrome_devtools_remote' && proc === `@${deviceSocket}`) {
+      webviews.push({proc, webview: CHROMIUM_WIN});
+      continue;
     }
 
     let webviewPid;
     let crosswalkWebviewSocket;
-    if ((webviewPid = line.match(WEBVIEW_REGEXP))) {
+    if ((webviewPid = proc.match(WEBVIEW_REGEXP))) {
       // for multiple webviews a list of 'WEBVIEW_<index>' will be returned
       // where <index> is zero based (same is in selendroid)
-      webviews.push(`${WEBVIEW_BASE}${webviewPid[1]}`);
-    } else if ((crosswalkWebviewSocket = line.match(CROSSWALK_REGEXP))) {
+      webviews.push({proc, webview: `${WEBVIEW_BASE}${webviewPid[1]}`});
+    } else if ((crosswalkWebviewSocket = proc.match(CROSSWALK_REGEXP))) {
       if (deviceSocket) {
-        if (crosswalkWebviewSocket[0].slice(1) === deviceSocket) {
-          webviews.push(`${WEBVIEW_BASE}${crosswalkWebviewSocket[1]}`);
+        if (crosswalkWebviewSocket[0] === `@${deviceSocket}`) {
+          webviews.push({proc, webview: `${WEBVIEW_BASE}${crosswalkWebviewSocket[1]}`});
         }
       } else {
-        webviews.push(`${WEBVIEW_BASE}${crosswalkWebviewSocket[1]}${CROSSWALK_SOCKET_SUFFIX}`);
+        webviews.push({proc, webview: `${WEBVIEW_BASE}${crosswalkWebviewSocket[1]}${CROSSWALK_SOCKET_SUFFIX}`});
       }
     }
   }
-  return _.uniq(webviews);
+  return webviews;
+}
+
+// given a 'webview-proc' object, check whether we can detect any active pages
+// corresponding to that webview. This is used by getWebviews to filter out any
+// webview-looking processes which have a remote debug port open but which
+// aren't actually running any pages, because such processes can't be automated
+// by chromedriver anyway.
+async function webviewHasPages (adb, wp, webviewDevtoolsPort) {
+  let hasPages = false;
+  const wvPort = webviewDevtoolsPort || DEFAULT_WEBVIEW_DEVTOOLS_PORT;
+
+  // proc names come with '@', but this should not be a part of the abstract
+  // remote port, so remove it
+  const remotePort = wp.proc.replace('@', '');
+
+  // forward the specified local port to the remote debugger port on the device
+  await adb.adbExec(['forward', `tcp:${wvPort}`, `localabstract:${remotePort}`]);
+  try {
+    const remoteDebugger = `http://localhost:${wvPort}/json/list`;
+    logger.info(`Attempting to get list of pages for webview '${wp.webview}' ` +
+                `from the remote debugger at ${remoteDebugger}.`);
+    // take advantage of the chrome remote debugger REST API just to get
+    // a list of pages
+    const pages = await request({
+      uri: remoteDebugger,
+      json: true
+    });
+    if (pages.length > 0) {
+      logger.info(`Webview '${wp.webview}' has pages`);
+      hasPages = true;
+    }
+  } catch (e) {
+    logger.warn(`Got error when retrieving page list, will assume no pages: ${e}`);
+  }
+  await adb.removePortForward(wvPort); // make sure we clean up
+  return hasPages;
 }
 
 // Take a webview name like WEBVIEW_4296 and use 'adb shell ps' to figure out
@@ -112,10 +162,34 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
 // Get a list of available webviews by introspecting processes with adb, where
 // webviews are listed. It's possible to pass in a 'deviceSocket' arg, which
 // limits the webview possibilities to the one running on the Chromium devtools
-// socket we're interested in (see note on webviewsFromProcs)
-helpers.getWebviews = async function getWebviews (adb, deviceSocket) {
+// socket we're interested in (see note on webviewsFromProcs). We can also
+// direct this method to verify whether a particular webview process actually
+// has any pages (if a process exists but no pages are found, Chromedriver will
+// not actually be able to connect to it, so this serves as a guard for that
+// strange failure mode). The strategy for checking whether any pages are
+// active involves sending a request to the remote debug server on the device,
+// hence it is also possible to specify the port on the host machine which
+// should be used for this communication.
+helpers.getWebviews = async function getWebviews (adb, deviceSocket,
+  ensureWebviewsHavePages, webviewDevtoolsPort) {
+
   logger.debug('Getting a list of available webviews');
-  let webviews = await webviewsFromProcs(adb, deviceSocket);
+  let webviewProcs = await webviewsFromProcs(adb, deviceSocket);
+
+  if (ensureWebviewsHavePages) {
+    logger.info('Retrieved potential webviews; will filter out ones with no active pages');
+    webviewProcs = await asyncfilter(webviewProcs, async (wp) => {
+      return await webviewHasPages(adb, wp, webviewDevtoolsPort);
+    }, false /*ensure serial operation*/);
+  } else {
+    logger.info('Not checking whether webviews have active pages; use the ' +
+                "'ensureWebviewsHavePages' cap to turn this check on");
+  }
+
+  // webviewProcs contains procs, which we only care about for ensuring
+  // presence of pages above, so we can now discard them and rely on just the
+  // webview names
+  let webviews = webviewProcs.map((wp) => wp.webview);
 
   if (deviceSocket) {
     return webviews;

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -18,8 +18,15 @@ const DEFAULT_WEBVIEW_DEVTOOLS_PORT = 9222;
 
 let helpers = {};
 
-// This function gets a list of android system processes and returns ones
-// that look like webviews
+/**
+ * This function gets a list of android system processes and returns ones
+ * that look like webviews
+ *
+ * @param {object} adb - an ADB instance
+ *
+ * @return {Array} - a list of webview process names (including the leading
+ * '@')
+ */
 async function getPotentialWebviewProcs (adb) {
   const procs = [];
   const out = await adb.shell(['cat', '/proc/net/unix']);
@@ -35,12 +42,19 @@ async function getPotentialWebviewProcs (adb) {
   return _.uniq(procs);
 }
 
-// This function retrieves a list of system processes that look like webviews,
-// and returns them along with the webview context name appropriate for it.
-// If we pass in a deviceSocket, we only attempt to find webviews which match
-// that socket name (this is for apps which embed Chromium, which isn't the
-// same as chrome-backed webviews). Returns a list of objects of the form
-// {proc: <proc-name>, webview: <webview-name>}
+/**
+ * This function retrieves a list of system processes that look like webviews,
+ * and returns them along with the webview context name appropriate for it.
+ * If we pass in a deviceSocket, we only attempt to find webviews which match
+ * that socket name (this is for apps which embed Chromium, which isn't the
+ * same as chrome-backed webviews).
+ *
+ * @param {object} adb - an ADB instance
+ * @param {string} deviceSocket - the explictly-named device socket to use
+ *
+ * @return {Array} - a list of objects of the form
+ * {proc: <proc-name>, webview: <webview-name>}
+ */
 // TODO: some of this function probably belongs in appium-adb?
 async function webviewsFromProcs (adb, deviceSocket) {
   const procs = await getPotentialWebviewProcs(adb);
@@ -70,25 +84,46 @@ async function webviewsFromProcs (adb, deviceSocket) {
   return webviews;
 }
 
-// given a 'webview-proc' object, check whether we can detect any active pages
-// corresponding to that webview. This is used by getWebviews to filter out any
-// webview-looking processes which have a remote debug port open but which
-// aren't actually running any pages, because such processes can't be automated
-// by chromedriver anyway.
-async function webviewHasPages (adb, wp, webviewDevtoolsPort) {
+/**
+ * Given a 'webview-proc' object resulting from a call to webviewsFromProcs,
+ * check whether we can detect any active pages corresponding to that webview.
+ * This is used by getWebviews to filter out any webview-looking processes
+ * which have a remote debug port open but which aren't actually running any
+ * pages, because such processes can't be automated by chromedriver anyway.
+ *
+ * @param {object} adb - an ADB instance
+ * @param {object} wp - a 'webview-proc' object (as returned by
+ * webviewsFromProcs), containing a 'proc' and 'webview' field.
+ * @param {number} webviewDevtoolsPort - the local port to use for the check
+ *
+ * @return {boolean} - whether or not the webview has pages
+ */
+async function webviewHasPages (adb, {proc, webview}, webviewDevtoolsPort) {
   let hasPages = false;
   const wvPort = webviewDevtoolsPort || DEFAULT_WEBVIEW_DEVTOOLS_PORT;
 
   // proc names come with '@', but this should not be a part of the abstract
   // remote port, so remove it
-  const remotePort = wp.proc.replace('@', '');
+  const remotePort = proc.replace(/^@/, '');
+
+  // we don't want to mess with things if our wvPort is already forwarded,
+  // since who knows what is currently going on there. So determine if it is
+  // already forwarded, and just short-circuit this whole method if so.
+  const portAlreadyForwarded = (await adb.getForwardList())
+    .map((line) => line.split(' ')[1]) // the local port is the second field in the line
+    .reduce((acc, portSpec) => acc || portSpec === `tcp:${wvPort}`, false);
+  if (portAlreadyForwarded) {
+    logger.warn(`Port ${wvPort} was already forwarded when attempting webview ` +
+                `page presence check, so was unable to perform check.`);
+    return false;
+  }
 
   // forward the specified local port to the remote debugger port on the device
   await adb.adbExec(['forward', `tcp:${wvPort}`, `localabstract:${remotePort}`]);
   try {
     const remoteDebugger = `http://localhost:${wvPort}/json/list`;
-    logger.info(`Attempting to get list of pages for webview '${wp.webview}' ` +
-                `from the remote debugger at ${remoteDebugger}.`);
+    logger.debug(`Attempting to get list of pages for webview '${webview}' ` +
+                 `from the remote debugger at ${remoteDebugger}.`);
     // take advantage of the chrome remote debugger REST API just to get
     // a list of pages
     const pages = await request({
@@ -96,9 +131,9 @@ async function webviewHasPages (adb, wp, webviewDevtoolsPort) {
       json: true
     });
     if (pages.length > 0) {
-      logger.info(`Webview '${wp.webview}' has pages`);
       hasPages = true;
     }
+    logger.info(`Webview '${webview}' has ${hasPages ? '' : 'no '} pages`);
   } catch (e) {
     logger.warn(`Got error when retrieving page list, will assume no pages: ${e}`);
   }
@@ -106,11 +141,18 @@ async function webviewHasPages (adb, wp, webviewDevtoolsPort) {
   return hasPages;
 }
 
-// Take a webview name like WEBVIEW_4296 and use 'adb shell ps' to figure out
-// which app package is associated with that webview. One of the reasons we
-// want to do this is to make sure we're listing webviews for the actual AUT,
-// not some other running app
-// TODO: this should be called procFromPid and exist in appium-adb
+/**
+ * Take a webview name like WEBVIEW_4296 and use 'adb shell ps' to figure out
+ * which app package is associated with that webview. One of the reasons we
+ * want to do this is to make sure we're listing webviews for the actual AUT,
+ * not some other running app
+ *
+ * @param {object} adb - an ADB instance
+ * @param {string} webview - a webview process name
+ *
+ * @returns {string} - the package name of the app running the webview
+ */
+// TODO: this should probably be called procFromPid and exist in appium-adb
 helpers.procFromWebview = async function procFromWebview (adb, webview) {
   if (webview.match(WEBVIEW_PID_REGEXP) === null) {
     let processName = webview.match(CROSSWALK_PROCESS_REGEXP);
@@ -159,22 +201,37 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
   return pkg;
 };
 
-// Get a list of available webviews by introspecting processes with adb, where
-// webviews are listed. It's possible to pass in a 'deviceSocket' arg, which
-// limits the webview possibilities to the one running on the Chromium devtools
-// socket we're interested in (see note on webviewsFromProcs). We can also
-// direct this method to verify whether a particular webview process actually
-// has any pages (if a process exists but no pages are found, Chromedriver will
-// not actually be able to connect to it, so this serves as a guard for that
-// strange failure mode). The strategy for checking whether any pages are
-// active involves sending a request to the remote debug server on the device,
-// hence it is also possible to specify the port on the host machine which
-// should be used for this communication.
-helpers.getWebviews = async function getWebviews (adb, deviceSocket,
-  ensureWebviewsHavePages, webviewDevtoolsPort) {
+/**
+ * Get a list of available webviews by introspecting processes with adb, where
+ * webviews are listed. It's possible to pass in a 'deviceSocket' arg, which
+ * limits the webview possibilities to the one running on the Chromium devtools
+ * socket we're interested in (see note on webviewsFromProcs). We can also
+ * direct this method to verify whether a particular webview process actually
+ * has any pages (if a process exists but no pages are found, Chromedriver will
+ * not actually be able to connect to it, so this serves as a guard for that
+ * strange failure mode). The strategy for checking whether any pages are
+ * active involves sending a request to the remote debug server on the device,
+ * hence it is also possible to specify the port on the host machine which
+ * should be used for this communication.
+ *
+ * @param {object} adb - an ADB instance
+ * @param {object} opts - an object with zero or more of the following fields:
+ *  - androidDeviceSocket {string} - device socket name
+ *  - ensureWebviewsHavePages {boolean} - whether to check for webview page
+ *    presence
+ *  - webviewDevtoolsPort {number} - port to use for webview page presence
+ *    check (if not the default of 9222).
+ *
+ * @return {Array} - a list of webview names
+ */
+helpers.getWebviews = async function getWebviews (adb, {
+  androidDeviceSocket = null,
+  ensureWebviewsHavePages = null,
+  webviewDevtoolsPort = null
+} = {}) {
 
   logger.debug('Getting a list of available webviews');
-  let webviewProcs = await webviewsFromProcs(adb, deviceSocket);
+  let webviewProcs = await webviewsFromProcs(adb, androidDeviceSocket);
 
   if (ensureWebviewsHavePages) {
     logger.info('Retrieved potential webviews; will filter out ones with no active pages');
@@ -191,7 +248,7 @@ helpers.getWebviews = async function getWebviews (adb, deviceSocket,
   // webview names
   let webviews = webviewProcs.map((wp) => wp.webview);
 
-  if (deviceSocket) {
+  if (androidDeviceSocket) {
     return webviews;
   }
 

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -86,7 +86,7 @@ describe('Webview Helpers', function () {
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
         });
 
-        webViews = await helpers.getWebviews(adb, 'webview_devtools_remote_123');
+        webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'webview_devtools_remote_123'});
       });
 
       it('then the unix sockets are queried', function () {
@@ -112,7 +112,7 @@ describe('Webview Helpers', function () {
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
         });
 
-        webViews = await helpers.getWebviews(adb, 'chrome_devtools_remote');
+        webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'chrome_devtools_remote'});
       });
 
       it('then the unix sockets are queried', function () {
@@ -181,7 +181,7 @@ describe('Webview Helpers', function () {
 
       describe('and the device socket is specified', function () {
         beforeEach(async function () {
-          webViews = await helpers.getWebviews(adb, 'com.application.myapp_devtools_remote');
+          webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'com.application.myapp_devtools_remote'});
         });
 
         it('then the unix sockets are queried', function () {
@@ -197,7 +197,7 @@ describe('Webview Helpers', function () {
 
       describe('and the device socket is specified but is not found', function () {
         beforeEach(async function () {
-          webViews = await helpers.getWebviews(adb, 'com.application.myotherapp_devtools_remote');
+          webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'com.application.myotherapp_devtools_remote'});
         });
 
         it('then the unix sockets are queried', function () {


### PR DESCRIPTION
This PR fixes an odd situation which I have observed with Chrome-backed webviews on Android. Currently, Appium's code assumes that if it can find a webview-type process in `/proc/net/unix`, then a webview exists for that process.

I've noticed that this assumption is not always true. Sometimes, the process exists, and a Chrome remote debugger is even running for the process, but there are no active webview pages. In this case, Chromedriver will always fail to attach to the webview, resulting in an error like "unable to discover open pages".

This PR adds a new capability `ensureWebviewsHavePages` which, if true, attempts to verify that a webview actually has active pages before adding it to the list of contexts. This serves to prevent users from trying to connect to a webview which is guaranteed to fail, and which will result in a cryptic error message.

I've added this behind a capability because the only way I can see to achieve this is to send a request to one of the [Chrome devtools HTTP endpoints](https://chromedevtools.github.io/devtools-protocol/). This involves running an adb command to forward a local port to the remote debugger port on the device, so we can make the necessary HTTP request, and then cleaning up the forwarded port afterwards. Thus it potentially adds overhead of time, and I'm also not certain that all webviews on all supported versions of Android support the Chrome devtools HTTP server. Once this feature is well-tested and proved useful, we could make this behavior opt-out rather than opt-in.

Because a local port is required for this feature, I've also added another capability, `webviewDevtoolsPort`, so that clients can specify a port to avoid port conflicts between sessions.