### PR TITLE
fix: pass waitDuration to adb startApp

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -142,6 +142,7 @@ commands.background = async function background (seconds) {
         waitPkg: this.opts.appWaitPackage,
         waitActivity: this.opts.appWaitActivity,
         waitForLaunch: this.opts.appWaitForLaunch,
+        waitDuration: this.opts.appWaitDuration,
         optionalIntentArguments: this.opts.optionalIntentArguments,
         stopApp: false,
         user: this.opts.userProfile}


### PR DESCRIPTION
## Proposed changes
Related to appium/appium#13663 and appium/appium-uiautomator2-driver#354, background command doesn't pass in waitDuration to appium-adb. If this is not needed, please ignore this PR.

## Types of changes
What types of changes does your code introduce to Appium?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules