### PR TITLE
chore: Add isEmulator to Android helpers

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import path from 'path';
-import { exec } from 'teen_process';
 import { retry, retryInterval } from 'asyncbox';
 import logger from './logger';
 import { fs } from 'appium-support';
@@ -47,6 +46,7 @@ const CHROME_BROWSER_PACKAGE_ACTIVITY = {
 };
 const SETTINGS_HELPER_PKG_ID = 'io.appium.settings';
 const SETTINGS_HELPER_UNLOCK_ACTIVITY = '.Unlock';
+const EMULATOR_PATTERN = /\bemulator\b/i;
 
 let helpers = {};
 
@@ -81,23 +81,6 @@ helpers.createBaseADB = async function createBaseADB (opts = {}) {
     remoteAppsCacheLimit,
     buildToolsVersion,
   });
-};
-
-helpers.getJavaVersion = async function getJavaVersion (logVersion = true) {
-  let stderr;
-  try {
-    ({stderr} = await exec('java', ['-version']));
-  } catch (e) {
-    throw new Error(`Could not get the Java version. Is Java installed? Original error: ${e.stderr}`);
-  }
-  const versionMatch = /(java|openjdk)\s+version.+?([0-9._]+)/i.exec(stderr);
-  if (!versionMatch) {
-    throw new Error(`Could not parse Java version. Is Java installed? Original output: ${stderr}`);
-  }
-  if (logVersion) {
-    logger.info(`Java version is: ${versionMatch[2]}`);
-  }
-  return versionMatch[2];
 };
 
 helpers.prepareEmulator = async function prepareEmulator (adb, opts) {
@@ -814,6 +797,18 @@ helpers.validateDesiredCaps = function validateDesiredCaps (caps) {
   }
 
   return true;
+};
+
+/**
+ * Checks whether the current device under test is an emulator
+ *
+ * @param {ADB} adb - appium-adb instance
+ * @param {Object} opts - driver options mapping
+ * @returns {boolean} `true` if the device is an Android emulator
+ */
+helpers.isEmulator = function isEmulator (adb, opts) {
+  const possibleNames = [opts.udid, adb?.curDeviceId];
+  return !!opts.avd || possibleNames.some((x) => EMULATOR_PATTERN.test(x));
 };
 
 helpers.bootstrap = Bootstrap;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -12,7 +12,6 @@ import B from 'bluebird';
 
 const APP_EXTENSION = '.apk';
 const DEVICE_PORT = 4724;
-const EMULATOR_PATTERN = /\bemulator\b/i;
 
 // This is a set of methods and paths that we never want to proxy to
 // Chromedriver
@@ -196,8 +195,7 @@ class AndroidDriver extends BaseDriver {
   }
 
   isEmulator () {
-    const possibleNames = [this.opts.udid, this.adb?.curDeviceId];
-    return !!this.opts.avd || possibleNames.some((x) => EMULATOR_PATTERN.test(x));
+    return helpers.isEmulator(this.adb, this.opts);
   }
 
   setAvdFromCapabilities (caps) {


### PR DESCRIPTION
Also removed the obsolete `getJavaVersion` helper, since it is not used anywhere