### PR TITLE
fix: Make sure we cache web view info per device

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -354,7 +354,7 @@ helpers.setupNewChromedriver = async function setupNewChromedriver (opts, curDev
     opts.chromedriverPort = await getChromedriverPort(opts.chromedriverPorts);
   }
 
-  const details = context ? webviewHelpers.getWebviewDetails(context) : undefined;
+  const details = context ? webviewHelpers.getWebviewDetails(adb, context) : undefined;
   if (!_.isEmpty(details)) {
     log.debug('Passing web view details to the Chromedriver constructor: ' +
       JSON.stringify(details, null, 2));

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -27,6 +27,10 @@ const CDP_REQ_TIMEOUT = 2000; // ms
 
 const helpers = {};
 
+function toDetailsCacheKey (adb, webview) {
+  return `${adb?.curDeviceId}:${webview}`;
+}
+
 /**
  * This function gets a list of android system processes and returns ones
  * that look like webviews
@@ -357,10 +361,11 @@ helpers.getWebviews = async function getWebviews (adb, {
     }
 
     result.push(wvName);
+    const key = toDetailsCacheKey(adb, wvName);
     if (info) {
-      WEBVIEWS_DETAILS_CACHE.set(wvName, { info });
-    } else if (WEBVIEWS_DETAILS_CACHE.has(wvName)) {
-      WEBVIEWS_DETAILS_CACHE.del(wvName);
+      WEBVIEWS_DETAILS_CACHE.set(key, { info });
+    } else if (WEBVIEWS_DETAILS_CACHE.has(key)) {
+      WEBVIEWS_DETAILS_CACHE.del(key);
     }
   }
   logger.debug(`Found ${util.pluralize('webview', result.length, true)}: ${JSON.stringify(result)}`);
@@ -383,11 +388,13 @@ helpers.getWebviews = async function getWebviews (adb, {
 /**
  * Retrieves web view details previously cached by `getWebviews` call
  *
+ * @param {ADB} adb ADB instance
  * @param {string} webview The name of the web view
  * @returns {?WebViewDetails} Either `undefined` or the recent web view details
  */
-helpers.getWebviewDetails = function getWebviewDetails (webview) {
-  return WEBVIEWS_DETAILS_CACHE.get(webview);
+helpers.getWebviewDetails = function getWebviewDetails (adb, webview) {
+  const key = toDetailsCacheKey(adb, webview);
+  return WEBVIEWS_DETAILS_CACHE.get(key);
 };
 
 /**


### PR DESCRIPTION
This PR avoids the situation where same web view names exist on different devices and get cached interchangeably because of that.