### PR TITLE
refactor: enable ensureWebviewsHavePages by default

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -291,12 +291,12 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
 
 /**
  * @typedef {Object} GetWebviewsOpts
- * @property {string} androidDeviceSocket - device socket name
- * @property {boolean} ensureWebviewsHavePages - whether to check for webview
+ * @property {string} androidDeviceSocket [null] - device socket name
+ * @property {boolean} ensureWebviewsHavePages [true] - whether to check for webview
  * page presence
- * @property {number} webviewDevtoolsPort - port to use for webview page
- * presence check (if not the default of 9222).
- * @property {boolean} enableWebviewDetailsCollection - whether to collect
+ * @property {number} webviewDevtoolsPort [9222] - port to use for webview page
+ * presence check.
+ * @property {boolean} enableWebviewDetailsCollection [false] - whether to collect
  * web view details and send them to Chromedriver constructor, so it could
  * select a binary more precisely based on this info.
  */
@@ -320,7 +320,7 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
  */
 helpers.getWebviews = async function getWebviews (adb, {
   androidDeviceSocket = null,
-  ensureWebviewsHavePages = null,
+  ensureWebviewsHavePages = true,
   webviewDevtoolsPort = null,
   enableWebviewDetailsCollection = null,
 } = {}) {


### PR DESCRIPTION
Enabling this capability by default will allow to avoid unexpected freezes if returned webview(s) don't have any active pages. This is actually a breaking change, but we agreed it is safe to apply it, since the behaviour without this capability enabled looks more like a bug.