### PR TITLE
feat: Protect the screen streaming by feature setting

### DIFF
--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -223,10 +223,6 @@ function extractRemoteAddress (req) {
     || req.connection.socket.remoteAddress;
 }
 
-function extractUserAgent (req) {
-  return req.headers['user-agent'];
-}
-
 
 /**
  * @typedef {Object} StartScreenStreamingOptions
@@ -334,10 +330,9 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
         log.info(`Successfully connected to MJPEG stream at tcp://${TCP_HOST}:${tcpPort}`);
         mjpegServer = http.createServer((req, res) => {
           const remoteAddress = extractRemoteAddress(req);
-          const userAgent = extractUserAgent(req);
           const currentPathname = url.parse(req.url).pathname;
-          log.info(`Got an incoming request from ${remoteAddress} ` +
-            `(${userAgent || 'User Agent unknown'}) to ${currentPathname}`);
+          log.info(`Got an incoming screen bradcasting request from ${remoteAddress} ` +
+            `(${req.headers['user-agent'] || 'User Agent unknown'}) at ${currentPathname}`);
 
           if (pathname && currentPathname !== pathname) {
             log.info('Rejecting the broadcast request since it does not match the given pathname');

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -238,7 +238,7 @@ function extractRemoteAddress (req) {
  * You can set it to `0.0.0.0` to trigger the broadcast on all available network interfaces.
  * @property {?string} pathname - The HTTP request path the MJPEG server should be available on.
  * If unset then any pathname on the given `host`/`port` combination will work. Note that the value
- * should always start with a single slash (`/`)
+ * should always start with a single slash: `/`
  * @property {?number} tcpPort [8094] - The port number to start the internal TCP MJPEG broadcast on.
  * This type of broadcast always starts on the loopback interface (`127.0.0.1`).
  * @property {?number} port [8093] - The port number to start the MJPEG server on.
@@ -262,7 +262,7 @@ function extractRemoteAddress (req) {
  * @param {?StartScreenStreamingOptions} options - The available options.
  * @throws {Error} If screen streaming has failed to start or
  * is not supported on the host system or
- * the corresponding server feature is disabled is not enabled.
+ * the corresponding server feature is not enabled.
  */
 commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming (options = {}) {
   this.ensureFeatureEnabled(ADB_SCREEN_STREAMING_FEATURE);

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -216,6 +216,17 @@ async function initGstreamerPipeline (deviceStreamingProc, deviceInfo, opts = {}
   return gstreamerPipeline;
 }
 
+function extractRemoteAddress (req) {
+  return req.headers['x-forwarded-for']
+    || req.socket.remoteAddress
+    || req.connection.remoteAddress
+    || req.connection.socket.remoteAddress;
+}
+
+function extractUserAgent (req) {
+  return req.headers['user-agent'];
+}
+
 
 /**
  * @typedef {Object} StartScreenStreamingOptions
@@ -230,7 +241,8 @@ async function initGstreamerPipeline (deviceStreamingProc, deviceInfo, opts = {}
  * @property {?string} host [127.0.0.1] - The IP address/host name to start the MJPEG server on.
  * You can set it to `0.0.0.0` to trigger the broadcast on all available network interfaces.
  * @property {?string} pathname - The HTTP request path the MJPEG server should be available on.
- * If unset then any pathname on the given host/port will work.
+ * If unset then any pathname on the given `host`/`port` combination will work. Note that the value
+ * should always start with a single slash (`/`)
  * @property {?number} tcpPort [8094] - The port number to start the internal TCP MJPEG broadcast on.
  * This type of broadcast always starts on the loopback interface (`127.0.0.1`).
  * @property {?number} port [8093] - The port number to start the MJPEG server on.
@@ -248,9 +260,13 @@ async function initGstreamerPipeline (deviceStreamingProc, deviceInfo, opts = {}
  * Starts device screen broadcast by creating MJPEG server.
  * Multiple calls to this method have no effect unless the previous streaming
  * session is stopped.
+ * This method only works if the `adb_screen_streaming` feature is
+ * enabled on the server side.
  *
  * @param {?StartScreenStreamingOptions} options - The available options.
- * @throws {Error} If screen streaming has failed to start or is not supported on the host system.
+ * @throws {Error} If screen streaming has failed to start or
+ * is not supported on the host system or
+ * the corresponding server feature is disabled is not enabled.
  */
 commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming (options = {}) {
   this.ensureFeatureEnabled(ADB_SCREEN_STREAMING_FEATURE);
@@ -317,12 +333,11 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
       mjpegSocket = net.createConnection(tcpPort, TCP_HOST, () => {
         log.info(`Successfully connected to MJPEG stream at tcp://${TCP_HOST}:${tcpPort}`);
         mjpegServer = http.createServer((req, res) => {
-          const remoteAddress = req.headers['x-forwarded-for']
-            || req.socket.remoteAddress
-            || req.connection.remoteAddress
-            || req.connection.socket.remoteAddress;
+          const remoteAddress = extractRemoteAddress(req);
+          const userAgent = extractUserAgent(req);
           const currentPathname = url.parse(req.url).pathname;
-          log.info(`Got an incoming connection from ${remoteAddress} to ${currentPathname}`);
+          log.info(`Got an incoming request from ${remoteAddress} ` +
+            `(${userAgent || 'User Agent unknown'}) to ${currentPathname}`);
 
           if (pathname && currentPathname !== pathname) {
             log.info('Rejecting the broadcast request since it does not match the given pathname');

--- a/lib/commands/streamscreen.js
+++ b/lib/commands/streamscreen.js
@@ -9,6 +9,7 @@ import B from 'bluebird';
 import { waitForCondition } from 'asyncbox';
 import { spawn } from 'child_process';
 import { quote } from 'shell-quote';
+import url from 'url';
 
 const commands = {};
 
@@ -32,6 +33,7 @@ const DEFAULT_QUALITY = 70;
 const DEFAULT_BITRATE = 4000000; // Mbps
 const BOUNDARY_STRING = '--2ae9746887f170b8cf7c271047ce314c';
 
+const ADB_SCREEN_STREAMING_FEATURE = 'adb_screen_streaming';
 
 async function verifyStreamingRequirements (adb) {
   if (!_.trim(await adb.shell(['which', SCREENRECORD_BINARY]))) {
@@ -227,6 +229,8 @@ async function initGstreamerPipeline (deviceStreamingProc, deviceInfo, opts = {}
  * but doing so results in larger movie files.
  * @property {?string} host [127.0.0.1] - The IP address/host name to start the MJPEG server on.
  * You can set it to `0.0.0.0` to trigger the broadcast on all available network interfaces.
+ * @property {?string} pathname - The HTTP request path the MJPEG server should be available on.
+ * If unset then any pathname on the given host/port will work.
  * @property {?number} tcpPort [8094] - The port number to start the internal TCP MJPEG broadcast on.
  * This type of broadcast always starts on the loopback interface (`127.0.0.1`).
  * @property {?number} port [8093] - The port number to start the MJPEG server on.
@@ -249,12 +253,15 @@ async function initGstreamerPipeline (deviceStreamingProc, deviceInfo, opts = {}
  * @throws {Error} If screen streaming has failed to start or is not supported on the host system.
  */
 commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming (options = {}) {
+  this.ensureFeatureEnabled(ADB_SCREEN_STREAMING_FEATURE);
+
   const {
     width,
     height,
     bitRate,
     host = DEFAULT_HOST,
     port = DEFAULT_PORT,
+    pathname,
     tcpPort = DEFAULT_PORT + 1,
     quality = DEFAULT_QUALITY,
     considerRotation = false,
@@ -314,7 +321,21 @@ commands.mobileStartScreenStreaming = async function mobileStartScreenStreaming 
             || req.socket.remoteAddress
             || req.connection.remoteAddress
             || req.connection.socket.remoteAddress;
-          log.info(`Got an incoming connection from ${remoteAddress}. Starting the MJPEG broadcast`);
+          const currentPathname = url.parse(req.url).pathname;
+          log.info(`Got an incoming connection from ${remoteAddress} to ${currentPathname}`);
+
+          if (pathname && currentPathname !== pathname) {
+            log.info('Rejecting the broadcast request since it does not match the given pathname');
+            res.writeHead(404, {
+              Connection: 'close',
+              'Content-Type': 'text/plain; charset=utf-8',
+            });
+            res.write(`'${currentPathname}' did not match any known endpoints`);
+            res.end();
+            return;
+          }
+
+          log.info('Starting MJPEG broadcast');
           res.writeHead(200, {
             'Cache-Control': 'no-store, no-cache, must-revalidate, pre-check=0, post-check=0, max-age=0',
             Pragma: 'no-cache',


### PR DESCRIPTION
I think it makes sense to hide the feature under the server switch, since opening connections on any given host/port is not a very secure practice. Also added an additional `pathname` argument to have a possibility to limit the broadcast to the given secret in the pathname