### PR TITLE
feat: "mobile: getContexts" on Android

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -62,9 +62,12 @@ commands.setContext = async function setContext (name) {
 };
 
 commands.mobileGetContexts = async function mobileGetContexts () {
-  const opts = _.cloneDeep(this.opts);
-  opts.ensureWebviewsHavePages = true;
-  opts.enableWebviewDetailsCollection = true;
+  const opts = {
+    androidDeviceSocket: this.opts.androidDeviceSocket,
+    ensureWebviewsHavePages: true,
+    webviewDevtoolsPort: this.opts.webviewDevtoolsPort,
+    enableWebviewDetailsCollection: true
+  };
   return await webviewHelpers.getWebViewsMapping(this.adb, opts);
 };
 

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -61,6 +61,13 @@ commands.setContext = async function setContext (name) {
   this.curContext = name;
 };
 
+commands.mobileGetContexts = async function mobileGetContexts () {
+  const opts = _.cloneDeep(this.opts);
+  opts.ensureWebviewsHavePages = true;
+  opts.enableWebviewDetailsCollection = true;
+  return await webviewHelpers.getWebViewsMapping(this.adb, opts);
+};
+
 helpers.switchContext = async function switchContext (name) {
   // We have some options when it comes to webviews. If we want a
   // Chromedriver webview, we can only control one at a time.

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -61,6 +61,52 @@ commands.setContext = async function setContext (name) {
   this.curContext = name;
 };
 
+/**
+ * @typedef {Object} WebviewsMapping
+ * @property {string} proc The name of the Devtools Unix socket
+ * @property {string} webview The web view alias. Looks like `WEBVIEW_`
+ * prefix plus PID or package name
+ * @property {?Object} info Webview information as it is retrieved by
+ * /json/version CDP endpoint
+ * @property {?Array<Object>} pages Webview pages list as it is retrieved by
+ * /json/list CDP endpoint
+ * @propery {?string} webviewName An actual webview name for switching context.
+ * This value becomes null when failing to find a PID for a webview.
+ *
+ * The following json demonstrates the example of WebviewsMapping object.
+ * Note that `description` in `page` can be an empty string most likely when it comes to Mobile Chrome)
+ * {
+ *   "proc": "@webview_devtools_remote_22138",
+ *   "webview": "WEBVIEW_22138",
+ *   "info": {
+ *     "Android-Package": "io.appium.settings",
+ *     "Browser": "Chrome/74.0.3729.185",
+ *     "Protocol-Version": "1.3",
+ *     "User-Agent": "Mozilla/5.0 (Linux; Android 10; Android SDK built for x86 Build/QSR1.190920.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.185 Mobile Safari/537.36",
+ *     "V8-Version": "7.4.288.28",
+ *     "WebKit-Version": "537.36 (@22955682f94ce09336197bfb8dffea991fa32f0d)",
+ *     "webSocketDebuggerUrl": "ws://127.0.0.1:10900/devtools/browser"
+ *   },
+ *   "pages": [
+ *     {
+ *       "description": "{\"attached\":true,\"empty\":false,\"height\":1458,\"screenX\":0,\"screenY\":336,\"visible\":true,\"width\":1080}",
+ *       "devtoolsFrontendUrl": "http://chrome-devtools-frontend.appspot.com/serve_rev/@22955682f94ce09336197bfb8dffea991fa32f0d/inspector.html?ws=127.0.0.1:10900/devtools/page/27325CC50B600D31B233F45E09487B1F",
+ *       "id": "27325CC50B600D31B233F45E09487B1F",
+ *       "title": "Releases · appium/appium · GitHub",
+ *       "type": "page",
+ *       "url": "https://github.com/appium/appium/releases",
+ *       "webSocketDebuggerUrl": "ws://127.0.0.1:10900/devtools/page/27325CC50B600D31B233F45E09487B1F"
+ *     }
+ *   ],
+ *   "webviewName": "WEBVIEW_com.io.appium.setting"
+ * }
+ */
+
+/**
+ * Returns a webviewsMapping based on CDP endpoints
+ *
+ * @return {Array<WebviewsMapping>} webviewsMapping
+ */
 commands.mobileGetContexts = async function mobileGetContexts () {
   const opts = {
     androidDeviceSocket: this.opts.androidDeviceSocket,

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -51,6 +51,8 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     startService: 'mobileStartService',
     stopService: 'mobileStopService',
+
+    getContexts: 'mobileGetContexts',
   };
 
   if (!_.has(mobileCommandsMapping, mobileCommand)) {

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -290,31 +290,10 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
 };
 
 /**
- * @typedef {Object} GetWebviewsOpts
- * @property {string} androidDeviceSocket [null] - device socket name
- * @property {boolean} ensureWebviewsHavePages [true] - whether to check for webview
- * page presence
- * @property {number} webviewDevtoolsPort [9222] - port to use for webview page
- * presence check.
- * @property {boolean} enableWebviewDetailsCollection [false] - whether to collect
- * web view details and send them to Chromedriver constructor, so it could
- * select a binary more precisely based on this info.
- */
-/**
- * Get a list of available webviews by introspecting processes with adb, where
- * webviews are listed. It's possible to pass in a 'deviceSocket' arg, which
- * limits the webview possibilities to the one running on the Chromium devtools
- * socket we're interested in (see note on webviewsFromProcs). We can also
- * direct this method to verify whether a particular webview process actually
- * has any pages (if a process exists but no pages are found, Chromedriver will
- * not actually be able to connect to it, so this serves as a guard for that
- * strange failure mode). The strategy for checking whether any pages are
- * active involves sending a request to the remote debug server on the device,
- * hence it is also possible to specify the port on the host machine which
- * should be used for this communication.
+ * Retrieves webview names for getContexts
  *
  * @param {object} adb - an ADB instance
- * @param {GetWebviewOpts} opts
+ * @param {GetWebviewOpts} opts See note on getWebViewsMapping
  *
  * @return {Array.<string>} - a list of webview names
  */
@@ -336,12 +315,43 @@ helpers.getWebviews = async function getWebviews (adb, {
 };
 
 /**
- * Retrieves web views mapping for getContexts
+ * @typedef {Object} GetWebviewsOpts
+ * @property {string} androidDeviceSocket [null] - device socket name
+ * @property {boolean} ensureWebviewsHavePages [true] - whether to check for webview
+ * page presence
+ * @property {number} webviewDevtoolsPort [9222] - port to use for webview page
+ * presence check.
+ * @property {boolean} enableWebviewDetailsCollection [false] - whether to collect
+ * web view details and send them to Chromedriver constructor, so it could
+ * select a binary more precisely based on this info.
+ */
+
+/**
+ * @typedef {Object} WebviewMappings
+ * @property {string} proc See note on WebviewProps
+ * @property {string} webview See note on WebviewProps
+ * @property {?Object} info See note on WebviewProps
+ * @property {?Array<Object>} pages See note on WebviewProps
+ * @propery {string} webviewName An actual webview name for switching context
+ */
+
+/**
+ * Get a list of available webviews mapping by introspecting processes with adb,
+ * where webviews are listed. It's possible to pass in a 'deviceSocket' arg, which
+ * limits the webview possibilities to the one running on the Chromium devtools
+ * socket we're interested in (see note on webviewsFromProcs). We can also
+ * direct this method to verify whether a particular webview process actually
+ * has any pages (if a process exists but no pages are found, Chromedriver will
+ * not actually be able to connect to it, so this serves as a guard for that
+ * strange failure mode). The strategy for checking whether any pages are
+ * active involves sending a request to the remote debug server on the device,
+ * hence it is also possible to specify the port on the host machine which
+ * should be used for this communication.
  *
  * @param {object} adb - an ADB instance
- * @param {GetWebviewOpts} opts (see note on getWebviews).
+ * @param {GetWebviewOpts} opts
  *
- * @return {Array<WebviewProps>} webviewsMapping(see note no collectWebviewsDetails).
+ * @return {Array<WebviewMappings>} webviewsMapping
  */
 helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
   androidDeviceSocket = null,

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -330,40 +330,7 @@ helpers.getWebviews = async function getWebviews (adb, {
     webviewDevtoolsPort,
     enableWebviewDetailsCollection
   });
-
-  // webviewProcs contains procs, which we only care about for ensuring
-  // presence of pages above, so we can now discard them and rely on just the
-  // webview names
-  const result = [];
-  for (const {webview, pages, info, proc} of webviewsMapping) {
-    if (ensureWebviewsHavePages && pages?.length === 0) {
-      logger.info(`Skipping the webview '${webview}' at '${proc}' ` +
-        `since it has reported having zero pages`);
-      continue;
-    }
-
-    let wvName = webview;
-    if (!androidDeviceSocket) {
-      const pkgMatch = WEBVIEW_PKG_PATTERN.exec(webview);
-      try {
-        // web view name could either be suffixed with PID or the package name
-        // package names could not start with a digit
-        const pkg = pkgMatch ? pkgMatch[1] : await helpers.procFromWebview(adb, webview);
-        wvName = `${WEBVIEW_BASE}${pkg}`;
-      } catch (e) {
-        logger.warn(e.message);
-        continue;
-      }
-    }
-
-    result.push(wvName);
-    const key = toDetailsCacheKey(adb, wvName);
-    if (info) {
-      WEBVIEWS_DETAILS_CACHE.set(key, { info });
-    } else if (WEBVIEWS_DETAILS_CACHE.has(key)) {
-      WEBVIEWS_DETAILS_CACHE.del(key);
-    }
-  }
+  const result = webviewsMapping.filter(function (w) {return w.webviewName;}).map(function (w) {return w.webviewName;});
   logger.debug(`Found ${util.pluralize('webview', result.length, true)}: ${JSON.stringify(result)}`);
   return result;
 };
@@ -390,6 +357,41 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
     enableWebviewDetailsCollection,
     webviewDevtoolsPort,
   });
+
+  // webviewProcs contains procs, which we only care about for ensuring
+  // presence of pages above, so we can now discard them and rely on just the
+  // webview names
+  for (const webviewMapping of webviewsMapping) {
+    const {webview, pages, info, proc} = webviewMapping;
+    if (ensureWebviewsHavePages && pages?.length === 0) {
+      logger.info(`Skipping the webview '${webview}' at '${proc}' ` +
+          `since it has reported having zero pages`);
+      continue;
+    }
+
+    let wvName = webview;
+    if (!androidDeviceSocket) {
+      const pkgMatch = WEBVIEW_PKG_PATTERN.exec(webview);
+      try {
+        // web view name could either be suffixed with PID or the package name
+        // package names could not start with a digit
+        const pkg = pkgMatch ? pkgMatch[1] : await helpers.procFromWebview(adb, webview);
+        wvName = `${WEBVIEW_BASE}${pkg}`;
+      } catch (e) {
+        logger.warn(e.message);
+        continue;
+      }
+    }
+
+    webviewMapping.webviewName = wvName;
+
+    const key = toDetailsCacheKey(adb, wvName);
+    if (info) {
+      WEBVIEWS_DETAILS_CACHE.set(key, {info});
+    } else if (WEBVIEWS_DETAILS_CACHE.has(key)) {
+      WEBVIEWS_DETAILS_CACHE.del(key);
+    }
+  }
   return webviewsMapping;
 };
 

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -337,7 +337,7 @@ helpers.getWebviews = async function getWebviews (adb, {
  */
 
 /**
- * @typedef {Object} WebviewMappings
+ * @typedef {Object} WebviewsMapping
  * @property {string} proc See note on WebviewProps
  * @property {string} webview See note on WebviewProps
  * @property {?Object} info See note on WebviewProps
@@ -361,7 +361,7 @@ helpers.getWebviews = async function getWebviews (adb, {
  * @param {object} adb - an ADB instance
  * @param {GetWebviewOpts} opts
  *
- * @return {Array<WebviewMappings>} webviewsMapping
+ * @return {Array<WebviewsMapping>} webviewsMapping
  */
 helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
   androidDeviceSocket = null,

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -324,13 +324,11 @@ helpers.getWebviews = async function getWebviews (adb, {
   webviewDevtoolsPort = null,
   enableWebviewDetailsCollection = null,
 } = {}) {
-  logger.debug('Getting a list of available webviews');
-  const webviewsMapping = await webviewsFromProcs(adb, androidDeviceSocket);
-
-  await collectWebviewsDetails(adb, webviewsMapping, {
+  const webviewsMapping = await this.getWebViewsMapping(adb, {
+    androidDeviceSocket,
     ensureWebviewsHavePages,
-    enableWebviewDetailsCollection,
     webviewDevtoolsPort,
+    enableWebviewDetailsCollection
   });
 
   // webviewProcs contains procs, which we only care about for ensuring
@@ -368,6 +366,31 @@ helpers.getWebviews = async function getWebviews (adb, {
   }
   logger.debug(`Found ${util.pluralize('webview', result.length, true)}: ${JSON.stringify(result)}`);
   return result;
+};
+
+/**
+ * Retrieves web views mapping for getContexts
+ *
+ * @param {object} adb - an ADB instance
+ * @param {GetWebviewOpts} opts (see note on getWebviews).
+ *
+ * @return {Array<WebviewProps>} webviewsMapping(see note no collectWebviewsDetails).
+ */
+helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
+  androidDeviceSocket = null,
+  ensureWebviewsHavePages = true,
+  webviewDevtoolsPort = null,
+  enableWebviewDetailsCollection = null,
+} = {}) {
+  logger.debug('Getting a list of available webviews');
+  const webviewsMapping = await webviewsFromProcs(adb, androidDeviceSocket);
+
+  await collectWebviewsDetails(adb, webviewsMapping, {
+    ensureWebviewsHavePages,
+    enableWebviewDetailsCollection,
+    webviewDevtoolsPort,
+  });
+  return webviewsMapping;
 };
 
 /**

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -375,7 +375,7 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
     const {webview, pages, info, proc} = webviewMapping;
     if (ensureWebviewsHavePages && pages?.length === 0) {
       logger.info(`Skipping the webview '${webview}' at '${proc}' ` +
-          `since it has reported having zero pages`);
+        `since it has reported having zero pages`);
       continue;
     }
 
@@ -394,10 +394,9 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
     }
 
     webviewMapping.webviewName = wvName;
-
     const key = toDetailsCacheKey(adb, wvName);
     if (info) {
-      WEBVIEWS_DETAILS_CACHE.set(key, {info});
+      WEBVIEWS_DETAILS_CACHE.set(key, { info });
     } else if (WEBVIEWS_DETAILS_CACHE.has(key)) {
       WEBVIEWS_DETAILS_CACHE.del(key);
     }

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -309,7 +309,17 @@ helpers.getWebviews = async function getWebviews (adb, {
     webviewDevtoolsPort,
     enableWebviewDetailsCollection
   });
-  const result = webviewsMapping.filter(function (w) {return w.webviewName;}).map(function (w) {return w.webviewName;});
+  const result = [];
+  for (const {webview, pages, proc, webviewName} of webviewsMapping) {
+    if (ensureWebviewsHavePages && pages?.length === 0) {
+      logger.info(`Skipping the webview '${webview}' at '${proc}' ` +
+        `since it has reported having zero pages`);
+      continue;
+    }
+    if (webviewName) {
+      result.push(webviewName);
+    }
+  }
   logger.debug(`Found ${util.pluralize('webview', result.length, true)}: ${JSON.stringify(result)}`);
   return result;
 };
@@ -332,7 +342,7 @@ helpers.getWebviews = async function getWebviews (adb, {
  * @property {string} webview See note on WebviewProps
  * @property {?Object} info See note on WebviewProps
  * @property {?Array<Object>} pages See note on WebviewProps
- * @propery {string} webviewName An actual webview name for switching context
+ * @propery {?string} webviewName An actual webview name for switching context
  */
 
 /**
@@ -372,12 +382,8 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
   // presence of pages above, so we can now discard them and rely on just the
   // webview names
   for (const webviewMapping of webviewsMapping) {
-    const {webview, pages, info, proc} = webviewMapping;
-    if (ensureWebviewsHavePages && pages?.length === 0) {
-      logger.info(`Skipping the webview '${webview}' at '${proc}' ` +
-        `since it has reported having zero pages`);
-      continue;
-    }
+    const {webview, info} = webviewMapping;
+    webviewMapping.webviewName = null;
 
     let wvName = webview;
     if (!androidDeviceSocket) {

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -378,9 +378,6 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
     webviewDevtoolsPort,
   });
 
-  // webviewProcs contains procs, which we only care about for ensuring
-  // presence of pages above, so we can now discard them and rely on just the
-  // webview names
   for (const webviewMapping of webviewsMapping) {
     const {webview, info} = webviewMapping;
     webviewMapping.webviewName = null;


### PR DESCRIPTION
This PR adds an endpoint named `mobile: getContexts` by reusing a logic for `ensureWebviewsHavePages`

Related to https://github.com/appium/appium/issues/14745