### PR TITLE
build: add call which will produce logs to log e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,6 @@ before_script:
   - sleep 30
   - adb shell input keyevent 82 &
 script:
-  - npm run lint && npm run mocha -- -t $MOCHA_TIMEOUT $RECURSIVE build/test/$TEST -g @skip-ci -i
+  - npm run lint && npx mocha -t $MOCHA_TIMEOUT $RECURSIVE build/test/$TEST -g @skip-ci -i
 after_success:
   - if [ ${COVERALLS} = "1" ]; then npm run coverage; fi


### PR DESCRIPTION
The log broadcast test is flakey. This adds a call which will produce logs, rather than leaving it to chance.