### PR TITLE
refactor: Move swipe helper methods to android-driver

### DIFF
--- a/lib/commands/touch.js
+++ b/lib/commands/touch.js
@@ -4,8 +4,31 @@ import androidHelpers from '../android-helpers';
 import B from 'bluebird';
 import { errors, isErrorType } from 'appium-base-driver';
 import { asyncmap } from 'asyncbox';
+import { util } from 'appium-support';
 
 let commands = {}, helpers = {}, extensions = {};
+
+function getCoordDefault (val) {
+  // going the long way and checking for undefined and null since
+  // we can't be assured `elId` is a string and not an int. Same
+  // thing with destElement below.
+  return util.hasValue(val) ? val : 0.5;
+}
+
+function getSwipeTouchDuration (waitGesture) {
+  // the touch action api uses ms, we want seconds
+  // 0.8 is the default time for the operation
+  let duration = 0.8;
+  if (typeof waitGesture.options.ms !== 'undefined' && waitGesture.options.ms) {
+    duration = waitGesture.options.ms / 1000;
+    if (duration === 0) {
+      // set to a very low number, since they wanted it fast
+      // but below 0.1 becomes 0 steps, which causes errors
+      duration = 0.1;
+    }
+  }
+  return duration;
+}
 
 commands.doTouchAction = async function doTouchAction (action, opts = {}) {
   const { element, x, y, count, ms, duration } = opts;
@@ -32,7 +55,6 @@ commands.doTouchAction = async function doTouchAction (action, opts = {}) {
       log.errorAndThrow(`unknown action ${action}`);
   }
 };
-
 
 // drag is *not* press-move-release, so we need to translate
 // drag works fine for scroll, as well
@@ -129,6 +151,34 @@ helpers.performGesture = async function performGesture (gesture) {
     }
     throw e;
   }
+};
+
+commands.getSwipeOptions = async function getSwipeOptions (gestures, touchCount = 1) {
+  let startX = getCoordDefault(gestures[0].options.x),
+      startY = getCoordDefault(gestures[0].options.y),
+      endX = getCoordDefault(gestures[2].options.x),
+      endY = getCoordDefault(gestures[2].options.y),
+      duration = getSwipeTouchDuration(gestures[1]),
+      element = gestures[0].options.element,
+      destElement = gestures[2].options.element || gestures[0].options.element;
+
+  // there's no destination element handling in bootstrap and since it applies to all platforms, we handle it here
+  if (util.hasValue(destElement)) {
+    let locResult = await this.getLocationInView(destElement);
+    let sizeResult = await this.getSize(destElement);
+    let offsetX = (Math.abs(endX) < 1 && Math.abs(endX) > 0) ? sizeResult.width * endX : endX;
+    let offsetY = (Math.abs(endY) < 1 && Math.abs(endY) > 0) ? sizeResult.height * endY : endY;
+    endX = locResult.x + offsetX;
+    endY = locResult.y + offsetY;
+    // if the target element was provided, the coordinates for the destination need to be relative to it.
+    if (util.hasValue(element)) {
+      let firstElLocation = await this.getLocationInView(element);
+      endX -= firstElLocation.x;
+      endY -= firstElLocation.y;
+    }
+  }
+  // clients are responsible to use these options correctly
+  return {startX, startY, endX, endY, duration, touchCount, element};
 };
 
 commands.performTouch = async function performTouch (gestures) {


### PR DESCRIPTION
This is a shame we have all these methods in base driver while they are only needed in android driver. The next step would be to remove them from base driver for good