### PR TITLE
feat: Add a possibility to stream the device's screen using adb+gstreamer

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -34,12 +34,15 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     performEditorAction: 'mobilePerformEditorAction',
 
-    sensorSet: 'sensorSet'
+    sensorSet: 'sensorSet',
+
+    startScreenStreaming: 'mobileStartScreenStreaming',
+    stopScreenStreaming: 'mobileStopScreenStreaming',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {
     throw new errors.UnknownCommandError(`Unknown mobile command "${mobileCommand}". ` +
-                                         `Only ${_.keys(mobileCommandsMapping)} commands are supported.`);
+      `Only ${_.keys(mobileCommandsMapping)} commands are supported.`);
   }
   return await this[mobileCommandsMapping[mobileCommand]](opts);
 };

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -9,6 +9,7 @@ import imeCmds from './ime';
 import networkCmds from './network';
 import coverageCmds from './coverage';
 import recordscreenCmds from './recordscreen';
+import screenStreamCmds from './streamscreen';
 import performanceCmds from './performance';
 import executeCmds from './execute';
 import shellCmds from './shell';
@@ -30,6 +31,7 @@ Object.assign(
   networkCmds,
   coverageCmds,
   recordscreenCmds,
+  screenStreamCmds,
   performanceCmds,
   executeCmds,
   shellCmds,

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -43,7 +43,7 @@ async function verifyStreamingRequirements (adb) {
     try {
       await fs.which(binaryName);
     } catch (e) {
-      throw new Error(`The ${binaryName} is not available in PATH on the host system. ` +
+      throw new Error(`The '${binaryName}' binary is not available in the PATH on the host system. ` +
         `See ${GST_TUTORIAL_URL} for more details on how to install it.`);
     }
   }
@@ -60,23 +60,19 @@ async function verifyStreamingRequirements (adb) {
 
 async function getDeviceInfo (adb) {
   const output = await adb.shell(['dumpsys', 'display']);
-  const widthMatch = /\bdeviceWidth=(\d+)/.exec(output);
-  if (!widthMatch) {
-    throw new Error(`Cannot parse the device width from ${output}`);
+  const result = {};
+  for (const [key, pattern] of [
+    ['width', /\bdeviceWidth=(\d+)/],
+    ['height', /\bdeviceHeight=(\d+)/],
+    ['fps', /\bfps=(\d+)/],
+  ]) {
+    const match = pattern.exec(output);
+    if (!match) {
+      throw new Error(`Cannot parse the device ${key} from the command output: ${output}`);
+    }
+    result[key] = parseInt(match[1], 10);
   }
-  const heightMatch = /\bdeviceHeight=(\d+)/.exec(output);
-  if (!heightMatch) {
-    throw new Error(`Cannot parse the device height from ${output}`);
-  }
-  const fpsMatch = /\bfps=(\d+)/.exec(output);
-  if (!fpsMatch) {
-    throw new Error(`Cannot parse the device FPS from ${output}`);
-  }
-  return {
-    width: parseInt(widthMatch[1], 10),
-    height: parseInt(heightMatch[1], 10),
-    fps: parseInt(fpsMatch[1], 10),
-  };
+  return result;
 }
 
 async function initDeviceStreamingProc (adb, deviceInfo, opts = {}) {

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -20,7 +20,7 @@ const REQUIRED_GST_PLUGINS = {
   h264parse: 'gst-plugins-bad',
   jpegenc: 'gst-plugins-good',
   tcpserversink: 'gst-plugins-base',
-  multipartmux: 'gst-plugins-base',
+  multipartmux: 'gst-plugins-good',
 };
 const SCREENRECORD_BINARY = 'screenrecord';
 const GST_TUTORIAL_URL = 'https://gstreamer.freedesktop.org/documentation/installing/index.html';
@@ -67,7 +67,7 @@ async function getDeviceInfo (adb) {
   if (!heightMatch) {
     throw new Error(`Cannot parse the device height from ${output}`);
   }
-  const fpsMatch = /\bfps=(\d+)/.exec();
+  const fpsMatch = /\bfps=(\d+)/.exec(output);
   if (!fpsMatch) {
     throw new Error(`Cannot parse the device FPS from ${output}`);
   }
@@ -106,11 +106,12 @@ async function initDeviceStreaming (adb, deviceInfo, opts = {}) {
   deviceStreaming.on('exit', (code, signal) => {
     log.debug(`Device streaming process exited with code ${code}, signal ${signal}`);
   });
-  const adbErrorsListener = deviceStreaming.on('output', (stdout, stderr) => {
+  const adbErrorsListener = (stdout, stderr) => {
     if (_.trim(stderr)) {
       log.debug(stderr);
     }
-  });
+  };
+  deviceStreaming.on('output', adbErrorsListener);
   try {
     log.info(`Starting device streaming: ${deviceStreaming.rep}`);
     await deviceStreaming.start(null, STREAMING_STARTUP_TIMEOUT_MS);
@@ -118,7 +119,7 @@ async function initDeviceStreaming (adb, deviceInfo, opts = {}) {
     log.errorAndThrow(
       `Cannot start the screen streaming process. Original error: ${e.message}`);
   } finally {
-    deviceStreaming.removeListener(adbErrorsListener);
+    deviceStreaming.removeListener('output', adbErrorsListener);
   }
   return deviceStreaming;
 }
@@ -154,11 +155,12 @@ async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
   gstreamerPipeline.on('exit', (code, signal) => {
     log.debug(`Pipeline streaming process exited with code ${code}, signal ${signal}`);
   });
-  const gstListener = gstreamerPipeline.on('output', (stdout, stderr) => {
+  const gstOutputListener = (stdout, stderr) => {
     if (_.trim(stderr || stdout)) {
       log.debug(stderr || stdout);
     }
-  });
+  };
+  gstreamerPipeline.on('output', gstOutputListener);
   let didFail = false;
   try {
     log.info(`Starting GStreamer pipeline: ${gstreamerPipeline.rep}`);
@@ -179,7 +181,7 @@ async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
       `Cannot start the screen streaming pipeline. Original error: ${e.message}`);
   } finally {
     if (!logPipelineDetails || didFail) {
-      gstreamerPipeline.removeListener(gstListener);
+      gstreamerPipeline.removeListener('output', gstOutputListener);
     }
   }
   return gstreamerPipeline;
@@ -259,53 +261,71 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
     height,
     bitRate,
   });
-  const gstreamerPipeline = await initGstreamerPipeline(deviceStreaming, deviceInfo, {
-    width,
-    height,
-    quality,
-    tcpPort,
-    considerRotation,
-    logPipelineDetails,
-  });
+  let gstreamerPipeline;
+  try {
+    gstreamerPipeline = await initGstreamerPipeline(deviceStreaming, deviceInfo, {
+      width,
+      height,
+      quality,
+      tcpPort,
+      considerRotation,
+      logPipelineDetails,
+    });
+  } catch (e) {
+    if (deviceStreaming.isRunning) {
+      await deviceStreaming.stop();
+    }
+    throw e;
+  }
 
   const mjpegSocket = net.createConnection(tcpPort, TCP_HOST);
   let mjpegServer;
-  await new B((resolve, reject) => {
-    mjpegSocket.on('error', (e) => {
-      log.warn(e);
-      if (mjpegServer) {
-        mjpegServer.close();
-      }
-      reject(e);
-    });
-    mjpegSocket.on('connect', () => {
-      log.info(`Successfully connected to MJPEG stream at tcp://${TCP_HOST}:${tcpPort}`);
-      mjpegServer = http.createServer((req, res) => {
-        res.writeHead(200, {
-          'Cache-Control': 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
-          Pragma: 'no-cache',
-          Connection: 'close',
-          'Content-Type': `multipart/x-mixed-replace; boundary=${BOUNDARY_STRING}`
-        });
-
-        mjpegSocket.pipe(res);
-      });
-      mjpegServer.on('error', (e) => {
+  try {
+    await new B((resolve, reject) => {
+      mjpegSocket.on('error', (e) => {
         log.warn(e);
-        mjpegSocket.end();
+        if (mjpegServer) {
+          mjpegServer.close();
+        }
         reject(e);
       });
-      mjpegServer.on('close', () => {
-        log.debug(`MJPEG server at http://${host}:${port} has been terminated`);
-        mjpegSocket.end();
+      mjpegSocket.on('connect', () => {
+        log.info(`Successfully connected to MJPEG stream at tcp://${TCP_HOST}:${tcpPort}`);
+        mjpegServer = http.createServer((req, res) => {
+          res.writeHead(200, {
+            'Cache-Control': 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
+            Pragma: 'no-cache',
+            Connection: 'close',
+            'Content-Type': `multipart/x-mixed-replace; boundary=${BOUNDARY_STRING}`
+          });
+
+          mjpegSocket.pipe(res);
+        });
+        mjpegServer.on('error', (e) => {
+          log.warn(e);
+          mjpegSocket.end();
+          reject(e);
+        });
+        mjpegServer.on('close', () => {
+          log.debug(`MJPEG server at http://${host}:${port} has been terminated`);
+          mjpegSocket.end();
+        });
+        mjpegServer.on('listening', () => {
+          log.info(`Successfully started MJPEG server at http://${host}:${port}`);
+          resolve();
+        });
+        mjpegServer.listen(port, host);
       });
-      mjpegServer.on('listening', () => {
-        log.info(`Successfully started MJPEG server at http://${host}:${port}`);
-        resolve();
-      });
-      mjpegServer.listen(port, host);
     });
-  });
+  } catch (e) {
+    if (deviceStreaming.isRunning) {
+      await deviceStreaming.stop();
+    }
+    if (gstreamerPipeline.isRunning) {
+      await gstreamerPipeline.stop();
+    }
+    throw e;
+  }
 
   this._screenStreamingProps = {
     deviceStreaming,

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -7,7 +7,8 @@ import http from 'http';
 import net from 'net';
 import B from 'bluebird';
 import { waitForCondition } from 'asyncbox';
-
+import { spawn } from 'child_process';
+import { quote } from 'shell-quote';
 
 const commands = {};
 
@@ -78,7 +79,7 @@ async function getDeviceInfo (adb) {
   };
 }
 
-async function initDeviceStreaming (adb, deviceInfo, opts = {}) {
+async function initDeviceStreamingProc (adb, deviceInfo, opts = {}) {
   const {
     width,
     height,
@@ -97,34 +98,48 @@ async function initDeviceStreaming (adb, deviceInfo, opts = {}) {
   if (bitRate) {
     screenRecordCmd += ` --bit-rate=${adjustedBitrate}`;
   }
-  const deviceStreaming = adb.createSubProcess([
+  const adbArgs = [
+    ...adb.executable.defaultArgs,
     'exec-out',
     // The loop is required, because by default the maximum record duration
     // for screenrecord is always limited
     `while true; do ${screenRecordCmd} -; done`,
-  ]);
+  ];
+  const deviceStreaming = spawn(adb.executable.path, adbArgs);
   deviceStreaming.on('exit', (code, signal) => {
     log.debug(`Device streaming process exited with code ${code}, signal ${signal}`);
   });
-  const adbErrorsListener = (stdout, stderr) => {
+  let isStarted = false;
+  const errorsListener = (chunk) => {
+    const stderr = chunk.toString();
     if (_.trim(stderr)) {
       log.debug(stderr);
     }
   };
-  deviceStreaming.on('output', adbErrorsListener);
+  const startupListener = (chunk) => {
+    if (!isStarted) {
+      isStarted = !_.isEmpty(chunk);
+    }
+  };
+  deviceStreaming.stderr.on('data', errorsListener);
+  deviceStreaming.stdout.on('data', startupListener);
   try {
-    log.info(`Starting device streaming: ${deviceStreaming.rep}`);
-    await deviceStreaming.start(null, STREAMING_STARTUP_TIMEOUT_MS);
+    log.info(`Starting device streaming: ${quote([adb.executable.path, ...adbArgs])}`);
+    await waitForCondition(() => isStarted, {
+      waitMs: STREAMING_STARTUP_TIMEOUT_MS,
+      intervalMs: 300,
+    });
   } catch (e) {
     log.errorAndThrow(
       `Cannot start the screen streaming process. Original error: ${e.message}`);
   } finally {
-    deviceStreaming.removeListener('output', adbErrorsListener);
+    deviceStreaming.stderr.removeListener('data', errorsListener);
+    deviceStreaming.stdout.removeListener('data', startupListener);
   }
   return deviceStreaming;
 }
 
-async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
+async function initGstreamerPipeline (deviceStreamingProc, deviceInfo, opts = {}) {
   const {
     width,
     height,
@@ -151,7 +166,7 @@ async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
     '!', 'multipartmux', `boundary=${BOUNDARY_STRING}`,
     '!', 'tcpserversink', `host=${TCP_HOST}`, `port=${tcpPort}`,
   ], {
-    stdio: [deviceStreaming.proc.stdout, 'pipe', 'pipe']
+    stdio: [deviceStreamingProc.stdout, 'pipe', 'pipe']
   });
   gstreamerPipeline.on('exit', (code, signal) => {
     log.debug(`Pipeline streaming process exited with code ${code}, signal ${signal}`);
@@ -255,14 +270,14 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
   this._screenStreamingProps = null;
 
   const deviceInfo = await getDeviceInfo(this.adb);
-  const deviceStreaming = await initDeviceStreaming(this.adb, deviceInfo, {
+  const deviceStreamingProc = await initDeviceStreamingProc(this.adb, deviceInfo, {
     width,
     height,
     bitRate,
   });
   let gstreamerPipeline;
   try {
-    gstreamerPipeline = await initGstreamerPipeline(deviceStreaming, deviceInfo, {
+    gstreamerPipeline = await initGstreamerPipeline(deviceStreamingProc, deviceInfo, {
       width,
       height,
       quality,
@@ -271,8 +286,8 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
       logPipelineDetails,
     });
   } catch (e) {
-    if (deviceStreaming.isRunning) {
-      await deviceStreaming.stop();
+    if (deviceStreamingProc.kill(0)) {
+      deviceStreamingProc.kill();
     }
     throw e;
   }
@@ -318,8 +333,8 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
     }).timeout(STREAMING_STARTUP_TIMEOUT_MS,
       `Cannot connect to the streaming server within ${STREAMING_STARTUP_TIMEOUT_MS}ms`);
   } catch (e) {
-    if (deviceStreaming.isRunning) {
-      await deviceStreaming.stop();
+    if (deviceStreamingProc.kill(0)) {
+      deviceStreamingProc.kill();
     }
     if (gstreamerPipeline.isRunning) {
       await gstreamerPipeline.stop();
@@ -334,7 +349,7 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
   }
 
   this._screenStreamingProps = {
-    deviceStreaming,
+    deviceStreamingProc,
     gstreamerPipeline,
     mjpegSocket,
     mjpegServer,
@@ -354,7 +369,7 @@ commands.mobileStopScreenStreaming = async function mobileStopScreenStreaming (/
   }
 
   const {
-    deviceStreaming,
+    deviceStreamingProc,
     gstreamerPipeline,
     mjpegSocket,
     mjpegServer,
@@ -365,17 +380,8 @@ commands.mobileStopScreenStreaming = async function mobileStopScreenStreaming (/
     if (mjpegServer.listening) {
       mjpegServer.close();
     }
-    if (deviceStreaming.isRunning) {
-      try {
-        await deviceStreaming.stop('SIGINT');
-      } catch (e) {
-        log.warn(e);
-        try {
-          await deviceStreaming.stop('SIGKILL');
-        } catch (e1) {
-          log.error(e1);
-        }
-      }
+    if (deviceStreamingProc.kill(0)) {
+      deviceStreamingProc.kill('SIGINT');
     }
     if (gstreamerPipeline.isRunning) {
       try {

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -144,8 +144,9 @@ async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
       `framerate=${deviceInfo.fps}/1,` +
       'byte-stream=true',
     '!', 'h264parse',
-    '!', 'avdec_h264', 'skip-frame=5',
-    '!', 'queue',
+    '!', 'queue', 'leaky=downstream',
+    '!', 'avdec_h264',
+    '!', 'queue', 'leaky=downstream',
     '!', 'jpegenc', `quality=${quality}`,
     '!', 'multipartmux', `boundary=${BOUNDARY_STRING}`,
     '!', 'tcpserversink', `host=${TCP_HOST}`, `port=${tcpPort}`,
@@ -242,8 +243,6 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
       `Stop it first in order to start a new one.`);
     return;
   }
-  this._screenStreamingProps = null;
-
   if ((await checkPortStatus(port, host)) === 'open') {
     log.info(`The port #${port} at ${host} is busy. ` +
       `Assuming the screen streaming is already running`);
@@ -252,8 +251,8 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
   if ((await checkPortStatus(tcpPort, TCP_HOST)) === 'open') {
     log.errorAndThrow(`The port #${tcpPort} at ${TCP_HOST} is busy. ` +
       `Make sure there are no leftovers from previous sessions.`);
-    return;
   }
+  this._screenStreamingProps = null;
 
   const deviceInfo = await getDeviceInfo(this.adb);
   const deviceStreaming = await initDeviceStreaming(this.adb, deviceInfo, {
@@ -278,20 +277,18 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
     throw e;
   }
 
-  const mjpegSocket = net.createConnection(tcpPort, TCP_HOST);
+  let mjpegSocket;
   let mjpegServer;
   try {
     await new B((resolve, reject) => {
-      mjpegSocket.on('error', (e) => {
-        log.warn(e);
-        if (mjpegServer) {
-          mjpegServer.close();
-        }
-        reject(e);
-      });
-      mjpegSocket.on('connect', () => {
+      mjpegSocket = net.createConnection(tcpPort, TCP_HOST, () => {
         log.info(`Successfully connected to MJPEG stream at tcp://${TCP_HOST}:${tcpPort}`);
         mjpegServer = http.createServer((req, res) => {
+          const remoteAddress = req.headers['x-forwarded-for']
+            || req.socket.remoteAddress
+            || req.connection.remoteAddress
+            || req.connection.socket.remoteAddress;
+          log.info(`Got an incoming connection from ${remoteAddress}. Starting the MJPEG broadcast`);
           res.writeHead(200, {
             'Cache-Control': 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
             Pragma: 'no-cache',
@@ -303,12 +300,10 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
         });
         mjpegServer.on('error', (e) => {
           log.warn(e);
-          mjpegSocket.end();
           reject(e);
         });
         mjpegServer.on('close', () => {
-          log.debug(`MJPEG server at http://${host}:${port} has been terminated`);
-          mjpegSocket.end();
+          log.debug(`MJPEG server at http://${host}:${port} has been closed`);
         });
         mjpegServer.on('listening', () => {
           log.info(`Successfully started MJPEG server at http://${host}:${port}`);
@@ -316,13 +311,24 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
         });
         mjpegServer.listen(port, host);
       });
-    });
+      mjpegSocket.on('error', (e) => {
+        log.error(e);
+        reject(e);
+      });
+    }).timeout(STREAMING_STARTUP_TIMEOUT_MS,
+      `Cannot connect to the streaming server within ${STREAMING_STARTUP_TIMEOUT_MS}ms`);
   } catch (e) {
     if (deviceStreaming.isRunning) {
       await deviceStreaming.stop();
     }
     if (gstreamerPipeline.isRunning) {
       await gstreamerPipeline.stop();
+    }
+    if (mjpegSocket) {
+      mjpegSocket.destroy();
+    }
+    if (mjpegServer && mjpegServer.listening) {
+      mjpegServer.close();
     }
     throw e;
   }

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { fs, system } from 'appium-support';
+import { fs, system, logger } from 'appium-support';
 import log from '../logger';
 import { exec, SubProcess } from 'teen_process';
 import { checkPortStatus } from 'portscanner';
@@ -107,20 +107,24 @@ async function initDeviceStreamingProc (adb, deviceInfo, opts = {}) {
   deviceStreaming.on('exit', (code, signal) => {
     log.debug(`Device streaming process exited with code ${code}, signal ${signal}`);
   });
+
   let isStarted = false;
+  const deviceStreamingLogger = logger.getLogger(`${SCREENRECORD_BINARY}@${this.opts.udid}`);
   const errorsListener = (chunk) => {
     const stderr = chunk.toString();
     if (_.trim(stderr)) {
-      log.debug(stderr);
+      deviceStreamingLogger.debug(stderr);
     }
   };
+  deviceStreaming.stderr.on('data', errorsListener);
+
   const startupListener = (chunk) => {
     if (!isStarted) {
       isStarted = !_.isEmpty(chunk);
     }
   };
-  deviceStreaming.stderr.on('data', errorsListener);
   deviceStreaming.stdout.on('data', startupListener);
+
   try {
     log.info(`Starting device streaming: ${quote([adb.executable.path, ...adbArgs])}`);
     await waitForCondition(() => isStarted, {
@@ -169,9 +173,10 @@ async function initGstreamerPipeline (deviceStreamingProc, deviceInfo, opts = {}
   gstreamerPipeline.on('exit', (code, signal) => {
     log.debug(`Pipeline streaming process exited with code ${code}, signal ${signal}`);
   });
+  const gstreamerLogger = logger.getLogger(`gstreamer@${this.opts.udid}`);
   const gstOutputListener = (stdout, stderr) => {
     if (_.trim(stderr || stdout)) {
-      log.debug(stderr || stdout);
+      gstreamerLogger.debug(stderr || stdout);
     }
   };
   gstreamerPipeline.on('output', gstOutputListener);

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -68,7 +68,9 @@ async function getDeviceInfo (adb) {
   ]) {
     const match = pattern.exec(output);
     if (!match) {
-      throw new Error(`Cannot parse the device ${key} from the command output: ${output}`);
+      log.debug(output);
+      throw new Error(`Cannot parse the device ${key} from the adb command output. ` +
+        `Check the server log for more details.`);
     }
     result[key] = parseInt(match[1], 10);
   }

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -1,0 +1,361 @@
+import _ from 'lodash';
+import { fs, system } from 'appium-support';
+import log from '../logger';
+import { exec, SubProcess } from 'teen_process';
+import { checkPortStatus } from 'portscanner';
+import http from 'http';
+import net from 'net';
+import B from 'bluebird';
+import { waitForCondition } from 'asyncbox';
+
+
+const commands = {};
+
+const RECORDING_INTERVAL_SEC = 5;
+const STREAMING_STARTUP_TIMEOUT_MS = 5000;
+const GSTREAMER_BINARY = `gst-launch-1.0${system.isWindows() ? '.exe' : ''}`;
+const GST_INSPECT_BINARY = `gst-inspect-1.0${system.isWindows() ? '.exe' : ''}`;
+const REQUIRED_GST_PLUGINS = {
+  avdec_h264: 'gst-libav',
+  h264parse: 'gst-plugins-bad',
+  jpegenc: 'gst-plugins-good',
+  tcpserversink: 'gst-plugins-base',
+  multipartmux: 'gst-plugins-base',
+};
+const SCREENRECORD_BINARY = 'screenrecord';
+const GST_TUTORIAL_URL = 'https://gstreamer.freedesktop.org/documentation/installing/index.html';
+const DEFAULT_HOST = '127.0.0.1';
+const TCP_HOST = '127.0.0.1';
+const DEFAULT_PORT = 8093;
+const DEFAULT_QUALITY = 70;
+const DEFAULT_BITRATE = 4000000; // Mbps
+const BOUNDARY_STRING = '--2ae9746887f170b8cf7c271047ce314c';
+
+
+async function verifyStreamingRequirements (adb) {
+  if (!_.trim(await adb.shell(['which', SCREENRECORD_BINARY]))) {
+    throw new Error(
+      `The required '${SCREENRECORD_BINARY}' binary is not available on the device under test`);
+  }
+
+  for (const binaryName of [GSTREAMER_BINARY, GST_INSPECT_BINARY]) {
+    try {
+      await fs.which(binaryName);
+    } catch (e) {
+      throw new Error(`The ${binaryName} is not available in PATH on the host system. ` +
+        `See ${GST_TUTORIAL_URL} for more details on how to install it.`);
+    }
+  }
+
+  for (const [name, modName] of _.toPairs(REQUIRED_GST_PLUGINS)) {
+    const {stdout} = await exec(GST_INSPECT_BINARY, [name]);
+    if (!_.includes(stdout, modName)) {
+      throw new Error(
+        `The required GStreamer plugin '${name}' from '${modName}' module is not installed. ` +
+        `See ${GST_TUTORIAL_URL} for more details on how to install it.`);
+    }
+  }
+}
+
+async function getDeviceInfo (adb) {
+  const output = await adb.shell(['dumpsys', 'display']);
+  const widthMatch = /\bdeviceWidth=(\d+)/.exec(output);
+  if (!widthMatch) {
+    throw new Error(`Cannot parse the device width from ${output}`);
+  }
+  const heightMatch = /\bdeviceHeight=(\d+)/.exec(output);
+  if (!heightMatch) {
+    throw new Error(`Cannot parse the device height from ${output}`);
+  }
+  const fpsMatch = /\bfps=(\d+)/.exec();
+  if (!fpsMatch) {
+    throw new Error(`Cannot parse the device FPS from ${output}`);
+  }
+  return {
+    width: parseInt(widthMatch[1], 10),
+    height: parseInt(heightMatch[1], 10),
+    fps: parseInt(fpsMatch[1], 10),
+  };
+}
+
+async function initDeviceStreaming (adb, deviceInfo, opts = {}) {
+  const {
+    width,
+    height,
+    bitRate,
+  } = opts;
+  const adjustedWidth = parseInt(width, 10) || deviceInfo.width;
+  const adjustedHeight = parseInt(height, 10) || deviceInfo.height;
+  const adjustedBitrate = parseInt(bitRate, 10) || DEFAULT_BITRATE;
+  let screenRecordCmd = SCREENRECORD_BINARY +
+    ` --output-format=h264` +
+    // 5 seconds is fine to detect rotation changes
+    ` --time-limit=${RECORDING_INTERVAL_SEC}`;
+  if (width || height) {
+    screenRecordCmd += ` --size=${adjustedWidth}x${adjustedHeight}`;
+  }
+  if (bitRate) {
+    screenRecordCmd += ` --bit-rate=${adjustedBitrate}`;
+  }
+  const deviceStreaming = adb.createSubProcess([
+    'exec-out',
+    // The loop is required, because by default the maximum record duration
+    // for screenrecord is always limited
+    `while true; do ${screenRecordCmd} -; done`,
+  ]);
+  deviceStreaming.on('exit', (code, signal) => {
+    log.debug(`Device streaming process exited with code ${code}, signal ${signal}`);
+  });
+  const adbErrorsListener = deviceStreaming.on('output', (stdout, stderr) => {
+    if (_.trim(stderr)) {
+      log.debug(stderr);
+    }
+  });
+  try {
+    log.info(`Starting device streaming: ${deviceStreaming.rep}`);
+    await deviceStreaming.start(null, STREAMING_STARTUP_TIMEOUT_MS);
+  } catch (e) {
+    log.errorAndThrow(
+      `Cannot start the screen streaming process. Original error: ${e.message}`);
+  } finally {
+    deviceStreaming.removeListener(adbErrorsListener);
+  }
+  return deviceStreaming;
+}
+
+async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
+  const {
+    width,
+    height,
+    quality,
+    tcpPort,
+    logPipelineDetails,
+  } = opts;
+  const adjustedWidth = parseInt(width, 10) || deviceInfo.width;
+  const adjustedHeight = parseInt(height, 10) || deviceInfo.height;
+  const gstreamerPipeline = new SubProcess(GSTREAMER_BINARY, [
+    '-v',
+    'fdsrc', 'fd=0',
+    '!', `video/x-h264,` +
+      `width=${adjustedWidth},` +
+      `height=${adjustedHeight},` +
+      `framerate=${deviceInfo.fps}/1,` +
+      `byte-stream=true`,
+    '!', 'h264parse',
+    '!', 'avdec_h264', 'skip-frame=5',
+    '!', 'jpegenc', `quality=${quality}`,
+    '!', 'multipartmux', `boundary=${BOUNDARY_STRING}`,
+    '!', 'tcpserversink', `host=${TCP_HOST}`, `port=${tcpPort}`,
+  ], {
+    stdio: [deviceStreaming.proc.stdout, 'pipe', 'pipe']
+  });
+  gstreamerPipeline.on('exit', (code, signal) => {
+    log.debug(`Pipeline streaming process exited with code ${code}, signal ${signal}`);
+  });
+  const gstListener = gstreamerPipeline.on('output', (stdout, stderr) => {
+    if (_.trim(stderr || stdout)) {
+      log.debug(stderr || stdout);
+    }
+  });
+  let didFail = false;
+  try {
+    log.info(`Starting GStreamer pipeline: ${gstreamerPipeline.rep}`);
+    await gstreamerPipeline.start(0);
+    await waitForCondition(async () => {
+      try {
+        return (await checkPortStatus(tcpPort, TCP_HOST)) === 'open';
+      } catch (ign) {
+        return false;
+      }
+    }, {
+      waitMs: STREAMING_STARTUP_TIMEOUT_MS,
+      intervalMs: 300,
+    });
+  } catch (e) {
+    didFail = true;
+    log.errorAndThrow(
+      `Cannot start the screen streaming pipeline. Original error: ${e.message}`);
+  } finally {
+    if (!logPipelineDetails || didFail) {
+      gstreamerPipeline.removeListener(gstListener);
+    }
+  }
+  return gstreamerPipeline;
+}
+
+
+/**
+ * @typedef {Object} StartScreenStreamingOptions
+ *
+ * @property {?number} width - The scaled width of the device's screen. If unset then the script will assign it
+ * to the actual screen width measured in pixels.
+ * @property {?number} height - The scaled height of the device's screen. If unset then the script will assign it
+ * to the actual screen height measured in pixels.
+ * @property {?number} bitRate - The video bit rate for the video, in bits per second.
+ * The default value is 4000000 (4 Mb/s). You can increase the bit rate to improve video quality,
+ * but doing so results in larger movie files.
+ * @property {?string} host [127.0.0.1] - The IP address/host name to start the MJPEG server on.
+ * You can set it to `0.0.0.0` to trigger the broadcast on all available network interfaces.
+ * @property {?number} tcpPort [8094] - The port number to start the internal TCP MJPEG broadcast on.
+ * This type of broadcast always starts on the loopback interface (`127.0.0.1`).
+ * @property {?number} port [8093] - The port number to start the MJPEG server on.
+ * @property {?number} quality [70] - The quality value for the streamed JPEG images.
+ * This number should be in range [1, 100], where 100 is the best quality.
+ * @property {?boolean} logPipelineDetails [false] - Whether to log GStreamer pipeline events into
+ * the standard log output. Might be useful for debugging purposes.
+ */
+
+/**
+ * Starts device screen broadcast by creating MJPEG server.
+ * Multiple calls to this method have no effect unless the previous streaming
+ * session is stopped.
+ *
+ * @param {?StartScreenStreamingOptions} options - The available options.
+ * @throws {Error} If screen streaming has failed to start or is not supported on the host system.
+ */
+commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming (options = {}) {
+  const {
+    width,
+    height,
+    bitRate,
+    host = DEFAULT_HOST,
+    port = DEFAULT_PORT,
+    tcpPort = DEFAULT_PORT + 1,
+    quality = DEFAULT_QUALITY,
+    logPipelineDetails = false,
+  } = options;
+
+  if (_.isUndefined(this._screenStreamingProps)) {
+    await verifyStreamingRequirements(this.adb);
+  }
+  if (!_.isEmpty(this._screenStreamingProps)) {
+    log.info(`The screen streaming session is already running. ` +
+      `Stop it first in order to start a new one.`);
+    return;
+  }
+  this._screenStreamingProps = null;
+
+  if ((await checkPortStatus(port, host)) === 'open') {
+    log.info(`The port #${port} at ${host} is busy. ` +
+      `Assuming the screen streaming is already running`);
+    return;
+  }
+  if ((await checkPortStatus(tcpPort, TCP_HOST)) === 'open') {
+    log.errorAndThrow(`The port #${tcpPort} at ${TCP_HOST} is busy. ` +
+      `Make sure there are no leftovers from previous sessions.`);
+    return;
+  }
+
+  const deviceInfo = await getDeviceInfo(this.adb);
+  const deviceStreaming = await initDeviceStreaming(this.adb, deviceInfo, {
+    width,
+    height,
+    bitRate,
+  });
+  const gstreamerPipeline = await initGstreamerPipeline(deviceStreaming, deviceInfo, {
+    width,
+    height,
+    quality,
+    tcpPort,
+    logPipelineDetails,
+  });
+
+  const mjpegSocket = net.createConnection(tcpPort, TCP_HOST);
+  let mjpegServer;
+  await new B((resolve, reject) => {
+    mjpegSocket.on('error', (e) => {
+      log.warn(e);
+      if (mjpegServer) {
+        mjpegServer.close();
+      }
+      reject(e);
+    });
+    mjpegSocket.on('connect', () => {
+      log.info(`Successfully connected to MJPEG stream at tcp://${TCP_HOST}:${tcpPort}`);
+      mjpegServer = http.createServer((req, res) => {
+        res.writeHead(200, {
+          'Cache-Control': 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
+          Pragma: 'no-cache',
+          Connection: 'close',
+          'Content-Type': `multipart/x-mixed-replace; boundary=${BOUNDARY_STRING}`
+        });
+
+        mjpegSocket.pipe(res);
+      });
+      mjpegServer.on('error', (e) => {
+        log.warn(e);
+        mjpegSocket.end();
+        reject(e);
+      });
+      mjpegServer.on('close', () => {
+        log.debug(`MJPEG server at http://${host}:${port} has been terminated`);
+        mjpegSocket.end();
+      });
+      mjpegServer.on('listening', () => {
+        log.info(`Successfully started MJPEG server at http://${host}:${port}`);
+        resolve();
+      });
+      mjpegServer.listen(port, host);
+    });
+  });
+
+  this._screenStreamingProps = {
+    deviceStreaming,
+    gstreamerPipeline,
+    mjpegSocket,
+    mjpegServer,
+  };
+};
+
+/**
+ * Stop screen streaming.
+ * If no screen streaming server has been started then nothing is done.
+ */
+commands.mobileStopScreenStreaming = async function mobileStopScreenStreaming (/* options = {} */) {
+  if (_.isEmpty(this._screenStreamingProps)) {
+    if (!_.isUndefined(this._screenStreamingProps)) {
+      log.debug(`Screen streaming is not running. There is nothing to stop`);
+    }
+    return;
+  }
+
+  const {
+    deviceStreaming,
+    gstreamerPipeline,
+    mjpegSocket,
+    mjpegServer,
+  } = this._screenStreamingProps;
+
+  try {
+    if (deviceStreaming.isRunning) {
+      try {
+        await deviceStreaming.stop('SIGINT');
+      } catch (e) {
+        try {
+          await deviceStreaming.stop('SIGKILL');
+        } catch (ign) {}
+        log.warn(e);
+      }
+    }
+    if (gstreamerPipeline.isRunning) {
+      try {
+        await gstreamerPipeline.stop('SIGINT');
+      } catch (e) {
+        try {
+          await gstreamerPipeline.stop('SIGKILL');
+        } catch (ign) {}
+        log.warn(e);
+      }
+    }
+    mjpegSocket.end();
+    if (mjpegServer.listening) {
+      mjpegServer.close();
+    }
+    log.info(`Successfully terminated the screen streaming MJPEG server`);
+  } finally {
+    this._screenStreamingProps = null;
+  }
+};
+
+
+export default commands;

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -129,6 +129,7 @@ async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
     height,
     quality,
     tcpPort,
+    considerRotation,
     logPipelineDetails,
   } = opts;
   const adjustedWidth = parseInt(width, 10) || deviceInfo.width;
@@ -136,13 +137,14 @@ async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
   const gstreamerPipeline = new SubProcess(GSTREAMER_BINARY, [
     '-v',
     'fdsrc', 'fd=0',
-    '!', `video/x-h264,` +
-      `width=${adjustedWidth},` +
-      `height=${adjustedHeight},` +
+    '!', 'video/x-h264,' +
+      `width=${considerRotation ? Math.max(adjustedWidth, adjustedHeight) : adjustedWidth},` +
+      `height=${considerRotation ? Math.max(adjustedWidth, adjustedHeight) : adjustedHeight},` +
       `framerate=${deviceInfo.fps}/1,` +
-      `byte-stream=true`,
+      'byte-stream=true',
     '!', 'h264parse',
     '!', 'avdec_h264', 'skip-frame=5',
+    '!', 'queue',
     '!', 'jpegenc', `quality=${quality}`,
     '!', 'multipartmux', `boundary=${BOUNDARY_STRING}`,
     '!', 'tcpserversink', `host=${TCP_HOST}`, `port=${tcpPort}`,
@@ -201,6 +203,10 @@ async function initGstreamerPipeline (deviceStreaming, deviceInfo, opts = {}) {
  * @property {?number} port [8093] - The port number to start the MJPEG server on.
  * @property {?number} quality [70] - The quality value for the streamed JPEG images.
  * This number should be in range [1, 100], where 100 is the best quality.
+ * @property {?boolean} considerRotation [false] - If set to `true` then GStreamer pipeline will
+ * increase the dimensions of the resulting images to properly fit images in both landscape and
+ * portrait orientations. Set it to `true` if the device rotation is not going to be the same during the
+ * broadcasting session.
  * @property {?boolean} logPipelineDetails [false] - Whether to log GStreamer pipeline events into
  * the standard log output. Might be useful for debugging purposes.
  */
@@ -222,6 +228,7 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
     port = DEFAULT_PORT,
     tcpPort = DEFAULT_PORT + 1,
     quality = DEFAULT_QUALITY,
+    considerRotation = false,
     logPipelineDetails = false,
   } = options;
 
@@ -257,6 +264,7 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
     height,
     quality,
     tcpPort,
+    considerRotation,
     logPipelineDetails,
   });
 
@@ -327,29 +335,33 @@ commands.mobileStopScreenStreaming = async function mobileStopScreenStreaming (/
   } = this._screenStreamingProps;
 
   try {
+    mjpegSocket.end();
+    if (mjpegServer.listening) {
+      mjpegServer.close();
+    }
     if (deviceStreaming.isRunning) {
       try {
         await deviceStreaming.stop('SIGINT');
       } catch (e) {
+        log.warn(e);
         try {
           await deviceStreaming.stop('SIGKILL');
-        } catch (ign) {}
-        log.warn(e);
+        } catch (e1) {
+          log.error(e1);
+        }
       }
     }
     if (gstreamerPipeline.isRunning) {
       try {
         await gstreamerPipeline.stop('SIGINT');
       } catch (e) {
+        log.warn(e);
         try {
           await gstreamerPipeline.stop('SIGKILL');
-        } catch (ign) {}
-        log.warn(e);
+        } catch (e1) {
+          log.error(e1);
+        }
       }
-    }
-    mjpegSocket.end();
-    if (mjpegServer.listening) {
-      mjpegServer.close();
     }
     log.info(`Successfully terminated the screen streaming MJPEG server`);
   } finally {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -398,6 +398,7 @@ class AndroidDriver extends BaseDriver {
   async deleteSession () {
     log.debug('Shutting down Android driver');
     await helpers.removeAllSessionWebSocketHandlers(this.server, this.sessionId);
+    await this.mobileStopScreenStreaming();
     await super.deleteSession();
     if (this.bootstrap) {
       // certain cleanup we only care to do if the bootstrap was ever run

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.26",
     "portfinder": "^1.0.6",
+    "portscanner": "2.2.0",
     "shared-preferences-builder": "^0.0.4",
     "shell-quote": "^1.6.1",
     "source-map-support": "^0.5.5",


### PR DESCRIPTION
This feature does the same trick as we do in iOS, although it requires GStreamer to be installed on the host machine. As the result, it is possible now to broadcast the device screen to any MJPEG client (including Chrome browser), which might be extremely useful for further integration with Appium Desktop