### PR TITLE
fix: Add more visibility into Chromedriver caps setting

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -127,7 +127,6 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context)
       let androidPackage = context.match(`${WEBVIEW_BASE}(.+)`);
       if (androidPackage && androidPackage.length > 0) {
         opts.chromeAndroidPackage = androidPackage[1];
-        log.debug(`Automatically set chromeAndroidPackage to '${androidPackage[1]}'`);
       }
     }
 
@@ -219,16 +218,9 @@ helpers.dismissChromeWelcome = async function dismissChromeWelcome () {
   }
 };
 
-// extract so sub-classes can decide
-helpers.shouldUseChromeRunningApp = function shouldUseChromeRunningApp () {
-  return false;
-};
-
 helpers.startChromeSession = async function startChromeSession () {
   log.info('Starting a chrome-based browser session');
   let opts = _.cloneDeep(this.opts);
-
-  opts.chromeUseRunningApp = this.shouldUseChromeRunningApp();
 
   const knownPackages = [
     'org.chromium.chrome.shell',

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -456,14 +456,26 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
     opts.chromeOptions.args = [...(opts.chromeOptions.args || []), ...opts.chromeOptions.Arguments];
     delete opts.chromeOptions.Arguments;
   }
+
+  logger.debug('Precalculated Chromedriver capabilities:' +
+    JSON.stringify(caps.chromeOptions, null, 2));
+
+  const protectedCapNames = [];
   for (const [opt, val] of _.toPairs(opts.chromeOptions)) {
     if (_.isUndefined(caps.chromeOptions[opt])) {
       caps.chromeOptions[opt] = val;
     } else {
-      logger.info(`The '${opt}' chromeOption (${caps.chromeOptions[opt]}) ` +
-        `won't be applied to Chromedriver capabilities because it has been already assigned before`);
+      protectedCapNames.push(opt);
     }
   }
+  if (!_.isEmpty(protectedCapNames)) {
+    logger.info('The following Chromedriver capabilities cannot be overridden ' +
+      'by the provided chromeOptions:');
+    for (const optName of protectedCapNames) {
+      logger.info(`  ${optName} (${JSON.stringify(opts.chromeOptions[optName])})`);
+    }
+  }
+
   return caps;
 };
 

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -418,8 +418,6 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
     caps.chromeOptions.androidProcess = opts.chromeAndroidProcess;
   }
   if (_.toLower(opts.browserName) === 'chromium-webview') {
-    logger.info(`Automatically setting 'androidActivity' capability ` +
-      `to '${opts.appActivity}' for '${opts.browserName}' browser`);
     caps.chromeOptions.androidActivity = opts.appActivity;
   }
   if (opts.pageLoadStrategy) {
@@ -429,8 +427,6 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
     // if we have extracted package from context name, it could come in as bare
     // "chrome", and so we should make sure the details are correct, including
     // not using an activity or process id
-    logger.info(`'androidPackage' Chromedriver capability has been ` +
-      `automatically corrected to '${CHROME_PACKAGE_NAME}'`);
     caps.chromeOptions.androidPackage = CHROME_PACKAGE_NAME;
     delete caps.chromeOptions.androidActivity;
     delete caps.chromeOptions.androidProcess;

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -457,7 +457,7 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
     delete opts.chromeOptions.Arguments;
   }
 
-  logger.debug('Precalculated Chromedriver capabilities:' +
+  logger.debug('Precalculated Chromedriver capabilities: ' +
     JSON.stringify(caps.chromeOptions, null, 2));
 
   const protectedCapNames = [];


### PR DESCRIPTION
It also makes sense to respect `androidUseRunningApp` cap as a part of `chromeOptions`. Related to https://github.com/appium/appium/issues/12651