### PR TITLE
fix: Fix partial platform version matching

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -238,7 +238,7 @@ helpers.getDeviceInfoFromCaps = async function getDeviceInfoFromCaps (opts = {})
         }
 
         const [majorDeviceVersion, minorDeviceVersion] = extractVersionDigits(deviceOS);
-        if ((opts.platformVersion.includes('.') && majorPlatformVersion === majorDeviceVersion)
+        if ((!opts.platformVersion.includes('.') && majorPlatformVersion === majorDeviceVersion)
           || (majorPlatformVersion === majorDeviceVersion && minorPlatformVersion === minorDeviceVersion)) {
           // Got a partial match - make sure we consider the most recent
           // device version available on the host system

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { exec } from 'teen_process';
 import { retry, retryInterval, waitForCondition } from 'asyncbox';
 import logger from './logger';
-import { fs } from 'appium-support';
+import { fs, util } from 'appium-support';
 import { path as settingsApkPath } from 'io.appium.settings';
 import Bootstrap from './bootstrap';
 import B from 'bluebird';
@@ -204,33 +204,56 @@ helpers.getDeviceInfoFromCaps = async function getDeviceInfoFromCaps (opts = {})
       opts.platformVersion = `${opts.platformVersion}`.trim();
 
       // a platform version was given. lets try to find a device with the same os
+      const platformVersion = util.coerceVersion(opts.platformVersion, false);
+      if (!platformVersion) {
+        logger.errorAndThrow(`The provided platform version value '${platformVersion}' ` +
+          `cannot be coerced to a valid version number`);
+      }
       logger.info(`Looking for a device with Android '${opts.platformVersion}'`);
 
       // in case we fail to find something, give the user a useful log that has
       // the device udids and os versions so they know what's available
-      let availDevicesStr = [];
-
+      const availDevices = [];
+      let partialMatchCandidate = null;
+      const extractMajorVersion = (versionStr) => /\d+/.exec(versionStr)[0];
+      const majorPlatformVersion = extractMajorVersion(platformVersion);
       // first try started devices/emulators
-      for (let device of devices) {
+      for (const device of devices) {
         // direct adb calls to the specific device
         await adb.setDeviceId(device.udid);
-        let deviceOS = await adb.getPlatformVersion();
+        const rawDeviceOS = await adb.getPlatformVersion();
+        availDevices.push(`${device.udid} (${rawDeviceOS})`);
+        const deviceOS = util.coerceVersion(rawDeviceOS, false);
+        if (!deviceOS) {
+          continue;
+        }
 
-        // build up our info string of available devices as we iterate
-        availDevicesStr.push(`${device.udid} (${deviceOS})`);
-
-        // we do a begins with check for implied wildcard matching
-        // eg: 4 matches 4.1, 4.0, 4.1.3-samsung, etc
-        if (deviceOS.indexOf(opts.platformVersion) === 0) {
+        if (util.compareVersions(deviceOS, '==', platformVersion)) {
+          // Got an exact match - proceed immediately
           udid = device.udid;
           break;
         }
+
+        if (majorPlatformVersion === extractMajorVersion(deviceOS)) {
+          // Got a partial match - make sure we consider the most recent
+          // device version available on the host system
+          if (partialMatchCandidate
+              && util.compareVersions(deviceOS, '>', _.values(partialMatchCandidate)[0])
+              || !partialMatchCandidate) {
+            partialMatchCandidate = {[device.udid]: deviceOS};
+          }
+        }
+      }
+      if (!udid && partialMatchCandidate) {
+        udid = _.keys(partialMatchCandidate)[0];
+        await adb.setDeviceId(udid);
       }
 
-      // we couldn't find anything! quit
       if (!udid) {
+        // we couldn't find anything! quit
         logger.errorAndThrow(`Unable to find an active device or emulator ` +
-          `with OS ${opts.platformVersion}. The following are available: ` + availDevicesStr.join(', '));
+          `with OS ${opts.platformVersion}. The following are available: ` +
+          availDevices.join(', '));
       }
 
       emPort = adb.getPortFromEmulatorString(udid);

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -215,8 +215,11 @@ helpers.getDeviceInfoFromCaps = async function getDeviceInfoFromCaps (opts = {})
       // the device udids and os versions so they know what's available
       const availDevices = [];
       let partialMatchCandidate = null;
-      const extractMajorVersion = (versionStr) => /\d+/.exec(versionStr)[0];
-      const majorPlatformVersion = extractMajorVersion(platformVersion);
+      const extractVersionDigits = (versionStr) => {
+        const match = /(\d+)\.?(\d+)?/.exec(versionStr);
+        return match ? match.slice(1) : [];
+      };
+      const [majorPlatformVersion, minorPlatformVersion] = extractVersionDigits(platformVersion);
       // first try started devices/emulators
       for (const device of devices) {
         // direct adb calls to the specific device
@@ -234,7 +237,9 @@ helpers.getDeviceInfoFromCaps = async function getDeviceInfoFromCaps (opts = {})
           break;
         }
 
-        if (majorPlatformVersion === extractMajorVersion(deviceOS)) {
+        const [majorDeviceVersion, minorDeviceVersion] = extractVersionDigits(deviceOS);
+        if ((opts.platformVersion.includes('.') && majorPlatformVersion === majorDeviceVersion)
+          || (majorPlatformVersion === majorDeviceVersion && minorPlatformVersion === minorDeviceVersion)) {
           // Got a partial match - make sure we consider the most recent
           // device version available on the host system
           if (partialMatchCandidate

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -143,6 +143,7 @@ describe('Android Helpers', function () {
       {udid: 'rotalume-1337', os: '5.0.1'},
       {udid: 'roamulet-9000', os: '6.0'},
       {udid: 'roamulet-0', os: '2.3'},
+      {udid: 'roamulet-2019', os: '9'},
       {udid: '0123456789', os: 'wellhellothere'}
     ];
     let curDeviceId = '';
@@ -219,6 +220,14 @@ describe('Android Helpers', function () {
       udid.should.equal('roamulet-9000');
       emPort.should.equal(1234);
     });
+    it('should get deviceId and emPort if platformVersion is shorter than os version', async function () {
+      let caps = {
+        platformVersion: '9.0'
+      };
+      let {udid, emPort} = await helpers.getDeviceInfoFromCaps(caps);
+      udid.should.equal('roamulet-2019');
+      emPort.should.equal(1234);
+    });
     it('should get the first deviceId and emPort if platformVersion is found multiple times', async function () {
       let caps = {
         platformVersion: '5.0.1'
@@ -227,12 +236,12 @@ describe('Android Helpers', function () {
       udid.should.equal('rotalume-1338');
       emPort.should.equal(1234);
     });
-    it('should get the first deviceId and emPort if platformVersion is found multiple times and is a partial match', async function () {
+    it('should get the deviceId and emPort of most recent version if we have partial match', async function () {
       let caps = {
         platformVersion: '5.0'
       };
       let {udid, emPort} = await helpers.getDeviceInfoFromCaps(caps);
-      udid.should.equal('rotalume-1338');
+      udid.should.equal('rotalume-1339');
       emPort.should.equal(1234);
     });
     it('should get deviceId and emPort by udid if udid and platformVersion are given', async function () {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -222,7 +222,7 @@ describe('Android Helpers', function () {
     });
     it('should get deviceId and emPort if platformVersion is shorter than os version', async function () {
       let caps = {
-        platformVersion: '9.0'
+        platformVersion: 9
       };
       let {udid, emPort} = await helpers.getDeviceInfoFromCaps(caps);
       udid.should.equal('roamulet-2019');
@@ -241,7 +241,7 @@ describe('Android Helpers', function () {
         platformVersion: '5.0'
       };
       let {udid, emPort} = await helpers.getDeviceInfoFromCaps(caps);
-      udid.should.equal('rotalume-1339');
+      udid.should.equal('rotalume-1338');
       emPort.should.equal(1234);
     });
     it('should get deviceId and emPort by udid if udid and platformVersion are given', async function () {


### PR DESCRIPTION
Addresses https://discuss.appium.io/t/android-7-and-8-emulators-work-9-returns-error-message-unable-to-find-an-active-device/25129