### PR TITLE
feat: Add ignore hidden api policy error

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -234,6 +234,9 @@ let commonCapConstraints = {
   allowOfflineDevices: {
     isBoolean: true
   },
+  ignoreHiddenApiPolicyError: {
+    isBoolean: true
+  },
 };
 
 let uiautomatorCapConstraints = {
@@ -255,9 +258,6 @@ let uiautomatorCapConstraints = {
   bootstrapPort: {
     isNumber: true
   },
-  ignoreHiddenApiPolicyError: {
-    isBoolean: true
-  }
 };
 
 let desiredCapConstraints = {};

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -255,6 +255,9 @@ let uiautomatorCapConstraints = {
   bootstrapPort: {
     isNumber: true
   },
+  ignoreHiddenApiPolicyError: {
+    isBoolean: true
+  }
 };
 
 let desiredCapConstraints = {};

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -247,7 +247,7 @@ class AndroidDriver extends BaseDriver {
         if (await this.adb.getApiLevel() >= 28) { // API level 28 is Android P
           // Don't forget to reset the relaxing in delete session
           log.warn('Relaxing hidden api policy to manage animation scale');
-          await this.adb.setHiddenApiPolicy('1');
+          await this.adb.setHiddenApiPolicy('1', this.opts.ignoreHiddenApiPolicyError || false);
         }
 
         log.info('Disabling window animation as it is requested by "disableWindowAnimation" capability');
@@ -431,7 +431,7 @@ class AndroidDriver extends BaseDriver {
       // This was necessary to change animation scale over Android P. We must reset the policy for the security.
       if (await this.adb.getApiLevel() >= 28) {
         log.info('Restoring hidden api policy to the device default configuration');
-        await this.adb.setDefaultHiddenApiPolicy();
+        await this.adb.setDefaultHiddenApiPolicy(this.opts.ignoreHiddenApiPolicyError || false);
       }
     }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -247,7 +247,7 @@ class AndroidDriver extends BaseDriver {
         if (await this.adb.getApiLevel() >= 28) { // API level 28 is Android P
           // Don't forget to reset the relaxing in delete session
           log.warn('Relaxing hidden api policy to manage animation scale');
-          await this.adb.setHiddenApiPolicy('1', this.opts.ignoreHiddenApiPolicyError || false);
+          await this.adb.setHiddenApiPolicy('1', !!this.opts.ignoreHiddenApiPolicyError);
         }
 
         log.info('Disabling window animation as it is requested by "disableWindowAnimation" capability');
@@ -431,7 +431,7 @@ class AndroidDriver extends BaseDriver {
       // This was necessary to change animation scale over Android P. We must reset the policy for the security.
       if (await this.adb.getApiLevel() >= 28) {
         log.info('Restoring hidden api policy to the device default configuration');
-        await this.adb.setDefaultHiddenApiPolicy(this.opts.ignoreHiddenApiPolicyError || false);
+        await this.adb.setDefaultHiddenApiPolicy(!!this.opts.ignoreHiddenApiPolicyError);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^7.22.0",
+    "appium-adb": "^7.27.0",
     "appium-base-driver": "^5.1.0",
     "appium-chromedriver": "^4.13.0",
     "appium-support": "^2.37.0",


### PR DESCRIPTION
Add `ignoreHiddenApiPolicyError` to ignore permission error when set/delete hidden api policy to relax the security. Some devices like a Chinese phone raises a permission error when the adb shell is called. Potentially, the security error blocks our change settings like animation scale, but it could be ignored.

Defaults to false. (Does not ignore the error)

https://github.com/appium/appium-adb/pull/507