### PR TITLE
feat: Add a capability for enforced app installation

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -397,7 +397,8 @@ helpers.installApk = async function installApk (adb, opts = {}) {
     fullReset,
     androidInstallTimeout = PACKAGE_INSTALL_TIMEOUT,
     autoGrantPermissions,
-    allowTestPackages
+    allowTestPackages,
+    enforceAppInstall,
   } = opts;
 
   if (!app || !appPackage) {
@@ -409,16 +410,15 @@ helpers.installApk = async function installApk (adb, opts = {}) {
     return;
   }
 
-  // There is no need to reset the newly installed app
-  const shouldPerformFastReset = fastReset && await adb.isAppInstalled(appPackage);
-
-  await adb.installOrUpgrade(app, appPackage, {
+  const {wasUninstalled} = await adb.installOrUpgrade(app, appPackage, {
     grantPermissions: autoGrantPermissions,
     timeout: androidInstallTimeout,
     allowTestPackages,
+    enforceCurrentBuild: enforceAppInstall,
   });
 
-  if (shouldPerformFastReset) {
+  // There is no need to reset the newly installed app
+  if (fastReset && !wasUninstalled) {
     logger.info(`Performing fast reset on '${appPackage}'`);
     await this.resetApp(adb, opts);
   }

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -410,7 +410,10 @@ helpers.installApk = async function installApk (adb, opts = {}) {
     return;
   }
 
-  const {wasUninstalled} = await adb.installOrUpgrade(app, appPackage, {
+  const {
+    appState,
+    wasUninstalled
+  } = await adb.installOrUpgrade(app, appPackage, {
     grantPermissions: autoGrantPermissions,
     timeout: androidInstallTimeout,
     allowTestPackages,
@@ -418,7 +421,8 @@ helpers.installApk = async function installApk (adb, opts = {}) {
   });
 
   // There is no need to reset the newly installed app
-  if (fastReset && !wasUninstalled) {
+  if (fastReset
+    && (!wasUninstalled || appState === adb.APP_INSTALL_STATE.NOT_INSTALLED)) {
     logger.info(`Performing fast reset on '${appPackage}'`);
     await this.resetApp(adb, opts);
   }

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -421,8 +421,9 @@ helpers.installApk = async function installApk (adb, opts = {}) {
   });
 
   // There is no need to reset the newly installed app
-  if (fastReset
-    && (!wasUninstalled || appState === adb.APP_INSTALL_STATE.NOT_INSTALLED)) {
+  const isInstalledOverExistingApp = !wasUninstalled
+    && appState !== adb.APP_INSTALL_STATE.NOT_INSTALLED;
+  if (fastReset && isInstalledOverExistingApp) {
     logger.info(`Performing fast reset on '${appPackage}'`);
     await this.resetApp(adb, opts);
   }

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -225,6 +225,9 @@ let commonCapConstraints = {
   browserName: {
     isString: true
   },
+  enforceAppInstall: {
+    isBoolean: true
+  },
 };
 
 let uiautomatorCapConstraints = {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^7.8.0",
+    "appium-adb": "^7.13.0",
     "appium-base-driver": "^4.0.0",
     "appium-chromedriver": "^4.13.0",
     "appium-support": "^2.25.0",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -417,7 +417,7 @@ describe('Android Helpers', function () {
     it('should install/upgrade and reset app if fast reset is set to true', async function () {
       mocks.adb.expects('installOrUpgrade').once()
         .withArgs(opts.app, opts.appPackage)
-        .returns({wasUninstalled: false, appState: 'notInstalled'});
+        .returns({wasUninstalled: false, appState: 'sameVersionInstalled'});
       mocks.helpers.expects('resetApp').once().withArgs(adb);
       await helpers.installApk(adb, Object.assign({}, opts, {fastReset: true}));
       mocks.adb.verify();
@@ -442,7 +442,7 @@ describe('Android Helpers', function () {
     it('should install/upgrade and skip fast resetting the app if this was the fresh install', async function () {
       mocks.adb.expects('installOrUpgrade').once()
         .withArgs(opts.app, opts.appPackage)
-        .returns({wasUninstalled: true, appState: 'sameVersionInstalled'});
+        .returns({wasUninstalled: false, appState: 'notInstalled'});
       mocks.helpers.expects('resetApp').never();
       await helpers.installApk(adb, Object.assign({}, opts, {fastReset: true}));
       mocks.adb.verify();

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -415,8 +415,9 @@ describe('Android Helpers', function () {
               .should.eventually.be.rejectedWith(/appPackage/);
     });
     it('should install/upgrade and reset app if fast reset is set to true', async function () {
-      mocks.adb.expects('isAppInstalled').once().returns(true);
-      mocks.adb.expects('installOrUpgrade').once().withArgs(opts.app, opts.appPackage);
+      mocks.adb.expects('installOrUpgrade').once()
+        .withArgs(opts.app, opts.appPackage)
+        .returns({wasUninstalled: false, appState: 'notInstalled'});
       mocks.helpers.expects('resetApp').once().withArgs(adb);
       await helpers.installApk(adb, Object.assign({}, opts, {fastReset: true}));
       mocks.adb.verify();
@@ -430,15 +431,18 @@ describe('Android Helpers', function () {
       mocks.helpers.verify();
     });
     it('should not run reset if the corresponding option is not set', async function () {
-      mocks.adb.expects('installOrUpgrade').once().withArgs(opts.app, opts.appPackage);
+      mocks.adb.expects('installOrUpgrade').once()
+        .withArgs(opts.app, opts.appPackage)
+        .returns({wasUninstalled: true, appState: 'sameVersionInstalled'});
       mocks.helpers.expects('resetApp').never();
       await helpers.installApk(adb, opts);
       mocks.adb.verify();
       mocks.helpers.verify();
     });
-    it('should install/upgrade and skip fast reseting the app if this was the fresh install', async function () {
-      mocks.adb.expects('isAppInstalled').once().returns(false);
-      mocks.adb.expects('installOrUpgrade').once().withArgs(opts.app, opts.appPackage);
+    it('should install/upgrade and skip fast resetting the app if this was the fresh install', async function () {
+      mocks.adb.expects('installOrUpgrade').once()
+        .withArgs(opts.app, opts.appPackage)
+        .returns({wasUninstalled: true, appState: 'sameVersionInstalled'});
       mocks.helpers.expects('resetApp').never();
       await helpers.installApk(adb, Object.assign({}, opts, {fastReset: true}));
       mocks.adb.verify();


### PR DESCRIPTION
Currently the default app installation algorithm verifies if the package with the same identifier is already present on the device and does not perform reinstall or downgrade if the installed package version is equal/greater in comparison to the current one. Although, for some users such behaviour might be undesired. The newly added capability called `enforceAppInstall` if set to `true` always enforces the installation of the current app (`app`) even if the same or the newer app version is already present on the device under test.