### PR TITLE
fix: Only provide element id to actions where it is needed

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -7,23 +7,23 @@ import { asyncmap } from 'asyncbox';
 
 let commands = {}, helpers = {}, extensions = {};
 
-commands.doTouchAction = async function doTouchAction (action, opts) {
+commands.doTouchAction = async function doTouchAction (action, opts = {}) {
+  const { element, x, y, count, ms, duration } = opts;
+  // parseTouch precalculates absolute element positions
+  // so there is no need to pass `element` to the affected gestures
   switch (action) {
     case 'tap':
-      return await this.tap(opts.element, opts.x, opts.y, opts.count);
+      return await this.tap(null, x, y, count);
     case 'press':
-      return await this.touchDown(opts.element, opts.x, opts.y);
+      return await this.touchDown(null, x, y);
     case 'release':
-      return await this.touchUp(opts.element, opts.x, opts.y);
+      return await this.touchUp(element, x, y);
     case 'moveTo':
-      return await this.touchMove(opts.element, opts.x, opts.y);
+      return await this.touchMove(null, x, y);
     case 'wait':
-      return await B.delay(opts.ms);
+      return await B.delay(ms);
     case 'longPress':
-      if (typeof opts.duration === 'undefined' || !opts.duration) {
-        opts.duration = 1000;
-      }
-      return await this.touchLongClick(opts.element, opts.x, opts.y, opts.duration);
+      return await this.touchLongClick(null, x, y, duration || 1000);
     case 'cancel':
       // TODO: clarify behavior of 'cancel' action and fix this
       log.warn('Cancel action currently has no effect');


### PR DESCRIPTION
The current touch actions algorithm used in android driver is quite counter-intuitive. The `parseTouch` already precalculates absolute gesture coordinates for the given elements, however it still passes element id with absolute coordinates to the downstream helpers. As far as I can understand the element id is used as a backup value if the coordinates action fails (even in that case the backend ignores the given x and y offsets and simply uses the central element point for the action). Also, since the coordinates precalculation is done on the Appium driver side (element location+size), there are many extra server calls, which slows down gestures in general. 

I don't want to change much there because of legacy reasons. Let's just align the action executor to only pass transformed coordinates without backup element ids to not confuse the backend and make the logic a bit more straightforward.