### PR TITLE
feat: add pinWithKeyEvent to put keys one by one for pin as key evnets

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -8,7 +8,7 @@ import Bootstrap from './bootstrap';
 import B from 'bluebird';
 import ADB from 'appium-adb';
 import {
-  default as unlocker, PIN_UNLOCK, PASSWORD_UNLOCK,
+  default as unlocker, PIN_UNLOCK, PIN_UNLOCK_KEY_EVENT, PASSWORD_UNLOCK,
   PATTERN_UNLOCK, FINGERPRINT_UNLOCK
 } from './unlock-helpers';
 import { EOL } from 'os';
@@ -638,6 +638,7 @@ helpers.unlockWithUIAutomation = async function unlockWithUIAutomation (driver, 
   }
   const unlockMethod = {
     [PIN_UNLOCK]: unlocker.pinUnlock,
+    [PIN_UNLOCK_KEY_EVENT]: unlocker.pinUnlockWithKeyEvent,
     [PASSWORD_UNLOCK]: unlocker.passwordUnlock,
     [PATTERN_UNLOCK]: unlocker.patternUnlock,
     [FINGERPRINT_UNLOCK]: unlocker.fingerprintUnlock

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -4,27 +4,41 @@ import _ from 'lodash';
 import { util } from 'appium-support';
 
 const PIN_UNLOCK = 'pin';
+const PIN_UNLOCK_KEY_EVENT = 'pinWithKeyEvent';
 const PASSWORD_UNLOCK = 'password';
 const PATTERN_UNLOCK = 'pattern';
 const FINGERPRINT_UNLOCK = 'fingerprint';
-const UNLOCK_TYPES = [PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK];
+const UNLOCK_TYPES = [PIN_UNLOCK, PIN_UNLOCK_KEY_EVENT, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK];
 const KEYCODE_NUMPAD_ENTER = 66;
 const KEYCODE_POWER = 26;
 const KEYCODE_WAKEUP = 224; // Can work over API Level 20
 const UNLOCK_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
 const INPUT_KEYS_WAIT_TIME = 100;
+// mapping of Android keycode and numbers
+const KEY_CODE_NUMBER = {
+  '0': 7,
+  '1': 8,
+  '2': 9,
+  '3': 10,
+  '4': 11,
+  '5': 12,
+  '6': 13,
+  '7': 14,
+  '8': 15,
+  '9': 16,
+};
 
 let helpers = {};
 helpers.isValidUnlockType = function isValidUnlockType (type) {
-  return UNLOCK_TYPES.indexOf(type) !== -1;
+  return UNLOCK_TYPES.includes(type);
 };
 
 helpers.isValidKey = function isValidKey (type, key) {
   if (_.isUndefined(key)) {
     return false;
   }
-  if (type === PIN_UNLOCK || type === FINGERPRINT_UNLOCK) {
+  if ([PIN_UNLOCK, PIN_UNLOCK_KEY_EVENT, FINGERPRINT_UNLOCK].includes(type)) {
     return /^[0-9]+$/.test(key.trim());
   }
   if (type === PATTERN_UNLOCK) {
@@ -131,6 +145,26 @@ helpers.pinUnlock = async function pinUnlock (adb, driver, capabilities) {
   }
 };
 
+helpers.pinUnlockWithKeyEvent = async function pinUnlockWithKeyEvent (adb, driver, capabilities) {
+  logger.info(`Trying to unlock device using pin with keycode ${capabilities.unlockKey}`);
+  await helpers.dismissKeyguard(driver, adb);
+  const keys = helpers.stringKeyToArr(capabilities.unlockKey);
+
+  // Some device does not have system key ids like 'com.android.keyguard:id/key'
+  // Then, sending keyevents are more reliable to unlock the screen.
+  for (const pin of keys) {
+    await adb.shell(['input', 'keyevent', KEY_CODE_NUMBER[pin]]);
+  }
+
+  // Some devices accept entering the code without pressing the Enter key
+  // When I rushed commands without this wait before pressKeyCode, rarely UI2 sever crashed
+  await sleep(UNLOCK_WAIT_TIME);
+  if (await adb.isScreenLocked()) {
+    await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);
+    await sleep(UNLOCK_WAIT_TIME);
+  }
+};
+
 helpers.passwordUnlock = async function passwordUnlock (adb, driver, capabilities) {
   logger.info(`Trying to unlock device using password ${capabilities.unlockKey}`);
   await helpers.dismissKeyguard(driver, adb);
@@ -144,6 +178,10 @@ helpers.passwordUnlock = async function passwordUnlock (adb, driver, capabilitie
   await adb.shell(['input', 'keyevent', KEYCODE_NUMPAD_ENTER]);
   // Waits a bit for the device to be unlocked
   await sleep(UNLOCK_WAIT_TIME);
+  if (await adb.isScreenLocked()) {
+    await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);
+    await sleep(UNLOCK_WAIT_TIME);
+  }
 };
 
 helpers.getPatternKeyPosition = function getPatternKeyPosition (key, initPos, piece) {
@@ -231,9 +269,10 @@ helpers.patternUnlock = async function patternUnlock (adb, driver, capabilities)
 };
 
 helpers.PIN_UNLOCK = PIN_UNLOCK;
+helpers.PIN_UNLOCK_KEY_EVENT = PIN_UNLOCK_KEY_EVENT;
 helpers.PASSWORD_UNLOCK = PASSWORD_UNLOCK;
 helpers.PATTERN_UNLOCK = PATTERN_UNLOCK;
 helpers.FINGERPRINT_UNLOCK = FINGERPRINT_UNLOCK;
 
-export { PIN_UNLOCK, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK, helpers };
+export { PIN_UNLOCK, PIN_UNLOCK_KEY_EVENT, PASSWORD_UNLOCK, PATTERN_UNLOCK, FINGERPRINT_UNLOCK, helpers };
 export default helpers;

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -116,7 +116,8 @@ helpers.pinUnlock = async function pinUnlock (adb, driver, capabilities) {
   if (await adb.getApiLevel() >= 21) {
     let els = await driver.findElOrEls('id', 'com.android.systemui:id/digit_text', true);
     if (_.isEmpty(els)) {
-      throw new Error('Error finding unlock pin buttons!');
+      // fallback to pin with key event
+      return await helpers.pinUnlockWithKeyEvent(adb, driver, capabilities);
     }
     let pins = {};
     for (let el of els) {
@@ -131,7 +132,8 @@ helpers.pinUnlock = async function pinUnlock (adb, driver, capabilities) {
     for (let pin of keys) {
       let el = await driver.findElOrEls('id', `com.android.keyguard:id/key${pin}`, false);
       if (el === null) {
-        throw new Error(`Error finding unlock pin '${pin}' button!`);
+        // fallback to pin with key event
+        return await helpers.pinUnlockWithKeyEvent(adb, driver, capabilities);
       }
       await driver.click(util.unwrapElement(el));
     }

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -134,8 +134,9 @@ helpers.pinUnlock = async function pinUnlock (adb, driver, capabilities) {
  * Wait for the display to be unlocked.
  * Some devices automatically accept typed 'pin' and 'password' code
  * without pressing the Enter key. But some devices need it.
- * This method wait a few seconds first for such automatic acceptance case.
- * If the device is still locked, then this method will try to type the enter.
+ * This method waits a few seconds first for such automatic acceptance case.
+ * If the device is still locked, then this method will try to send
+ * the enter key code.
  *
  * @param {ADB} adb The instance of ADB
  * @param {AndroidDriver} driver The instance of AndroidDriver

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -15,6 +15,7 @@ const KEYCODE_WAKEUP = 224; // Can work over API Level 20
 const UNLOCK_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
 const INPUT_KEYS_WAIT_TIME = 100;
+const NUMBER_ZERO_KEYCODE = 7;
 
 let helpers = {};
 helpers.isValidUnlockType = function isValidUnlockType (type) {
@@ -142,9 +143,9 @@ helpers.pinUnlockWithKeyEvent = async function pinUnlockWithKeyEvent (adb, drive
   // Some device does not have system key ids like 'com.android.keyguard:id/key'
   // Then, sending keyevents are more reliable to unlock the screen.
   for (const pin of keys) {
-    // 'pin' is number in string.
-    // Number '0' is keycode 7. number '9' is keycode '16'.
-    await adb.shell(['input', 'keyevent', parseInt(pin, 10) + 7]);
+    // 'pin' is number (0-9) in string.
+    // Number '0' is keycode '7'. number '9' is keycode '16'.
+    await adb.shell(['input', 'keyevent', parseInt(pin, 10) + NUMBER_ZERO_KEYCODE]);
   }
 
   // Some devices accept entering the code without pressing the Enter key

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -16,7 +16,7 @@ const UNLOCK_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
 const INPUT_KEYS_WAIT_TIME = 100;
 // mapping of Android keycode and numbers
-const KEY_CODE_NUMBER = {
+const ANDROID_KEY_CODE_NUMBER = {
   '0': 7,
   '1': 8,
   '2': 9,
@@ -153,7 +153,7 @@ helpers.pinUnlockWithKeyEvent = async function pinUnlockWithKeyEvent (adb, drive
   // Some device does not have system key ids like 'com.android.keyguard:id/key'
   // Then, sending keyevents are more reliable to unlock the screen.
   for (const pin of keys) {
-    await adb.shell(['input', 'keyevent', KEY_CODE_NUMBER[pin]]);
+    await adb.shell(['input', 'keyevent', ANDROID_KEY_CODE_NUMBER[pin]]);
   }
 
   // Some devices accept entering the code without pressing the Enter key

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -126,14 +126,29 @@ helpers.pinUnlock = async function pinUnlock (adb, driver, capabilities) {
       await driver.click(util.unwrapElement(el));
     }
   }
-  // Some devices accept entering the code without pressing the Enter key
-  // When I rushed commands without this wait before pressKeyCode, rarely UI2 sever crashed
-  await sleep(UNLOCK_WAIT_TIME);
-  if (await adb.isScreenLocked()) {
-    await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);
-    await sleep(UNLOCK_WAIT_TIME);
-  }
+  await waitForUnlock(adb, driver);
 };
+
+
+/**
+ * Wait for the display to be unlocked.
+ * Some devices automatically accept typed 'pin' and 'password' code
+ * without pressing the Enter key. But some devices need it.
+ * This method wait a few seconds first for such automatic acceptance case.
+ * If the device is still locked, then this method will try to type the enter.
+ *
+ * @param {ADB} adb The instance of ADB
+ * @param {AndroidDriver} driver The instance of AndroidDriver
+ */
+async function waitForUnlock (adb, driver) {
+  await sleep(UNLOCK_WAIT_TIME);
+  if (!await adb.isScreenLocked()) {
+    return;
+  }
+
+  await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);
+  await sleep(UNLOCK_WAIT_TIME);
+}
 
 helpers.pinUnlockWithKeyEvent = async function pinUnlockWithKeyEvent (adb, driver, capabilities) {
   logger.info(`Trying to unlock device using pin with keycode ${capabilities.unlockKey}`);
@@ -147,14 +162,7 @@ helpers.pinUnlockWithKeyEvent = async function pinUnlockWithKeyEvent (adb, drive
     // Number '0' is keycode '7'. number '9' is keycode '16'.
     await adb.shell(['input', 'keyevent', parseInt(pin, 10) + NUMBER_ZERO_KEYCODE]);
   }
-
-  // Some devices accept entering the code without pressing the Enter key
-  // When I rushed commands without this wait before pressKeyCode, rarely UI2 sever crashed
-  await sleep(UNLOCK_WAIT_TIME);
-  if (await adb.isScreenLocked()) {
-    await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);
-    await sleep(UNLOCK_WAIT_TIME);
-  }
+  await waitForUnlock(adb, driver);
 };
 
 helpers.passwordUnlock = async function passwordUnlock (adb, driver, capabilities) {
@@ -169,11 +177,7 @@ helpers.passwordUnlock = async function passwordUnlock (adb, driver, capabilitie
   await sleep(INPUT_KEYS_WAIT_TIME);
   await adb.shell(['input', 'keyevent', KEYCODE_NUMPAD_ENTER]);
   // Waits a bit for the device to be unlocked
-  await sleep(UNLOCK_WAIT_TIME);
-  if (await adb.isScreenLocked()) {
-    await driver.pressKeyCode(KEYCODE_NUMPAD_ENTER);
-    await sleep(UNLOCK_WAIT_TIME);
-  }
+  await waitForUnlock(adb, driver);
 };
 
 helpers.getPatternKeyPosition = function getPatternKeyPosition (key, initPos, piece) {

--- a/lib/unlock-helpers.js
+++ b/lib/unlock-helpers.js
@@ -15,19 +15,6 @@ const KEYCODE_WAKEUP = 224; // Can work over API Level 20
 const UNLOCK_WAIT_TIME = 100;
 const HIDE_KEYBOARD_WAIT_TIME = 100;
 const INPUT_KEYS_WAIT_TIME = 100;
-// mapping of Android keycode and numbers
-const ANDROID_KEY_CODE_NUMBER = {
-  '0': 7,
-  '1': 8,
-  '2': 9,
-  '3': 10,
-  '4': 11,
-  '5': 12,
-  '6': 13,
-  '7': 14,
-  '8': 15,
-  '9': 16,
-};
 
 let helpers = {};
 helpers.isValidUnlockType = function isValidUnlockType (type) {
@@ -155,7 +142,9 @@ helpers.pinUnlockWithKeyEvent = async function pinUnlockWithKeyEvent (adb, drive
   // Some device does not have system key ids like 'com.android.keyguard:id/key'
   // Then, sending keyevents are more reliable to unlock the screen.
   for (const pin of keys) {
-    await adb.shell(['input', 'keyevent', ANDROID_KEY_CODE_NUMBER[pin]]);
+    // 'pin' is number in string.
+    // Number '0' is keycode 7. number '9' is keycode '16'.
+    await adb.shell(['input', 'keyevent', parseInt(pin, 10) + 7]);
   }
 
   // Some devices accept entering the code without pressing the Enter key

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -676,6 +676,7 @@ describe('Android Helpers', function () {
       await helpers.unlock(helpers, adb, {unlockType: 'pin', unlockKey: '1111'});
       mocks.adb.verify();
       mocks.helpers.verify();
+      mocks.unlocker.verify();
     });
     it('should call pinUnlock if unlockType is pinWithKeyEvent', async function () {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
@@ -684,6 +685,7 @@ describe('Android Helpers', function () {
       await helpers.unlock(helpers, adb, {unlockType: 'pinWithKeyEvent', unlockKey: '1111'});
       mocks.adb.verify();
       mocks.helpers.verify();
+      mocks.unlocker.verify();
     });
     it('should call passwordUnlock if unlockType is password', async function () {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
@@ -692,6 +694,7 @@ describe('Android Helpers', function () {
       await helpers.unlock(helpers, adb, {unlockType: 'password', unlockKey: 'appium'});
       mocks.adb.verify();
       mocks.helpers.verify();
+      mocks.unlocker.verify();
     });
     it('should call patternUnlock if unlockType is pattern', async function () {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -677,6 +677,14 @@ describe('Android Helpers', function () {
       mocks.adb.verify();
       mocks.helpers.verify();
     });
+    it('should call pinUnlock if unlockType is pinWithKeyEvent', async function () {
+      mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
+      mocks.adb.expects('isScreenLocked').returns(false);
+      mocks.unlocker.expects('pinUnlockWithKeyEvent').once();
+      await helpers.unlock(helpers, adb, {unlockType: 'pinWithKeyEvent', unlockKey: '1111'});
+      mocks.adb.verify();
+      mocks.helpers.verify();
+    });
     it('should call passwordUnlock if unlockType is password', async function () {
       mocks.adb.expects('isScreenLocked').onCall(0).returns(true);
       mocks.adb.expects('isScreenLocked').returns(false);

--- a/test/unit/unlock-helper-specs.js
+++ b/test/unit/unlock-helper-specs.js
@@ -228,8 +228,8 @@ describe('Unlock Helpers', function () {
       mocks.helpers.expects('stringKeyToArr').once();
       mocks.adb.expects('getApiLevel').returns(21);
       mocks.driver.expects('findElOrEls').returns(null);
-      await helpers.pinUnlock(adb, driver, caps).should.eventually.be
-        .rejectedWith('Error finding unlock pin buttons!');
+      mocks.helpers.expects('pinUnlockWithKeyEvent').once();
+      await helpers.pinUnlock(adb, driver, caps);
       mocks.helpers.verify();
       mocks.driver.verify();
       mocks.adb.verify();
@@ -241,8 +241,8 @@ describe('Unlock Helpers', function () {
       mocks.driver.expects('findElOrEls')
         .withExactArgs('id', 'com.android.keyguard:id/key1', false)
         .returns(null);
-      await helpers.pinUnlock(adb, driver, caps).should.eventually.be
-        .rejectedWith(`Error finding unlock pin '1' button!`);
+      mocks.helpers.expects('pinUnlockWithKeyEvent').once();
+      await helpers.pinUnlock(adb, driver, caps);
       mocks.helpers.verify();
       mocks.driver.verify();
       mocks.adb.verify();

--- a/test/unit/unlock-helper-specs.js
+++ b/test/unit/unlock-helper-specs.js
@@ -35,6 +35,10 @@ describe('Unlock Helpers', function () {
       helpers.isValidKey('pin', ' ').should.equal(false);
       helpers.isValidKey('pin', '1111').should.equal(true);
       helpers.isValidKey('pin', '1abc').should.equal(false);
+      helpers.isValidKey('pinWithKeyEvent').should.equal(false);
+      helpers.isValidKey('pinWithKeyEvent', ' ').should.equal(false);
+      helpers.isValidKey('pinWithKeyEvent', '1111').should.equal(true);
+      helpers.isValidKey('pinWithKeyEvent', '1abc').should.equal(false);
       helpers.isValidKey('fingerprint').should.equal(false);
       helpers.isValidKey('fingerprint', ' ').should.equal(false);
       helpers.isValidKey('fingerprint', '1111').should.equal(true);
@@ -244,7 +248,7 @@ describe('Unlock Helpers', function () {
       mocks.adb.verify();
     });
   }));
-  describe('passwordUnlock', withMocks({adb, helpers, asyncbox}, (mocks) => {
+  describe('passwordUnlock', withMocks({adb, helpers, driver, asyncbox}, (mocks) => {
     it('should be able to unlock device using password', async function () {
       let caps = {unlockKey: 'psswrd'};
       mocks.helpers.expects('dismissKeyguard').withExactArgs(driver, adb).once();
@@ -252,7 +256,9 @@ describe('Unlock Helpers', function () {
       mocks.adb.expects('shell').withExactArgs(['input', 'text', caps.unlockKey]).once();
       mocks.asyncbox.expects('sleep').withExactArgs(INPUT_KEYS_WAIT_TIME).once();
       mocks.adb.expects('shell').withExactArgs(['input', 'keyevent', KEYCODE_NUMPAD_ENTER]);
-      mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).once();
+      mocks.adb.expects('isScreenLocked').returns(true);
+      mocks.driver.expects('pressKeyCode').withExactArgs(66).once();
+      mocks.asyncbox.expects('sleep').withExactArgs(UNLOCK_WAIT_TIME).twice();
       await helpers.passwordUnlock(adb, driver, caps);
       mocks.helpers.verify();
       mocks.adb.verify();


### PR DESCRIPTION
Some devices like Samsung have customized keyboard in `pin`.
Then, it is reliable to send keys as keycode like `password` rather than finding numbers with ids. I named the strategy as `pinWithKeyEvent` for now. (Suggestions are welcome)

As backward compatibility, `pin` should be there, but the `pinUnlockWithKeyEvent` can be used as a fallback method when no system key ids in the pin view. Afaik, this fallback is pretty enough.


---

After this change:
- https://github.com/appium/appium-android-driver/blob/master/docs/UNLOCK.md
- readme in uia2 and espresso