### PR TITLE
chore: Add file deletion validation

### DIFF
--- a/lib/commands/file-actions.js
+++ b/lib/commands/file-actions.js
@@ -231,6 +231,10 @@ async function deleteFileOrFolder (adb, remotePath) {
   } else {
     await adb.shell(['rm', `-f${expectsFile ? '' : 'r'}`, dstPath]);
   }
+  if (await isPresent(dstPath, pkgId)) {
+    log.errorAndThrow(`The item at '${dstPath}' still exists after being deleted. ` +
+      `Is it writable?`);
+  }
   return true;
 }
 


### PR DESCRIPTION
This check is needed if one tries to delete a file he does not have write access to