### PR TITLE
feat: relax webview pid check with devtools port

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -391,13 +391,9 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
         const pkg = pkgMatch ? pkgMatch[1] : await helpers.procFromWebview(adb, webview);
         wvName = `${WEBVIEW_BASE}${pkg}`;
       } catch (e) {
-        if (webviewDevtoolsPort) {
-          // WebView by chrome could be this case
-          wvName = webview;
-        } else {
-          logger.warn(e.message);
-          continue;
-        }
+        logger.warn(e.message);
+        logger.info(`'${webview}' could be WebView found by Chrome DevTools`);
+        wvName = webview;
       }
     }
 

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -391,8 +391,13 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
         const pkg = pkgMatch ? pkgMatch[1] : await helpers.procFromWebview(adb, webview);
         wvName = `${WEBVIEW_BASE}${pkg}`;
       } catch (e) {
-        logger.warn(e.message);
-        continue;
+        if (webviewDevtoolsPort) {
+          // WebView by chrome could be this case
+          wvName = webview;
+        } else {
+          logger.warn(e.message);
+          continue;
+        }
       }
     }
 


### PR DESCRIPTION
Related issue: https://github.com/appium/appium-desktop/issues/1618

According to the issue, WebView has a case the response by CDP (in the app under test) has webview(s) but the process id is not the app under test's one.

This PR tries to relax the process check.