### PR TITLE
fix: did not wait long enough for the app to come back after background

### DIFF
--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
 import androidHelpers from '../android-helpers';
 import { util } from 'appium-support';
-import B from 'bluebird';
 import log from '../logger';
 import moment from 'moment';
-import { waitForCondition } from 'asyncbox';
+import { waitForCondition, longSleep } from 'asyncbox';
 
 const MOMENT_FORMAT_ISO8601 = 'YYYY-MM-DDTHH:mm:ssZ';
 
@@ -136,7 +135,19 @@ commands.background = async function background (seconds) {
   }
   let {appPackage, appActivity} = await this.adb.getFocusedPackageAndActivity();
   await this.adb.goToHome();
-  await B.delay(seconds * 1000);
+
+  // people can wait for a long time, so to be safe let's use the longSleep function and log
+  // progress periodically.
+  const sleepMs = seconds * 1000;
+  const thresholdMs = 30 * 1000; // use the spin-wait for anything over this threshold
+  // for our spin interval, use 1% of the total wait time, but nothing bigger than 30s
+  const intervalMs = _.min([30 * 1000, parseInt(sleepMs / 100, 10)]);
+  const progressCb = ({elapsedMs, progress}) => {
+    const waitSecs = (elapsedMs / 1000).toFixed(0);
+    const progressPct = (progress * 100).toFixed(2);
+    log.debug(`Waited ${waitSecs}s so far (${progressPct}%)`);
+  };
+  await longSleep(sleepMs, {thresholdMs, intervalMs, progressCb});
 
   let args;
   if (this._cachedActivityArgs && this._cachedActivityArgs[`${appPackage}/${appActivity}`]) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "appium-chromedriver": "^4.13.0",
     "appium-support": "^2.47.1",
     "async-lock": "^1.2.2",
-    "asyncbox": "^2.0.4",
+    "asyncbox": "^2.8.0",
     "axios": "^0.20.0",
     "bluebird": "^3.4.7",
     "io.appium.settings": "^3.1.0",


### PR DESCRIPTION
turns out a simple `await B.delay` can be off by a factor of minutes for long values. This looping strategy checks in with the actual system clock to make sure we wait long enough.