### PR TITLE
fix: Add waitForLaunch in startAUT

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -236,6 +236,7 @@ commands.startAUT = async function startAUT () {
     flags: this.opts.intentFlags,
     waitPkg: this.opts.appWaitPackage,
     waitActivity: this.opts.appWaitActivity,
+    waitForLaunch: this.opts.appWaitForLaunch,
     waitDuration: this.opts.appWaitDuration,
     optionalIntentArguments: this.opts.optionalIntentArguments,
     stopApp: !this.opts.dontStopAppOnReset,

--- a/test/unit/commands/general-specs.js
+++ b/test/unit/commands/general-specs.js
@@ -364,6 +364,7 @@ describe('General', function () {
         intentFlags: 'flgs',
         appWaitPackage: 'wpkg',
         appWaitActivity: 'wact',
+        appWaitForLaunch: true,
         appWaitDuration: 'wdur',
         optionalIntentArguments: 'opt',
         userProfile: 1
@@ -376,6 +377,7 @@ describe('General', function () {
         flags: 'flgs',
         waitPkg: 'wpkg',
         waitActivity: 'wact',
+        waitForLaunch: true,
         waitDuration: 'wdur',
         optionalIntentArguments: 'opt',
         stopApp: false,


### PR DESCRIPTION
https://github.com/appium/appium/issues/14000

In `reset`, `commands.startAUT` is called but it does not give `this.opts.appWaitForLaunch` to `adb.startApp`.
`commands.background` in this file already does the same thing.
