### PR TITLE
Fix toggle_location_services not working on android 9.0 devices

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -154,10 +154,12 @@ commands.getGeoLocation = async function getGeoLocation () {
 };
 // https://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_DPAD_CENTER
 // in the android docs, this is how the keycodes are defined
-let up = 19;
-let down = 20;
-let right = 22;
-let center = 23;
+const KeyCode = {
+  UP: 19,
+  DOWN: 20,
+  RIGHT: 22,
+  CENTER: 23
+}
 commands.toggleLocationServices = async function toggleLocationServices () {
   log.info('Toggling location services');
   let api = await this.adb.getApiLevel();
@@ -169,24 +171,24 @@ commands.toggleLocationServices = async function toggleLocationServices () {
   }
 
   if (api > 15) {
-    let seq = [up, up];
+    let seq = [KeyCode.UP, KeyCode.UP];
     if (api === 16) {
       // This version of Android has a "parent" button in its action bar
-      seq.push(down); // down
+      seq.push(KeyCode.DOWN); // down
     } else if (api < 28) {
       // Newer versions of Android have the toggle in the Action bar
-      seq = [right, right, up];
+      seq = [KeyCode.RIGHT, KeyCode.RIGHT, KeyCode.UP];
       /*
        * Once the Location services switch is OFF, it won't receive focus
        * when going back to the Location Services settings screen unless we
        * send a dummy keyevent (UP) *before* opening the settings screen
        */
-      await this.adb.keyevent(up);
+      await this.adb.keyevent(KeyCode.UP);
     } else if (api >= 28) {
       // Even newer versions of android have the toggle in a bar below the action bar
       // this means a single right click will cause it to be selected.
-      seq = [right];
-      await this.adb.keyevent(up);
+      seq = [KeyCode.RIGHT];
+      await this.adb.keyevent(KeyCode.UP);
     }
     await this.toggleSetting('LOCATION_SOURCE_SETTINGS', seq);
   } else {
@@ -204,7 +206,7 @@ helpers.toggleSetting = async function toggleSetting (setting, preKeySeq) {
    * already positionned on the 1st item, but we can't know for sure
    */
   if (_.isNull(preKeySeq)) {
-    preKeySeq = [up, up, down]; // up, up, down
+    preKeySeq = [KeyCode.UP, KeyCode.UP, KeyCode.DOWN]; // up, up, down
   }
 
   await this.openSettingsActivity(setting);
@@ -220,7 +222,7 @@ helpers.toggleSetting = async function toggleSetting (setting, preKeySeq) {
    * emulator when the network connection is disabled
    */
   await this.wrapBootstrapDisconnect(async () => {
-    await this.doKey(center);
+    await this.doKey(KeyCode.CENTER);
   });
 
   /*
@@ -231,8 +233,8 @@ helpers.toggleSetting = async function toggleSetting (setting, preKeySeq) {
    */
   try {
     await this.adb.waitForNotActivity(appPackage, appActivity, 5000);
-    await this.doKey(right);
-    await this.doKey(center);
+    await this.doKey(KeyCode.RIGHT);
+    await this.doKey(KeyCode.CENTER);
     await this.adb.waitForNotActivity(appPackage, appActivity, 5000);
   } catch (ign) {}
 

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -168,7 +168,8 @@ commands.toggleLocationServices = async function toggleLocationServices () {
     if (api === 16) {
       // This version of Android has a "parent" button in its action bar
       seq.push(20); // down
-    } else if (api >= 19) {
+    } else if (api < 28) {
+      log.info('apparently api is less than 28' + String(api));
       // Newer versions of Android have the toggle in the Action bar
       seq = [22, 22, 19]; // right, right, up
       /*
@@ -176,6 +177,10 @@ commands.toggleLocationServices = async function toggleLocationServices () {
        * when going back to the Location Services settings screen unless we
        * send a dummy keyevent (UP) *before* opening the settings screen
        */
+      await this.adb.keyevent(19);
+    } else if (api >= 28) {
+      log.info('hit special branch!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+      seq = [22, 22];
       await this.adb.keyevent(19);
     }
     await this.toggleSetting('LOCATION_SOURCE_SETTINGS', seq);

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -152,7 +152,12 @@ commands.getGeoLocation = async function getGeoLocation () {
     altitude: parseFloat(altitude) || GEO_EPSILON,
   };
 };
-
+// https://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_DPAD_CENTER
+// in the android docs, this is how the keycodes are defined
+let up = 19;
+let down = 20;
+let right = 22;
+let center = 23;
 commands.toggleLocationServices = async function toggleLocationServices () {
   log.info('Toggling location services');
   let api = await this.adb.getApiLevel();
@@ -164,24 +169,24 @@ commands.toggleLocationServices = async function toggleLocationServices () {
   }
 
   if (api > 15) {
-    let seq = [19, 19]; // up, up
+    let seq = [up, up];
     if (api === 16) {
       // This version of Android has a "parent" button in its action bar
-      seq.push(20); // down
+      seq.push(down); // down
     } else if (api < 28) {
       // Newer versions of Android have the toggle in the Action bar
-      seq = [22, 22, 19]; // right, right, up
+      seq = [right, right, up];
       /*
        * Once the Location services switch is OFF, it won't receive focus
        * when going back to the Location Services settings screen unless we
        * send a dummy keyevent (UP) *before* opening the settings screen
        */
-      await this.adb.keyevent(19);
+      await this.adb.keyevent(up);
     } else if (api >= 28) {
       // Even newer versions of android have the toggle in a bar below the action bar
       // this means a single right click will cause it to be selected.
-      seq = [22];
-      await this.adb.keyevent(19);
+      seq = [right];
+      await this.adb.keyevent(up);
     }
     await this.toggleSetting('LOCATION_SOURCE_SETTINGS', seq);
   } else {
@@ -199,7 +204,7 @@ helpers.toggleSetting = async function toggleSetting (setting, preKeySeq) {
    * already positionned on the 1st item, but we can't know for sure
    */
   if (_.isNull(preKeySeq)) {
-    preKeySeq = [19, 19, 20]; // up, up, down
+    preKeySeq = [up, up, down]; // up, up, down
   }
 
   await this.openSettingsActivity(setting);
@@ -215,7 +220,7 @@ helpers.toggleSetting = async function toggleSetting (setting, preKeySeq) {
    * emulator when the network connection is disabled
    */
   await this.wrapBootstrapDisconnect(async () => {
-    await this.doKey(23);
+    await this.doKey(center);
   });
 
   /*
@@ -226,8 +231,8 @@ helpers.toggleSetting = async function toggleSetting (setting, preKeySeq) {
    */
   try {
     await this.adb.waitForNotActivity(appPackage, appActivity, 5000);
-    await this.doKey(22); // right
-    await this.doKey(23); // click
+    await this.doKey(right);
+    await this.doKey(center);
     await this.adb.waitForNotActivity(appPackage, appActivity, 5000);
   } catch (ign) {}
 

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -178,6 +178,8 @@ commands.toggleLocationServices = async function toggleLocationServices () {
        */
       await this.adb.keyevent(19);
     } else if (api >= 28) {
+      // Even newer versions of android have the toggle in a bar below the action bar
+      // this means a single right click will cause it to be selected.
       seq = [22];
       await this.adb.keyevent(19);
     }

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -174,7 +174,7 @@ commands.toggleLocationServices = async function toggleLocationServices () {
     let seq = [KeyCode.UP, KeyCode.UP];
     if (api === 16) {
       // This version of Android has a "parent" button in its action bar
-      seq.push(KeyCode.DOWN); // down
+      seq.push(KeyCode.DOWN);
     } else if (api < 28) {
       // Newer versions of Android have the toggle in the Action bar
       seq = [KeyCode.RIGHT, KeyCode.RIGHT, KeyCode.UP];
@@ -206,7 +206,7 @@ helpers.toggleSetting = async function toggleSetting (setting, preKeySeq) {
    * already positionned on the 1st item, but we can't know for sure
    */
   if (_.isNull(preKeySeq)) {
-    preKeySeq = [KeyCode.UP, KeyCode.UP, KeyCode.DOWN]; // up, up, down
+    preKeySeq = [KeyCode.UP, KeyCode.UP, KeyCode.DOWN];
   }
 
   await this.openSettingsActivity(setting);

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -180,7 +180,7 @@ commands.toggleLocationServices = async function toggleLocationServices () {
       await this.adb.keyevent(19);
     } else if (api >= 28) {
       log.info('hit special branch!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-      seq = [22, 22];
+      seq = [22];
       await this.adb.keyevent(19);
     }
     await this.toggleSetting('LOCATION_SOURCE_SETTINGS', seq);

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -169,7 +169,6 @@ commands.toggleLocationServices = async function toggleLocationServices () {
       // This version of Android has a "parent" button in its action bar
       seq.push(20); // down
     } else if (api < 28) {
-      log.info('apparently api is less than 28' + String(api));
       // Newer versions of Android have the toggle in the Action bar
       seq = [22, 22, 19]; // right, right, up
       /*
@@ -179,7 +178,6 @@ commands.toggleLocationServices = async function toggleLocationServices () {
        */
       await this.adb.keyevent(19);
     } else if (api >= 28) {
-      log.info('hit special branch!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
       seq = [22];
       await this.adb.keyevent(19);
     }

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -159,7 +159,7 @@ const KeyCode = {
   DOWN: 20,
   RIGHT: 22,
   CENTER: 23
-}
+};
 commands.toggleLocationServices = async function toggleLocationServices () {
   log.info('Toggling location services');
   let api = await this.adb.getApiLevel();


### PR DESCRIPTION
unfortunately i haven't been able to test this end to end
i did test by manually inputting the adb keycode sequence and it toggled the location

this potentially fixes https://github.com/appium/appium/issues/13755