### PR TITLE
Fix time zone formatting for device time getter

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -34,22 +34,16 @@ commands.doSendKeys = async function doSendKeys (params) {
  *                          `YYYY-MM-DDTHH:mm:ssZ`, which complies to ISO-8601
  * @returns Formatted datetime string or the raw command output if formatting fails
  */
-const DEFAULT_DEVICE_TIME = 'YYYY-MM-DDTHH:mm:ssZ';
-commands.getDeviceTime = async function getDeviceTime (format = DEFAULT_DEVICE_TIME) {
-  log.info('Attempting to capture android device date and time');
-
-  if (!_.isString(format)) {
-    log.errorAndThrow(`The format specifier is expected to be a valid string specifier like '${DEFAULT_DEVICE_TIME}'. ` +
-        `The current value is: ${format}`);
-  }
-
+commands.getDeviceTime = async function getDeviceTime (format = 'YYYY-MM-DDTHH:mm:ssZ') {
+  log.info(`Attempting to capture android device date and time and format it as ${format}`);
   const deviceTimestamp = (await this.adb.shell(['date', '+%Y-%m-%dT%T%z'])).trim();
-  const parsedTimestamp = moment(deviceTimestamp, 'YYYY-MM-DDTHH:mm:ssZ');
+  log.debug(`Got device timestamp: ${deviceTimestamp}`);
+  const parsedTimestamp = moment.utc(deviceTimestamp, 'YYYY-MM-DDTHH:mm:ssZZ');
   if (!parsedTimestamp.isValid()) {
-    log.warn(`Cannot parse the returned timestamp '${deviceTimestamp}'. Returning as is`);
+    log.warn('Cannot parse the returned timestamp. Returning as is');
     return deviceTimestamp;
   }
-  return parsedTimestamp.format(format);
+  return parsedTimestamp.utcOffset(parsedTimestamp._tzm).format(format);
 };
 
 commands.getPageSource = async function getPageSource () {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -35,7 +35,8 @@ commands.doSendKeys = async function doSendKeys (params) {
  * @returns Formatted datetime string or the raw command output if formatting fails
  */
 commands.getDeviceTime = async function getDeviceTime (format = 'YYYY-MM-DDTHH:mm:ssZ') {
-  log.info(`Attempting to capture android device date and time and format it as ${format}`);
+  log.debug('Attempting to capture android device date and time. ' +
+    `The format specifier is '${format}'`);
   const deviceTimestamp = (await this.adb.shell(['date', '+%Y-%m-%dT%T%z'])).trim();
   log.debug(`Got device timestamp: ${deviceTimestamp}`);
   const parsedTimestamp = moment.utc(deviceTimestamp, 'YYYY-MM-DDTHH:mm:ssZZ');

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -65,12 +65,6 @@ describe('General', function () {
       sandbox.stub(driver.adb, 'shell').throws();
       await driver.getDeviceTime().should.be.rejected;
     });
-    it('should throw error if format is not string', async function () {
-      sandbox.stub(driver.adb, 'shell').throws();
-      await driver.getDeviceTime({}).should.be.rejectedWith(
-        /The format specifier is expected to be a valid string specifier/
-      );
-    });
   });
   describe('getPageSource', function () {
     it('should return page source', async function () {

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -9,7 +9,6 @@ import { fs } from 'appium-support';
 import Bootstrap from '../../../lib/bootstrap';
 import B from 'bluebird';
 import ADB from 'appium-adb';
-import moment from 'moment-timezone';
 
 
 chai.should();

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -50,16 +50,10 @@ describe('General', function () {
     });
   });
   describe('getDeviceTime', function () {
-    beforeEach(function () {
-      moment.tz.setDefault('Atlantic/Reykjavik');
-    });
-    afterEach(function () {
-      moment.tz.setDefault();
-    });
     it('should return device time', async function () {
       sandbox.stub(driver.adb, 'shell');
       driver.adb.shell.returns(' 2018-06-09T16:21:54+0900 ');
-      await driver.getDeviceTime().should.become('2018-06-09T07:21:54+00:00');
+      await driver.getDeviceTime().should.become('2018-06-09T16:21:54+09:00');
       driver.adb.shell.calledWithExactly(['date', '+%Y-%m-%dT%T%z']).should.be.true;
     });
     it('should return device time with custom format', async function () {


### PR DESCRIPTION
By default moment.js uses the local time zone. And we need to enforce the device time zone to be used while formatting the resulting stamp.

Addresses https://discuss.appium.io/t/driver-getdevicetime-works-incorrectly-for-appium-1-7-2/27369/3