### PR TITLE
fix: not to set androidPackage as null for chromedriver

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -405,11 +405,12 @@ helpers.getWebviewDetails = function getWebviewDetails (adb, webview) {
  * See https://chromedriver.chromium.org/capabilities for more details.
  */
 helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId) {
-  const caps = {
-    chromeOptions: {
-      androidPackage: opts.chromeOptions?.androidPackage || opts.appPackage,
-    }
-  };
+  const caps = { chromeOptions: {} };
+
+  const androidPackage = opts.chromeOptions?.androidPackage || opts.appPackage;
+  if (androidPackage) {
+    caps.chromeOptions.androidPackage = androidPackage;
+  }
   if (_.isBoolean(opts.chromeUseRunningApp)) {
     caps.chromeOptions.androidUseRunningApp = opts.chromeUseRunningApp;
   }

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -409,6 +409,7 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
 
   const androidPackage = opts.chromeOptions?.androidPackage || opts.appPackage;
   if (androidPackage) {
+    // chromedriver raises an invalid argument error when androidPackage is 'null'
     caps.chromeOptions.androidPackage = androidPackage;
   }
   if (_.isBoolean(opts.chromeUseRunningApp)) {


### PR DESCRIPTION
I found a case in which `androidPackage` was `null` when `noReset` was `true` case.
Newer (Not sure which version..) chromedriver and Android OS version can ignore it, but older one (at least  4.x) raised an error invalid argument by chromedriver.
Without this `androidPackage`, the request worked.