### PR TITLE
Provide an option to set successful unlock timeout

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -665,12 +665,13 @@ helpers.unlock = async function unlock (driver, adb, capabilities) {
     await helpers.unlockWithHelperApp(adb);
   } else {
     await helpers.unlockWithUIAutomation(driver, adb, {unlockType: capabilities.unlockType, unlockKey: capabilities.unlockKey});
-    await helpers.verifyUnlock(adb);
+    await helpers.verifyUnlock(adb, capabilities.unlockSuccessTimeout);
   }
 };
 
-helpers.verifyUnlock = async function verifyUnlock (adb) {
-  await retryInterval(2, 1000, async () => {
+helpers.verifyUnlock = async function verifyUnlock (adb, unlockSuccessTimeout) {
+  let successTimeout = unlockSuccessTimeout || 2000;
+  await retryInterval(successTimeout / 1000, successTimeout, async () => {
     if (await adb.isScreenLocked()) {
       throw new Error('Screen did not unlock successfully, retrying');
     }

--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -237,6 +237,9 @@ let commonCapConstraints = {
   ignoreHiddenApiPolicyError: {
     isBoolean: true
   },
+  unlockSuccessTimeout: {
+    isNumber: true
+  },
 };
 
 let uiautomatorCapConstraints = {


### PR DESCRIPTION
I'm facing the issue when 2 seconds is not enough in order to verify that screen was unlocked successfully. So in scope of this PR I'd like to propose the option to provide the value of this timeout as part of the desired capabilities. By default (if not provided) this timeout still will be 2 seconds.

If the name of proposed capability is fine (`unlockSuccessTimeout`), I could update the list of desired capabilities for Android.