### PR TITLE
fix: Avoid package/activity caps override if they have been already provided

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -831,7 +831,7 @@ helpers.adjustCapsIfBrowserSession = function adjustCapsIfBrowserSession (caps =
     logger.info(`Application package/activity have been automatically set to ${pkg}/${activity} ` +
       `for '${browserName}'`);
     logger.info(`Consider changing the browserName to the one from the list of supported browser names ` +
-      `or provide custom appPackage/appActivity capability values if the automatically assigned values do ` +
+      `or provide custom appPackage/appActivity capability values if the automatically assigned ones do ` +
       `not make sense`);
   }
   return caps;

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -14,6 +14,7 @@ import { EOL } from 'os';
 import semver from 'semver';
 
 const PACKAGE_INSTALL_TIMEOUT = 90000; // milliseconds
+// https://cs.chromium.org/chromium/src/chrome/browser/devtools/device/android_device_info_query.cc
 const CHROME_BROWSER_PACKAGE_ACTIVITY = {
   chrome: {
     pkg: 'com.android.chrome',
@@ -817,5 +818,5 @@ helpers.isEmulator = function isEmulator (adb, opts) {
 helpers.bootstrap = Bootstrap;
 helpers.unlocker = unlocker;
 
-export { helpers, SETTINGS_HELPER_PKG_ID };
+export { helpers, SETTINGS_HELPER_PKG_ID, CHROME_BROWSER_PACKAGE_ACTIVITY };
 export default helpers;

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -804,6 +804,40 @@ helpers.validateDesiredCaps = function validateDesiredCaps (caps) {
 };
 
 /**
+ * Adjust the capabilities for a browser session
+ *
+ * @param {Object} caps - Current capabilities object
+ * !!! The object is mutated by this method call !!!
+ * @returns {Object} The same possibly mutated `opts` instance.
+ * No mutation is happening is the current session is
+ * not a browser based or appPackage/appActivity caps
+ * have already been provided.
+ */
+helpers.adjustCapsForBrowserSession = function adjustCapsForBrowserSession (caps = {}) {
+  const { browserName } = caps;
+  if (!this.isChromeBrowser(browserName)) {
+    return caps;
+  }
+
+  logger.info(`The current session is considered browser-based`);
+  logger.info(`Supported browser names: ${JSON.stringify(_.keys(CHROME_BROWSER_PACKAGE_ACTIVITY))}`);
+  if (caps.appPackage || caps.appActivity) {
+    logger.info(`Not overriding appPackage/appActivity capability values for '${browserName}' ` +
+      'because some of them have been already provided');
+  } else {
+    const {pkg, activity} = this.getChromePkg(browserName);
+    caps.appPackage = pkg;
+    caps.appActivity = activity;
+    logger.info(`Application package/activity have been automatically set to ${pkg}/${activity} ` +
+      `for '${browserName}'`);
+    logger.info(`Consider changing the browserName to the one from the list of supported browser names ` +
+      `or provide custom appPackage/appActivity capability values if the automatically assigned values do ` +
+      `not make sense`);
+  }
+  return caps;
+};
+
+/**
  * Checks whether the current device under test is an emulator
  *
  * @param {ADB} adb - appium-adb instance
@@ -818,5 +852,5 @@ helpers.isEmulator = function isEmulator (adb, opts) {
 helpers.bootstrap = Bootstrap;
 helpers.unlocker = unlocker;
 
-export { helpers, SETTINGS_HELPER_PKG_ID, CHROME_BROWSER_PACKAGE_ACTIVITY };
+export { helpers, SETTINGS_HELPER_PKG_ID };
 export default helpers;

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -813,7 +813,7 @@ helpers.validateDesiredCaps = function validateDesiredCaps (caps) {
  * not a browser based or appPackage/appActivity caps
  * have already been provided.
  */
-helpers.adjustCapsForBrowserSession = function adjustCapsForBrowserSession (caps = {}) {
+helpers.adjustCapsIfBrowserSession = function adjustCapsIfBrowserSession (caps = {}) {
   const { browserName } = caps;
   if (!this.isChromeBrowser(browserName)) {
     return caps;

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -809,31 +809,27 @@ helpers.validateDesiredCaps = function validateDesiredCaps (caps) {
  * @param {Object} caps - Current capabilities object
  * !!! The object is mutated by this method call !!!
  * @returns {Object} The same possibly mutated `opts` instance.
- * No mutation is happening is the current session is
- * not a browser based or appPackage/appActivity caps
- * have already been provided.
+ * No mutation is happening is the current session if
+ * appPackage/appActivity caps have already been provided.
  */
-helpers.adjustCapsIfBrowserSession = function adjustCapsIfBrowserSession (caps = {}) {
+helpers.adjustBrowserSessionCaps = function adjustBrowserSessionCaps (caps = {}) {
   const { browserName } = caps;
-  if (!this.isChromeBrowser(browserName)) {
-    return caps;
-  }
-
   logger.info(`The current session is considered browser-based`);
   logger.info(`Supported browser names: ${JSON.stringify(_.keys(CHROME_BROWSER_PACKAGE_ACTIVITY))}`);
   if (caps.appPackage || caps.appActivity) {
     logger.info(`Not overriding appPackage/appActivity capability values for '${browserName}' ` +
       'because some of them have been already provided');
-  } else {
-    const {pkg, activity} = this.getChromePkg(browserName);
-    caps.appPackage = pkg;
-    caps.appActivity = activity;
-    logger.info(`Application package/activity have been automatically set to ${pkg}/${activity} ` +
-      `for '${browserName}'`);
-    logger.info(`Consider changing the browserName to the one from the list of supported browser names ` +
-      `or provide custom appPackage/appActivity capability values if the automatically assigned ones do ` +
-      `not make sense`);
+    return caps;
   }
+
+  const {pkg, activity} = this.getChromePkg(browserName);
+  caps.appPackage = pkg;
+  caps.appActivity = activity;
+  logger.info(`appPackage/appActivity capabilities have been automatically set to ${pkg}/${activity} ` +
+    `for '${browserName}'`);
+  logger.info(`Consider changing the browserName to the one from the list of supported browser names ` +
+    `or provide custom appPackage/appActivity capability values if the automatically assigned ones do ` +
+    `not make sense`);
   return caps;
 };
 

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -379,7 +379,7 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
     }
   }
 
-  const caps = webviewHelpers.createChromeOptions(opts, curDeviceId);
+  const caps = webviewHelpers.createChromedriverCaps(opts, curDeviceId);
   log.debug(`Before starting chromedriver, androidPackage is '${caps.chromeOptions.androidPackage}'`);
   await chromedriver.start(caps);
   return chromedriver;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -379,52 +379,7 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
     }
   }
 
-  let caps = {
-    chromeOptions: {
-      androidPackage: opts.chromeOptions.androidPackage || opts.appPackage,
-    }
-  };
-  if (opts.chromeUseRunningApp) {
-    caps.chromeOptions.androidUseRunningApp = opts.chromeUseRunningApp;
-  }
-  if (opts.chromeAndroidPackage) {
-    caps.chromeOptions.androidPackage = opts.chromeAndroidPackage;
-  }
-  if (opts.chromeAndroidActivity) {
-    caps.chromeOptions.androidActivity = opts.chromeAndroidActivity;
-  }
-  if (opts.chromeAndroidProcess) {
-    caps.chromeOptions.androidProcess = opts.chromeAndroidProcess;
-  }
-  if (opts.loggingPrefs) {
-    caps.loggingPrefs = opts.loggingPrefs;
-  }
-  if (opts.enablePerformanceLogging) {
-    log.warn(`The 'enablePerformanceLogging' cap is deprecated; simply use ` +
-             `the 'loggingPrefs' cap instead, with a 'performance' key set to 'ALL'`);
-    const newPref = {performance: 'ALL'};
-
-    // don't overwrite other logging prefs that have been sent in if they exist
-    caps.loggingPrefs = caps.loggingPrefs ?
-      Object.assign({}, caps.loggingPrefs, newPref) :
-      newPref;
-  }
-  if (opts.browserName === 'chromium-webview') {
-    caps.chromeOptions.androidActivity = opts.appActivity;
-  }
-  if (opts.pageLoadStrategy) {
-    caps.pageLoadStrategy = opts.pageLoadStrategy;
-  }
-  const pkg = caps.chromeOptions.androidPackage;
-  if ((pkg && pkg.toLowerCase()) === 'chrome') {
-    // if we have extracted package from context name, it could come in as bare
-    // "chrome", and so we should make sure the details are correct, including
-    // not using an activity or process id
-    caps.chromeOptions.androidPackage = 'com.android.chrome';
-    delete caps.chromeOptions.androidActivity;
-    delete caps.chromeOptions.androidProcess;
-  }
-  caps = webviewHelpers.decorateChromeOptions(caps, opts, curDeviceId);
+  const caps = webviewHelpers.createChromeOptions(opts, curDeviceId);
   log.debug(`Before starting chromedriver, androidPackage is '${caps.chromeOptions.androidPackage}'`);
   await chromedriver.start(caps);
   return chromedriver;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -109,7 +109,7 @@ class AndroidDriver extends BaseDriver {
       this.opts.fastReset = !this.opts.fullReset && !this.opts.noReset;
       this.opts.skipUninstall = this.opts.fastReset || this.opts.noReset;
 
-      helpers.adjustCapsForBrowserSession(this.opts);
+      helpers.adjustCapsIfBrowserSession(this.opts);
 
       if (this.opts.nativeWebScreenshot) {
         this.jwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,7 +1,11 @@
 import { BaseDriver, DeviceSettings } from 'appium-base-driver';
 import desiredConstraints from './desired-caps';
 import commands from './commands/index';
-import { helpers, SETTINGS_HELPER_PKG_ID } from './android-helpers';
+import {
+  helpers,
+  SETTINGS_HELPER_PKG_ID,
+  CHROME_BROWSER_PACKAGE_ACTIVITY,
+} from './android-helpers';
 import log from './logger';
 import _ from 'lodash';
 import { DEFAULT_ADB_PORT } from 'appium-adb';
@@ -107,11 +111,20 @@ class AndroidDriver extends BaseDriver {
       this.opts.skipUninstall = this.opts.fastReset || this.opts.noReset;
 
       if (this.isChromeSession) {
-        log.info("We're going to run a Chrome-based session");
-        let {pkg, activity} = helpers.getChromePkg(this.opts.browserName);
-        this.opts.appPackage = pkg;
-        this.opts.appActivity = activity;
-        log.info(`Chrome-type package and activity are ${pkg} and ${activity}`);
+        log.info(`The session is considered as browser-based`);
+        log.info(`Supported browser names: ${JSON.stringify(_.keys(CHROME_BROWSER_PACKAGE_ACTIVITY))}`);
+        if (this.opts.appPackage || this.opts.appActivity) {
+          log.info(`Not overriding appPackage/appActivity capability values for '${this.opts.browserName}' ` +
+            'because some of them have been already provided');
+        } else {
+          const {pkg, activity} = helpers.getChromePkg(this.opts.browserName);
+          this.opts.appPackage = pkg;
+          this.opts.appActivity = activity;
+          log.info(`Application package/activity have been automatically set to ${pkg}/${activity} ` +
+            `for '${this.opts.browserName}'`);
+          log.info(`Consider changing the browserName to the one from the list of supported browser names ` +
+            `or provide custom appPackage/appActivity capability values if the automatic values do not make sense`);
+        }
       }
 
       if (this.opts.nativeWebScreenshot) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -4,7 +4,6 @@ import commands from './commands/index';
 import {
   helpers,
   SETTINGS_HELPER_PKG_ID,
-  CHROME_BROWSER_PACKAGE_ACTIVITY,
 } from './android-helpers';
 import log from './logger';
 import _ from 'lodash';
@@ -110,22 +109,7 @@ class AndroidDriver extends BaseDriver {
       this.opts.fastReset = !this.opts.fullReset && !this.opts.noReset;
       this.opts.skipUninstall = this.opts.fastReset || this.opts.noReset;
 
-      if (this.isChromeSession) {
-        log.info(`The session is considered as browser-based`);
-        log.info(`Supported browser names: ${JSON.stringify(_.keys(CHROME_BROWSER_PACKAGE_ACTIVITY))}`);
-        if (this.opts.appPackage || this.opts.appActivity) {
-          log.info(`Not overriding appPackage/appActivity capability values for '${this.opts.browserName}' ` +
-            'because some of them have been already provided');
-        } else {
-          const {pkg, activity} = helpers.getChromePkg(this.opts.browserName);
-          this.opts.appPackage = pkg;
-          this.opts.appActivity = activity;
-          log.info(`Application package/activity have been automatically set to ${pkg}/${activity} ` +
-            `for '${this.opts.browserName}'`);
-          log.info(`Consider changing the browserName to the one from the list of supported browser names ` +
-            `or provide custom appPackage/appActivity capability values if the automatic values do not make sense`);
-        }
-      }
+      helpers.adjustCapsForBrowserSession(this.opts);
 
       if (this.opts.nativeWebScreenshot) {
         this.jwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -109,7 +109,9 @@ class AndroidDriver extends BaseDriver {
       this.opts.fastReset = !this.opts.fullReset && !this.opts.noReset;
       this.opts.skipUninstall = this.opts.fastReset || this.opts.noReset;
 
-      helpers.adjustCapsIfBrowserSession(this.opts);
+      if (this.isChromeSession) {
+        helpers.adjustBrowserSessionCaps(this.opts);
+      }
 
       if (this.opts.nativeWebScreenshot) {
         this.jwpProxyAvoid.push(['GET', new RegExp('^/session/[^/]+/screenshot')]);

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -14,6 +14,7 @@ const DEFAULT_WEBVIEW_DEVTOOLS_PORT = 9222;
 const DEVTOOLS_SOCKET_PATTERN = /@[\w.]+_devtools_remote_?(\d+)?\b/;
 const CROSSWALK_SOCKET_PATTERN = /@([\w.]+)_devtools_remote\b/;
 const CHROMIUM_DEVTOOLS_SOCKET = 'chrome_devtools_remote';
+const CHROME_PACKAGE_NAME = 'com.android.chrome';
 
 
 let helpers = {};
@@ -258,26 +259,80 @@ helpers.getWebviews = async function getWebviews (adb, {
   return result;
 };
 
-helpers.decorateChromeOptions = function decorateChromeOptions (caps, opts, deviceId) {
-  // add options from appium session caps
-  if (opts.chromeOptions) {
-    if (opts.chromeOptions.Arguments) {
-      // merge `Arguments` and `args`
-      opts.chromeOptions.args = [...(opts.chromeOptions.args || []), ...opts.chromeOptions.Arguments];
-      delete opts.chromeOptions.Arguments;
+/**
+ * Create Chrome driver capabilities based on the provided
+ * Appium capabilities
+ *
+ * @param {Object} opts User-provided capabilities object
+ * @param {string} deviceId The identifier of the Android device under test
+ * @returns {Object} The capabilities object.
+ * See https://chromedriver.chromium.org/capabilities for more details.
+ */
+helpers.createChromeOptions = function createChromeOptions (opts, deviceId) {
+  const caps = {
+    chromeOptions: {
+      androidPackage: opts.chromeOptions?.androidPackage || opts.appPackage,
     }
-    for (let [opt, val] of _.toPairs(opts.chromeOptions)) {
-      if (_.isUndefined(caps.chromeOptions[opt])) {
-        caps.chromeOptions[opt] = val;
-      } else {
-        logger.warn(`Cannot pass option '${opt}' (${caps.chromeOptions[opt]}) because ` +
-                    'Appium needs it to make chromeDriver work');
-      }
-    }
+  };
+  if (_.isBoolean(opts.chromeUseRunningApp)) {
+    caps.chromeOptions.androidUseRunningApp = opts.chromeUseRunningApp;
   }
-
+  if (opts.chromeAndroidPackage) {
+    caps.chromeOptions.androidPackage = opts.chromeAndroidPackage;
+  }
+  if (opts.chromeAndroidActivity) {
+    caps.chromeOptions.androidActivity = opts.chromeAndroidActivity;
+  }
+  if (opts.chromeAndroidProcess) {
+    caps.chromeOptions.androidProcess = opts.chromeAndroidProcess;
+  }
+  if (_.toLower(opts.browserName) === 'chromium-webview') {
+    logger.info(`Automatically setting 'androidActivity' capability ` +
+      `to '${opts.appActivity}' for '${opts.browserName}' browser`);
+    caps.chromeOptions.androidActivity = opts.appActivity;
+  }
+  if (opts.pageLoadStrategy) {
+    caps.pageLoadStrategy = opts.pageLoadStrategy;
+  }
+  if (_.toLower(caps.chromeOptions.androidPackage) === 'chrome') {
+    // if we have extracted package from context name, it could come in as bare
+    // "chrome", and so we should make sure the details are correct, including
+    // not using an activity or process id
+    logger.info(`'androidPackage' Chromedriver capability has been ` +
+      `automatically corrected to '${CHROME_PACKAGE_NAME}'`);
+    caps.chromeOptions.androidPackage = CHROME_PACKAGE_NAME;
+    delete caps.chromeOptions.androidActivity;
+    delete caps.chromeOptions.androidProcess;
+  }
   // add device id from adb
   caps.chromeOptions.androidDeviceSerial = deviceId;
+
+  if (opts.loggingPrefs) {
+    caps.loggingPrefs = opts.loggingPrefs;
+  }
+  if (opts.enablePerformanceLogging) {
+    logger.warn(`The 'enablePerformanceLogging' cap is deprecated; simply use ` +
+      `the 'loggingPrefs' cap instead, with a 'performance' key set to 'ALL'`);
+    const newPref = {performance: 'ALL'};
+    // don't overwrite other logging prefs that have been sent in if they exist
+    caps.loggingPrefs = caps.loggingPrefs ?
+      Object.assign({}, caps.loggingPrefs, newPref) :
+      newPref;
+  }
+
+  if (opts.chromeOptions?.Arguments) {
+    // merge `Arguments` and `args`
+    opts.chromeOptions.args = [...(opts.chromeOptions.args || []), ...opts.chromeOptions.Arguments];
+    delete opts.chromeOptions.Arguments;
+  }
+  for (const [opt, val] of _.toPairs(opts.chromeOptions)) {
+    if (_.isUndefined(caps.chromeOptions[opt])) {
+      caps.chromeOptions[opt] = val;
+    } else {
+      logger.info(`The '${opt}' chromeOption (${caps.chromeOptions[opt]}) ` +
+        `won't be applied to Chromedriver capabilities because it has been already assigned before`);
+    }
+  }
   return caps;
 };
 

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -268,7 +268,7 @@ helpers.getWebviews = async function getWebviews (adb, {
  * @returns {Object} The capabilities object.
  * See https://chromedriver.chromium.org/capabilities for more details.
  */
-helpers.createChromeOptions = function createChromeOptions (opts, deviceId) {
+helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId) {
   const caps = {
     chromeOptions: {
       androidPackage: opts.chromeOptions?.androidPackage || opts.appPackage,


### PR DESCRIPTION
Sometimes users don't really know which browser name they want (or which names exist in general). This PR fixes that