### PR TITLE
chore: Increased io.appium.settings to version ^3.3.0 for compatibility reasons 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^8.8.0",
+    "appium-adb": "^8.11.0",
     "appium-base-driver": "^7.0.0",
     "appium-chromedriver": "^4.13.0",
     "appium-support": "^2.47.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "asyncbox": "^2.8.0",
     "axios": "^0.x",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^3.1.0",
+    "io.appium.settings": "^3.3.0",
     "jimp": "^0.16.1",
     "lodash": "^4.17.4",
     "lru-cache": "^6.0.0",


### PR DESCRIPTION
This is needed because appium-android-driver would require a newer version of io.appium.settings to have full functionality on proper location mocking. 

This is related to:
- **python-client** pull request: appium/python-client#594
- **io.appium.settings** pull request appium/io.appium.settings#70
- **appium-adb** pull request https://github.com/appium/appium-adb/pull/563