### PR TITLE
feat: create chrome session for beta chromes

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -49,6 +49,12 @@ const CHROME_BROWSER_PACKAGE_ACTIVITY = {
 const SETTINGS_HELPER_PKG_ID = 'io.appium.settings';
 const SETTINGS_HELPER_UNLOCK_ACTIVITY = '.Unlock';
 const EMULATOR_PATTERN = /\bemulator\b/i;
+// These constants are in sync with
+// https://developer.apple.com/documentation/xctest/xcuiapplicationstate/xcuiapplicationstaterunningbackground?language=objc
+const APP_STATE_NOT_INSTALLED = 0;
+const APP_STATE_NOT_RUNNING = 1;
+const APP_STATE_RUNNING_IN_BACKGROUND = 3;
+const APP_STATE_RUNNING_IN_FOREGROUND = 4;
 
 
 function ensureNetworkSpeed (adb, networkSpeed) {
@@ -890,5 +896,6 @@ helpers.isEmulator = function isEmulator (adb, opts) {
 helpers.bootstrap = Bootstrap;
 helpers.unlocker = unlocker;
 
-export { helpers, SETTINGS_HELPER_PKG_ID, prepareAvdArgs, ensureNetworkSpeed };
+export { helpers, SETTINGS_HELPER_PKG_ID, APP_STATE_NOT_INSTALLED, APP_STATE_NOT_RUNNING,
+  APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND, prepareAvdArgs, ensureNetworkSpeed };
 export default helpers;

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -51,10 +51,13 @@ const SETTINGS_HELPER_UNLOCK_ACTIVITY = '.Unlock';
 const EMULATOR_PATTERN = /\bemulator\b/i;
 // These constants are in sync with
 // https://developer.apple.com/documentation/xctest/xcuiapplicationstate/xcuiapplicationstaterunningbackground?language=objc
-const APP_STATE_NOT_INSTALLED = 0;
-const APP_STATE_NOT_RUNNING = 1;
-const APP_STATE_RUNNING_IN_BACKGROUND = 3;
-const APP_STATE_RUNNING_IN_FOREGROUND = 4;
+const APP_STATE = {
+  NOT_INSTALLED: 0,
+  NOT_RUNNING: 1,
+  RUNNING_IN_BACKGROUND: 3,
+  RUNNING_IN_FOREGROUND: 4
+};
+Object.freeze(APP_STATE);
 
 
 function ensureNetworkSpeed (adb, networkSpeed) {
@@ -896,6 +899,5 @@ helpers.isEmulator = function isEmulator (adb, opts) {
 helpers.bootstrap = Bootstrap;
 helpers.unlocker = unlocker;
 
-export { helpers, SETTINGS_HELPER_PKG_ID, APP_STATE_NOT_INSTALLED, APP_STATE_NOT_RUNNING,
-  APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND, prepareAvdArgs, ensureNetworkSpeed };
+export { helpers, SETTINGS_HELPER_PKG_ID, APP_STATE, prepareAvdArgs, ensureNetworkSpeed };
 export default helpers;

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -51,13 +51,12 @@ const SETTINGS_HELPER_UNLOCK_ACTIVITY = '.Unlock';
 const EMULATOR_PATTERN = /\bemulator\b/i;
 // These constants are in sync with
 // https://developer.apple.com/documentation/xctest/xcuiapplicationstate/xcuiapplicationstaterunningbackground?language=objc
-const APP_STATE = {
+const APP_STATE = Object.freeze({
   NOT_INSTALLED: 0,
   NOT_RUNNING: 1,
   RUNNING_IN_BACKGROUND: 3,
   RUNNING_IN_FOREGROUND: 4
-};
-Object.freeze(APP_STATE);
+});
 
 
 function ensureNetworkSpeed (adb, networkSpeed) {

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -157,5 +157,5 @@ commands.installApp = async function installApp (appPath, options = {}) {
 };
 
 
-export { commands };
+export { commands, APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND };
 export default commands;

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -1,14 +1,14 @@
 import { waitForCondition } from 'asyncbox';
 import { util } from 'appium-support';
 import log from '../logger';
+import {
+  APP_STATE_NOT_INSTALLED,
+  APP_STATE_NOT_RUNNING,
+  APP_STATE_RUNNING_IN_BACKGROUND,
+  APP_STATE_RUNNING_IN_FOREGROUND
+} from '../android-helpers';
 
 const APP_EXTENSIONS = ['.apk', '.apks'];
-// These constants are in sync with
-// https://developer.apple.com/documentation/xctest/xcuiapplicationstate/xcuiapplicationstaterunningbackground?language=objc
-const APP_STATE_NOT_INSTALLED = 0;
-const APP_STATE_NOT_RUNNING = 1;
-const APP_STATE_RUNNING_IN_BACKGROUND = 3;
-const APP_STATE_RUNNING_IN_FOREGROUND = 4;
 
 let commands = {};
 
@@ -157,5 +157,5 @@ commands.installApp = async function installApp (appPath, options = {}) {
 };
 
 
-export { commands, APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND };
+export { commands };
 export default commands;

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -1,12 +1,7 @@
 import { waitForCondition } from 'asyncbox';
 import { util } from 'appium-support';
 import log from '../logger';
-import {
-  APP_STATE_NOT_INSTALLED,
-  APP_STATE_NOT_RUNNING,
-  APP_STATE_RUNNING_IN_BACKGROUND,
-  APP_STATE_RUNNING_IN_FOREGROUND
-} from '../android-helpers';
+import { APP_STATE } from '../android-helpers';
 
 const APP_EXTENSIONS = ['.apk', '.apks'];
 
@@ -36,17 +31,17 @@ commands.isAppInstalled = async function isAppInstalled (appId) {
 commands.queryAppState = async function queryAppState (appId) {
   log.info(`Querying the state of '${appId}'`);
   if (!await this.adb.isAppInstalled(appId)) {
-    return APP_STATE_NOT_INSTALLED;
+    return APP_STATE.NOT_INSTALLED;
   }
   if (!await this.adb.processExists(appId)) {
-    return APP_STATE_NOT_RUNNING;
+    return APP_STATE.NOT_RUNNING;
   }
   for (const line of (await this.adb.dumpWindows()).split('\n')) {
     if (line.includes(appId) && (line.includes('mCurrentFocus') || line.includes('mFocusedApp'))) {
-      return APP_STATE_RUNNING_IN_FOREGROUND;
+      return APP_STATE.RUNNING_IN_FOREGROUND;
     }
   }
-  return APP_STATE_RUNNING_IN_BACKGROUND;
+  return APP_STATE.RUNNING_IN_BACKGROUND;
 };
 
 /**
@@ -118,7 +113,7 @@ commands.terminateApp = async function terminateApp (appId, options = {}) {
   await this.adb.forceStop(appId);
   const timeout = util.hasValue(options.timeout) && !isNaN(options.timeout) ? parseInt(options.timeout, 10) : 500;
   try {
-    await waitForCondition(async () => await this.queryAppState(appId) <= APP_STATE_NOT_RUNNING,
+    await waitForCondition(async () => await this.queryAppState(appId) <= APP_STATE.NOT_RUNNING,
                            {waitMs: timeout, intervalMs: 100});
   } catch (e) {
     log.errorAndThrow(`'${appId}' is still running after ${timeout}ms timeout`);

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -30,7 +30,7 @@ commands.getContexts = async function getContexts () {
     // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
     webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   }
-  return this.getContextsWithWebviewMappings(webviewsMapping);
+  return this.getContextsWithWebviewsMapping(webviewsMapping);
 };
 
 commands.setContext = async function setContext (name) {
@@ -48,15 +48,9 @@ commands.setContext = async function setContext (name) {
   let webviewsMapping = [];
   if (!this.isChromeSession) {
     // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
-    const opts = {
-      androidDeviceSocket: this.opts.androidDeviceSocket,
-      ensureWebviewsHavePages: this.opts.ensureWebviewsHavePages,
-      webviewDevtoolsPort: this.opts.webviewDevtoolsPort,
-      enableWebviewDetailsCollection: true
-    };
-    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, opts);
+    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   }
-  const contexts = this.getContextsWithWebviewMappings(webviewsMapping);
+  const contexts = this.getContextsWithWebviewsMapping(webviewsMapping);
   // if the context we want doesn't exist, fail
   if (!_.includes(contexts, name)) {
     throw new errors.NoSuchContextError();
@@ -122,17 +116,11 @@ commands.mobileGetContexts = async function mobileGetContexts () {
   return await webviewHelpers.getWebViewsMapping(this.adb, opts);
 };
 
-helpers.getContextsWithWebviewMappings = function getContexts (webViewsMapping) {
-  let webviews;
-  if (this.isChromeSession) {
-    // if we have a Chrome browser session, we only care about the Chrome
-    // context and the native context
-    webviews = [CHROMIUM_WIN];
-  } else {
-    // otherwise we use ADB to figure out which webviews are available
-    webviews = webviewHelpers.getWebviews(webViewsMapping, this.opts.ensureWebviewsHavePages);
-  }
-  this.contexts = _.union([NATIVE_WIN], webviews);
+helpers.getContextsWithWebviewsMapping = function getContexts (webviewsMapping) {
+  const webviews = this.isChromeSession ?
+    [CHROMIUM_WIN] :
+    webviewHelpers.getWebviews(webviewsMapping, this.opts.ensureWebviewsHavePages);
+  this.contexts = [NATIVE_WIN, ...webviews];
   log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);
   return this.contexts;
 };
@@ -206,7 +194,7 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
       }
       if (!opts.extractChromeAndroidPackageFromContextName) {
         for (const wm of webviewsMapping) {
-          if (wm.webviewName === context && 'info' in wm && 'Android-Package' in wm.info) {
+          if (wm.webviewName === context && _.has(wm?.info, 'Android-Package')) {
             opts.chromeAndroidPackage = wm.info['Android-Package'];
             break;
           }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -194,9 +194,9 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
       }
       if (!opts.extractChromeAndroidPackageFromContextName) {
         if (_.has(this.opts, 'enableWebviewDetailsCollection') && !this.opts.enableWebviewDetailsCollection) {
-          // When enableWebviewDetailsCollection capability is explictly disabled, try to identify 
-          // chromeAndroidPackage based on contexts, known chrome variant packages and queryAppState result 
-          // since webviewsMapping does not have info object 
+          // When enableWebviewDetailsCollection capability is explictly disabled, try to identify
+          // chromeAndroidPackage based on contexts, known chrome variant packages and queryAppState result
+          // since webviewsMapping does not have info object
           const contexts = webviewsMapping.map((wm) => wm.webviewName);
           for (const knownPackage of KNOWN_CHROME_PACKAGE_NAMES) {
             if (_.includes(contexts, `${WEBVIEW_BASE}${knownPackage}`)) {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -30,7 +30,7 @@ commands.getContexts = async function getContexts () {
     // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
     webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   }
-  return this.getContextsWithWebviewsMapping(webviewsMapping);
+  return this.assignContexts(webviewsMapping);
 };
 
 commands.setContext = async function setContext (name) {
@@ -50,7 +50,7 @@ commands.setContext = async function setContext (name) {
     // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
     webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   }
-  const contexts = this.getContextsWithWebviewsMapping(webviewsMapping);
+  const contexts = this.assignContexts(webviewsMapping);
   // if the context we want doesn't exist, fail
   if (!_.includes(contexts, name)) {
     throw new errors.NoSuchContextError();
@@ -116,7 +116,7 @@ commands.mobileGetContexts = async function mobileGetContexts () {
   return await webviewHelpers.getWebViewsMapping(this.adb, opts);
 };
 
-helpers.getContextsWithWebviewsMapping = function getContexts (webviewsMapping) {
+helpers.assignContexts = function assignContexts (webviewsMapping) {
   const webviews = this.isChromeSession ?
     [CHROMIUM_WIN] :
     webviewHelpers.parseWebviewNames(webviewsMapping, this.opts.ensureWebviewsHavePages);

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -7,7 +7,7 @@ import { util } from 'appium-support';
 import { errors } from 'appium-base-driver';
 import {
   default as webviewHelpers,
-  NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES
+  NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN
 } from '../webview-helpers';
 
 const CHROMEDRIVER_AUTODOWNLOAD_FEATURE = 'chromedriver_autodownload';
@@ -56,7 +56,7 @@ commands.setContext = async function setContext (name) {
     throw new errors.NoSuchContextError();
   }
 
-  await this.switchContext(name, contexts);
+  await this.switchContext(name, webviewsMapping);
   this.curContext = name;
 };
 
@@ -131,12 +131,12 @@ helpers.getContextsWithWebviewMappings = function getContexts (webViewsMapping) 
   return this.contexts;
 };
 
-helpers.switchContext = async function switchContext (name, contexts) {
+helpers.switchContext = async function switchContext (name, webviewsMapping) {
   // We have some options when it comes to webviews. If we want a
   // Chromedriver webview, we can only control one at a time.
   if (this.isChromedriverContext(name)) {
     // start proxying commands directly to chromedriver
-    await this.startChromedriverProxy(name, contexts);
+    await this.startChromedriverProxy(name, webviewsMapping);
   } else if (this.isChromedriverContext(this.curContext)) {
     // if we're moving to a non-chromedriver webview, and our current context
     // _is_ a chromedriver webview, if caps recreateChromeDriverSessions is set
@@ -174,7 +174,7 @@ helpers.isWebContext = function isWebContext () {
 };
 
 // Turn on proxying to an existing Chromedriver session or a new one
-helpers.startChromedriverProxy = async function startChromedriverProxy (context, contexts) {
+helpers.startChromedriverProxy = async function startChromedriverProxy (context, webviewsMapping) {
   log.debug(`Connecting to chrome-backed webview context '${context}'`);
 
   let cd;
@@ -199,21 +199,9 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
         opts.chromeAndroidPackage = androidPackage[1];
       }
       if (!opts.extractChromeAndroidPackageFromContextName) {
-        const getWebviewOpts = {
-          androidDeviceSocket: opts.androidDeviceSocket,
-          ensureWebviewsHavePages: true,
-          webviewDevtoolsPort: opts.webviewDevtoolsPort,
-          enableWebviewDetailsCollection: true
-        };
-        const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, getWebviewOpts);
-        const chromeAndroidPackageCandidates = webviewsMapping.filter(
-          (wm) => 'info' in wm && 'Android-Package' in wm.info).map(
-          (wm) => wm.info['Android-Package']);
-        for (const chromeAndroidPackageCandidate of chromeAndroidPackageCandidates) {
-          if (_.includes(contexts, `${WEBVIEW_BASE}${chromeAndroidPackageCandidate}`)) {
-            continue;
-          } else if (_.includes(KNOWN_CHROME_PACKAGE_NAMES, chromeAndroidPackageCandidate)) {
-            opts.chromeAndroidPackage = chromeAndroidPackageCandidate;
+        for (const wm of webviewsMapping) {
+          if (wm.webviewName === context && 'info' in wm && 'Android-Package' in wm.info) {
+            opts.chromeAndroidPackage = wm.info['Android-Package'];
             break;
           }
         }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -204,7 +204,7 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
             const appState = await this.queryAppState(knownPackage);
             if (_.includes([APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND], appState)) {
               opts.chromeAndroidPackage = knownPackage;
-              log.debug(`Identified chromeAndroidPackage as '${opts.chromeAndroidPackage}'` +
+              log.debug(`Identified chromeAndroidPackage as '${opts.chromeAndroidPackage}' ` +
                 `for context '${context}' by querying states of Chrome app packages`);
               break;
             }
@@ -213,7 +213,7 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
           for (const wm of webviewsMapping) {
             if (wm.webviewName === context && _.has(wm?.info, 'Android-Package')) {
               opts.chromeAndroidPackage = wm.info['Android-Package'];
-              log.debug(`Identified chromeAndroidPackage as '${opts.chromeAndroidPackage}'` +
+              log.debug(`Identified chromeAndroidPackage as '${opts.chromeAndroidPackage}' ` +
                 `for context '${context}' by CDP`);
               break;
             }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -118,7 +118,7 @@ commands.mobileGetContexts = async function mobileGetContexts () {
 helpers.assignContexts = function assignContexts (webviewsMapping) {
   const webviews = this.isChromeSession ?
     [CHROMIUM_WIN] :
-    webviewHelpers.parseWebviewNames(webviewsMapping, this.opts.ensureWebviewsHavePages);
+    webviewHelpers.parseWebviewNames(webviewsMapping, {'ensureWebviewsHavePages': this.opts.ensureWebviewsHavePages});
   this.contexts = [NATIVE_WIN, ...webviews];
   log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);
   return this.contexts;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -194,6 +194,9 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
       }
       if (!opts.extractChromeAndroidPackageFromContextName) {
         if (_.has(this.opts, 'enableWebviewDetailsCollection') && !this.opts.enableWebviewDetailsCollection) {
+          // When enableWebviewDetailsCollection capability is explictly disabled, try to identify 
+          // chromeAndroidPackage based on contexts, known chrome variant packages and queryAppState result 
+          // since webviewsMapping does not have info object 
           const contexts = webviewsMapping.map((wm) => wm.webviewName);
           for (const knownPackage of KNOWN_CHROME_PACKAGE_NAMES) {
             if (_.includes(contexts, `${WEBVIEW_BASE}${knownPackage}`)) {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -113,9 +113,8 @@ commands.mobileGetContexts = async function mobileGetContexts () {
 };
 
 helpers.assignContexts = function assignContexts (webviewsMapping) {
-  const webviews = this.isChromeSession ?
-    [CHROMIUM_WIN] :
-    webviewHelpers.parseWebviewNames(webviewsMapping, {ensureWebviewsHavePages: this.opts.ensureWebviewsHavePages});
+  const opts = Object.assign({isChromeSession: this.isChromeSession}, this.opts);
+  const webviews = webviewHelpers.parseWebviewNames(webviewsMapping, opts);
   this.contexts = [NATIVE_WIN, ...webviews];
   log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);
   return this.contexts;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -48,7 +48,13 @@ commands.setContext = async function setContext (name) {
   let webviewsMapping = [];
   if (!this.isChromeSession) {
     // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
-    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
+    const opts = {
+      androidDeviceSocket: this.opts.androidDeviceSocket,
+      ensureWebviewsHavePages: this.opts.ensureWebviewsHavePages,
+      webviewDevtoolsPort: this.opts.webviewDevtoolsPort,
+      enableWebviewDetailsCollection: true
+    };
+    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, opts);
   }
   const contexts = this.getContextsWithWebviewMappings(webviewsMapping);
   // if the context we want doesn't exist, fail

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -9,9 +9,7 @@ import {
   default as webviewHelpers,
   NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES
 } from '../webview-helpers';
-import {
-  APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND
-} from './app-management';
+import { APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND } from '../android-helpers';
 
 const CHROMEDRIVER_AUTODOWNLOAD_FEATURE = 'chromedriver_autodownload';
 

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -119,7 +119,7 @@ commands.mobileGetContexts = async function mobileGetContexts () {
 helpers.getContextsWithWebviewsMapping = function getContexts (webviewsMapping) {
   const webviews = this.isChromeSession ?
     [CHROMIUM_WIN] :
-    webviewHelpers.getWebviews(webviewsMapping, this.opts.ensureWebviewsHavePages);
+    webviewHelpers.parseWebviewNames(webviewsMapping, this.opts.ensureWebviewsHavePages);
   this.contexts = [NATIVE_WIN, ...webviews];
   log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);
   return this.contexts;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -9,7 +9,7 @@ import {
   default as webviewHelpers,
   NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES
 } from '../webview-helpers';
-import { APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND } from '../android-helpers';
+import { APP_STATE } from '../android-helpers';
 
 const CHROMEDRIVER_AUTODOWNLOAD_FEATURE = 'chromedriver_autodownload';
 
@@ -200,7 +200,7 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
               continue;
             }
             const appState = await this.queryAppState(knownPackage);
-            if (_.includes([APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND], appState)) {
+            if (_.includes([APP_STATE.RUNNING_IN_BACKGROUND, APP_STATE.RUNNING_IN_FOREGROUND], appState)) {
               opts.chromeAndroidPackage = knownPackage;
               log.debug(`Identified chromeAndroidPackage as '${opts.chromeAndroidPackage}' ` +
                 `for context '${context}' by querying states of Chrome app packages`);

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -204,6 +204,8 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
             const appState = await this.queryAppState(knownPackage);
             if (_.includes([APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND], appState)) {
               opts.chromeAndroidPackage = knownPackage;
+              log.debug(`Identified chromeAndroidPackage as '${opts.chromeAndroidPackage}'` +
+                `for context '${context}' by querying states of Chrome app packages`);
               break;
             }
           }
@@ -211,6 +213,8 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
           for (const wm of webviewsMapping) {
             if (wm.webviewName === context && _.has(wm?.info, 'Android-Package')) {
               opts.chromeAndroidPackage = wm.info['Android-Package'];
+              log.debug(`Identified chromeAndroidPackage as '${opts.chromeAndroidPackage}'` +
+                `for context '${context}' by CDP`);
               break;
             }
           }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -9,6 +9,9 @@ import {
   default as webviewHelpers,
   NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES
 } from '../webview-helpers';
+import {
+  APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND
+} from './app-management';
 
 const CHROMEDRIVER_AUTODOWNLOAD_FEATURE = 'chromedriver_autodownload';
 
@@ -190,7 +193,7 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
       }
       if (!opts.extractChromeAndroidPackageFromContextName) {
         if (_.has(this.opts, 'enableWebviewDetailsCollection') && !this.opts.enableWebviewDetailsCollection) {
-          // When enableWebviewDetailsCollection capability is explictly disabled, try to identify
+          // When enableWebviewDetailsCollection capability is explicitly disabled, try to identify
           // chromeAndroidPackage based on contexts, known chrome variant packages and queryAppState result
           // since webviewsMapping does not have info object
           const contexts = webviewsMapping.map((wm) => wm.webviewName);
@@ -199,8 +202,7 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
               continue;
             }
             const appState = await this.queryAppState(knownPackage);
-            if (appState === 3 || appState === 4) {
-              // When APP_STATE_RUNNING_IN_BACKGROUND or APP_STATE_RUNNING_IN_FOREGROUND
+            if (_.includes([APP_STATE_RUNNING_IN_BACKGROUND, APP_STATE_RUNNING_IN_FOREGROUND], appState)) {
               opts.chromeAndroidPackage = knownPackage;
               break;
             }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -116,7 +116,7 @@ commands.mobileGetContexts = async function mobileGetContexts () {
 helpers.assignContexts = function assignContexts (webviewsMapping) {
   const webviews = this.isChromeSession ?
     [CHROMIUM_WIN] :
-    webviewHelpers.parseWebviewNames(webviewsMapping, {'ensureWebviewsHavePages': this.opts.ensureWebviewsHavePages});
+    webviewHelpers.parseWebviewNames(webviewsMapping, {ensureWebviewsHavePages: this.opts.ensureWebviewsHavePages});
   this.contexts = [NATIVE_WIN, ...webviews];
   log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);
   return this.contexts;

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -7,7 +7,7 @@ import { util } from 'appium-support';
 import { errors } from 'appium-base-driver';
 import {
   default as webviewHelpers,
-  NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN
+  NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES
 } from '../webview-helpers';
 
 const CHROMEDRIVER_AUTODOWNLOAD_FEATURE = 'chromedriver_autodownload';
@@ -193,10 +193,25 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
         opts.chromeAndroidPackage = androidPackage[1];
       }
       if (!opts.extractChromeAndroidPackageFromContextName) {
-        for (const wm of webviewsMapping) {
-          if (wm.webviewName === context && _.has(wm?.info, 'Android-Package')) {
-            opts.chromeAndroidPackage = wm.info['Android-Package'];
-            break;
+        if (_.has(this.opts, 'enableWebviewDetailsCollection') && !this.opts.enableWebviewDetailsCollection) {
+          const contexts = webviewsMapping.map((wm) => wm.webviewName);
+          for (const knownPackage of KNOWN_CHROME_PACKAGE_NAMES) {
+            if (_.includes(contexts, `${WEBVIEW_BASE}${knownPackage}`)) {
+              continue;
+            }
+            const appState = await this.queryAppState(knownPackage);
+            if (appState === 3 || appState === 4) {
+              // When APP_STATE_RUNNING_IN_BACKGROUND or APP_STATE_RUNNING_IN_FOREGROUND
+              opts.chromeAndroidPackage = knownPackage;
+              break;
+            }
+          }
+        } else {
+          for (const wm of webviewsMapping) {
+            if (wm.webviewName === context && _.has(wm?.info, 'Android-Package')) {
+              opts.chromeAndroidPackage = wm.info['Android-Package'];
+              break;
+            }
           }
         }
       }

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -25,18 +25,12 @@ commands.getCurrentContext = async function getCurrentContext () { // eslint-dis
 };
 
 commands.getContexts = async function getContexts () {
-  let webviews;
-  if (this.isChromeSession) {
-    // if we have a Chrome browser session, we only care about the Chrome
-    // context and the native context
-    webviews = [CHROMIUM_WIN];
-  } else {
-    // otherwise we use ADB to figure out which webviews are available
-    webviews = await webviewHelpers.getWebviews(this.adb, this.opts);
+  let webviewsMapping = [];
+  if (!this.isChromeSession) {
+    // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
+    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   }
-  this.contexts = _.union([NATIVE_WIN], webviews);
-  log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);
-  return this.contexts;
+  return this.getContextsWithWebviewMappings(webviewsMapping);
 };
 
 commands.setContext = async function setContext (name) {
@@ -51,7 +45,12 @@ commands.setContext = async function setContext (name) {
     return;
   }
 
-  let contexts = await this.getContexts();
+  let webviewsMapping = [];
+  if (!this.isChromeSession) {
+    // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
+    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
+  }
+  const contexts = this.getContextsWithWebviewMappings(webviewsMapping);
   // if the context we want doesn't exist, fail
   if (!_.includes(contexts, name)) {
     throw new errors.NoSuchContextError();
@@ -115,6 +114,21 @@ commands.mobileGetContexts = async function mobileGetContexts () {
     enableWebviewDetailsCollection: true
   };
   return await webviewHelpers.getWebViewsMapping(this.adb, opts);
+};
+
+helpers.getContextsWithWebviewMappings = function getContexts (webViewsMapping) {
+  let webviews;
+  if (this.isChromeSession) {
+    // if we have a Chrome browser session, we only care about the Chrome
+    // context and the native context
+    webviews = [CHROMIUM_WIN];
+  } else {
+    // otherwise we use ADB to figure out which webviews are available
+    webviews = webviewHelpers.getWebviews(webViewsMapping, this.opts.ensureWebviewsHavePages);
+  }
+  this.contexts = _.union([NATIVE_WIN], webviews);
+  log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);
+  return this.contexts;
 };
 
 helpers.switchContext = async function switchContext (name, contexts) {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -26,9 +26,8 @@ commands.getCurrentContext = async function getCurrentContext () { // eslint-dis
 };
 
 commands.getContexts = async function getContexts () {
-  const webviewsMapping = this.isChromeSession
-    ? []
-    : await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
+  const opts = Object.assign({isChromeSession: this.isChromeSession}, this.opts);
+  const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, opts);
   return this.assignContexts(webviewsMapping);
 };
 
@@ -44,9 +43,8 @@ commands.setContext = async function setContext (name) {
     return;
   }
 
-  const webviewsMapping = this.isChromeSession
-    ? []
-    : await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
+  const opts = Object.assign({isChromeSession: this.isChromeSession}, this.opts);
+  const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, opts);
   const contexts = this.assignContexts(webviewsMapping);
   // if the context we want doesn't exist, fail
   if (!_.includes(contexts, name)) {
@@ -108,7 +106,8 @@ commands.mobileGetContexts = async function mobileGetContexts () {
     androidDeviceSocket: this.opts.androidDeviceSocket,
     ensureWebviewsHavePages: true,
     webviewDevtoolsPort: this.opts.webviewDevtoolsPort,
-    enableWebviewDetailsCollection: true
+    enableWebviewDetailsCollection: true,
+    isChromeSession: this.isChromeSession
   };
   return await webviewHelpers.getWebViewsMapping(this.adb, opts);
 };

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -25,11 +25,9 @@ commands.getCurrentContext = async function getCurrentContext () { // eslint-dis
 };
 
 commands.getContexts = async function getContexts () {
-  let webviewsMapping = [];
-  if (!this.isChromeSession) {
-    // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
-    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
-  }
+  const webviewsMapping = this.isChromeSession
+    ? []
+    : await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   return this.assignContexts(webviewsMapping);
 };
 
@@ -45,11 +43,9 @@ commands.setContext = async function setContext (name) {
     return;
   }
 
-  let webviewsMapping = [];
-  if (!this.isChromeSession) {
-    // if we don't have a Chrome browser session, we use ADB to figure out which webviews are available
-    webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
-  }
+  const webviewsMapping = this.isChromeSession
+    ? []
+    : await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   const contexts = this.assignContexts(webviewsMapping);
   // if the context we want doesn't exist, fail
   if (!_.includes(contexts, name)) {

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -7,7 +7,7 @@ import { util } from 'appium-support';
 import { errors } from 'appium-base-driver';
 import {
   default as webviewHelpers,
-  NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN
+  NATIVE_WIN, WEBVIEW_BASE, WEBVIEW_WIN, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES
 } from '../webview-helpers';
 
 const CHROMEDRIVER_AUTODOWNLOAD_FEATURE = 'chromedriver_autodownload';
@@ -57,7 +57,7 @@ commands.setContext = async function setContext (name) {
     throw new errors.NoSuchContextError();
   }
 
-  await this.switchContext(name);
+  await this.switchContext(name, contexts);
   this.curContext = name;
 };
 
@@ -117,12 +117,12 @@ commands.mobileGetContexts = async function mobileGetContexts () {
   return await webviewHelpers.getWebViewsMapping(this.adb, opts);
 };
 
-helpers.switchContext = async function switchContext (name) {
+helpers.switchContext = async function switchContext (name, contexts) {
   // We have some options when it comes to webviews. If we want a
   // Chromedriver webview, we can only control one at a time.
   if (this.isChromedriverContext(name)) {
     // start proxying commands directly to chromedriver
-    await this.startChromedriverProxy(name);
+    await this.startChromedriverProxy(name, contexts);
   } else if (this.isChromedriverContext(this.curContext)) {
     // if we're moving to a non-chromedriver webview, and our current context
     // _is_ a chromedriver webview, if caps recreateChromeDriverSessions is set
@@ -160,7 +160,7 @@ helpers.isWebContext = function isWebContext () {
 };
 
 // Turn on proxying to an existing Chromedriver session or a new one
-helpers.startChromedriverProxy = async function startChromedriverProxy (context) {
+helpers.startChromedriverProxy = async function startChromedriverProxy (context, contexts) {
   log.debug(`Connecting to chrome-backed webview context '${context}'`);
 
   let cd;
@@ -183,6 +183,19 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context)
       let androidPackage = context.match(`${WEBVIEW_BASE}(.+)`);
       if (androidPackage && androidPackage.length > 0) {
         opts.chromeAndroidPackage = androidPackage[1];
+      }
+      if (!opts.extractChromeAndroidPackageFromContextName) {
+        for (const knownPackage of KNOWN_CHROME_PACKAGE_NAMES) {
+          if (_.includes(contexts, `${WEBVIEW_BASE}${knownPackage}`)) {
+            continue;
+          }
+          const appState = await this.queryAppState(knownPackage);
+          if (appState === 3 || appState === 4) {
+            // When APP_STATE_RUNNING_IN_BACKGROUND or APP_STATE_RUNNING_IN_FOREGROUND
+            opts.chromeAndroidPackage = knownPackage;
+            break;
+          }
+        }
       }
     }
 

--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -185,14 +185,21 @@ helpers.startChromedriverProxy = async function startChromedriverProxy (context,
         opts.chromeAndroidPackage = androidPackage[1];
       }
       if (!opts.extractChromeAndroidPackageFromContextName) {
-        for (const knownPackage of KNOWN_CHROME_PACKAGE_NAMES) {
-          if (_.includes(contexts, `${WEBVIEW_BASE}${knownPackage}`)) {
+        const getWebviewOpts = {
+          androidDeviceSocket: opts.androidDeviceSocket,
+          ensureWebviewsHavePages: true,
+          webviewDevtoolsPort: opts.webviewDevtoolsPort,
+          enableWebviewDetailsCollection: true
+        };
+        const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, getWebviewOpts);
+        const chromeAndroidPackageCandidates = webviewsMapping.filter(
+          (wm) => 'info' in wm && 'Android-Package' in wm.info).map(
+          (wm) => wm.info['Android-Package']);
+        for (const chromeAndroidPackageCandidate of chromeAndroidPackageCandidates) {
+          if (_.includes(contexts, `${WEBVIEW_BASE}${chromeAndroidPackageCandidate}`)) {
             continue;
-          }
-          const appState = await this.queryAppState(knownPackage);
-          if (appState === 3 || appState === 4) {
-            // When APP_STATE_RUNNING_IN_BACKGROUND or APP_STATE_RUNNING_IN_FOREGROUND
-            opts.chromeAndroidPackage = knownPackage;
+          } else if (_.includes(KNOWN_CHROME_PACKAGE_NAMES, chromeAndroidPackageCandidate)) {
+            opts.chromeAndroidPackage = chromeAndroidPackageCandidate;
             break;
           }
         }

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -475,12 +475,12 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
   if (opts.pageLoadStrategy) {
     caps.pageLoadStrategy = opts.pageLoadStrategy;
   }
-  if (_.includes(KNOWN_CHROME_PACKAGE_NAMES, caps.chromeOptions.androidPackage)
-    || _.toLower(caps.chromeOptions.androidPackage) === 'chrome') {
+  const isChrome = _.toLower(caps.chromeOptions.androidPackage) === 'chrome';
+  if (_.includes(KNOWN_CHROME_PACKAGE_NAMES, caps.chromeOptions.androidPackage) || isChrome) {
     // if we have extracted package from context name, it could come in as bare
     // "chrome", and so we should make sure the details are correct, including
     // not using an activity or process id
-    if (_.toLower(caps.chromeOptions.androidPackage) === 'chrome') {
+    if (isChrome) {
       caps.chromeOptions.androidPackage = CHROME_PACKAGE_NAME;
     }
     delete caps.chromeOptions.androidActivity;

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -299,10 +299,12 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
  * Retrieves webview names for getContexts
  *
  * @param {Array<WebviewsMapping>} webviewsMapping See note on getWebViewsMapping
- * @param {boolean} ensureWebviewsHavePages Whether to check for webview pages presence
+ * @param {GetWebviewOpts} opts See note on getWebViewsMapping
  * @return {Array.<string>} - a list of webview names
  */
-helpers.getWebviews = function getWebviews (webviewsMapping, ensureWebviewsHavePages = true) {
+helpers.getWebviews = function getWebviews (webviewsMapping, {
+  ensureWebviewsHavePages = true
+} = {}) {
   const result = [];
   for (const {webview, pages, proc, webviewName} of webviewsMapping) {
     if (ensureWebviewsHavePages && pages?.length === 0) {

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -302,7 +302,7 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
  * @param {GetWebviewOpts} opts See note on getWebViewsMapping
  * @return {Array.<string>} - a list of webview names
  */
-helpers.getWebviews = function getWebviews (webviewsMapping, {
+helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
   ensureWebviewsHavePages = true
 } = {}) {
   const result = [];

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -537,4 +537,4 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
 };
 
 export default helpers;
-export { helpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE, CHROMIUM_WIN };
+export { helpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES };

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -330,6 +330,7 @@ helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
  * @property {boolean} enableWebviewDetailsCollection [true] - whether to collect
  * web view details and send them to Chromedriver constructor, so it could
  * select a binary more precisely based on this info.
+ * @property {boolean} isChromeSession [false] - true if ChromeSession
  */
 
 /**
@@ -364,7 +365,12 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
   ensureWebviewsHavePages = true,
   webviewDevtoolsPort = null,
   enableWebviewDetailsCollection = true,
+  isChromeSession = false
 } = {}) {
+  if (isChromeSession) {
+    return [];
+  }
+
   logger.debug('Getting a list of available webviews');
   const webviewsMapping = await webviewsFromProcs(adb, androidDeviceSocket);
 

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -296,15 +296,20 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
 };
 
 /**
- * Retrieves webview names for getContexts
+ * Parse webview names for getContexts
  *
  * @param {Array<WebviewsMapping>} webviewsMapping See note on getWebViewsMapping
  * @param {GetWebviewsOpts} opts See note on getWebViewsMapping
  * @return {Array.<string>} - a list of webview names
  */
 helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
-  ensureWebviewsHavePages = true
+  ensureWebviewsHavePages = true,
+  isChromeSession = false
 } = {}) {
+  if (isChromeSession) {
+    return [CHROMIUM_WIN];
+  }
+
   const result = [];
   for (const {webview, pages, proc, webviewName} of webviewsMapping) {
     if (ensureWebviewsHavePages && pages?.length === 0) {

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -327,7 +327,7 @@ helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
  * page presence
  * @property {number} webviewDevtoolsPort [9222] - port to use for webview page
  * presence check.
- * @property {boolean} enableWebviewDetailsCollection [false] - whether to collect
+ * @property {boolean} enableWebviewDetailsCollection [true] - whether to collect
  * web view details and send them to Chromedriver constructor, so it could
  * select a binary more precisely based on this info.
  */

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -17,6 +17,12 @@ const DEVTOOLS_SOCKET_PATTERN = /@[\w.]+_devtools_remote_?(\d+)?\b/;
 const CROSSWALK_SOCKET_PATTERN = /@([\w.]+)_devtools_remote\b/;
 const CHROMIUM_DEVTOOLS_SOCKET = 'chrome_devtools_remote';
 const CHROME_PACKAGE_NAME = 'com.android.chrome';
+const KNOWN_CHROME_PACKAGE_NAMES = [
+  CHROME_PACKAGE_NAME,
+  'com.chrome.beta',
+  'com.chrome.dev',
+  'com.chrome.canary',
+];
 const DEVTOOLS_PORTS_RANGE = [10900, 11000];
 const PORT_ALLOCATION_GUARD = new AsyncLock();
 const WEBVIEWS_DETAILS_CACHE = new LRU({
@@ -481,11 +487,14 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
   if (opts.pageLoadStrategy) {
     caps.pageLoadStrategy = opts.pageLoadStrategy;
   }
-  if (_.toLower(caps.chromeOptions.androidPackage) === 'chrome') {
+  if (_.includes(KNOWN_CHROME_PACKAGE_NAMES, caps.chromeOptions.androidPackage)
+    || _.toLower(caps.chromeOptions.androidPackage) === 'chrome') {
     // if we have extracted package from context name, it could come in as bare
     // "chrome", and so we should make sure the details are correct, including
     // not using an activity or process id
-    caps.chromeOptions.androidPackage = CHROME_PACKAGE_NAME;
+    if (_.toLower(caps.chromeOptions.androidPackage) === 'chrome') {
+      caps.chromeOptions.androidPackage = CHROME_PACKAGE_NAME;
+    }
     delete caps.chromeOptions.androidActivity;
     delete caps.chromeOptions.androidProcess;
   }
@@ -538,4 +547,4 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
 };
 
 export default helpers;
-export { helpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE, CHROMIUM_WIN };
+export { helpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES };

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -299,7 +299,7 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
  * Retrieves webview names for getContexts
  *
  * @param {Array<WebviewsMapping>} webviewsMapping See note on getWebViewsMapping
- * @param {GetWebviewOpts} opts See note on getWebViewsMapping
+ * @param {GetWebviewsOpts} opts See note on getWebViewsMapping
  * @return {Array.<string>} - a list of webview names
  */
 helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
@@ -355,7 +355,7 @@ helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
  * should be used for this communication.
  *
  * @param {object} adb - an ADB instance
- * @param {GetWebviewOpts} opts
+ * @param {GetWebviewsOpts} opts
  *
  * @return {Array<WebviewsMapping>} webviewsMapping
  */

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -535,4 +535,4 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
 };
 
 export default helpers;
-export { helpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES };
+export { helpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE, CHROMIUM_WIN };

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -361,7 +361,7 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
   androidDeviceSocket = null,
   ensureWebviewsHavePages = true,
   webviewDevtoolsPort = null,
-  enableWebviewDetailsCollection = null,
+  enableWebviewDetailsCollection = true,
 } = {}) {
   logger.debug('Getting a list of available webviews');
   const webviewsMapping = await webviewsFromProcs(adb, androidDeviceSocket);

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -298,23 +298,11 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
 /**
  * Retrieves webview names for getContexts
  *
- * @param {object} adb - an ADB instance
- * @param {GetWebviewOpts} opts See note on getWebViewsMapping
- *
+ * @param {Array<WebviewsMapping>} webviewsMapping See note on getWebViewsMapping
+ * @param {boolean} ensureWebviewsHavePages Whether to check for webview pages presence
  * @return {Array.<string>} - a list of webview names
  */
-helpers.getWebviews = async function getWebviews (adb, {
-  androidDeviceSocket = null,
-  ensureWebviewsHavePages = true,
-  webviewDevtoolsPort = null,
-  enableWebviewDetailsCollection = null,
-} = {}) {
-  const webviewsMapping = await this.getWebViewsMapping(adb, {
-    androidDeviceSocket,
-    ensureWebviewsHavePages,
-    webviewDevtoolsPort,
-    enableWebviewDetailsCollection
-  });
+helpers.getWebviews = function getWebviews (webviewsMapping, ensureWebviewsHavePages = true) {
   const result = [];
   for (const {webview, pages, proc, webviewName} of webviewsMapping) {
     if (ensureWebviewsHavePages && pages?.length === 0) {

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -56,13 +56,16 @@ describe('Context', function () {
     });
     it('should use ADB to figure out which webviews are available', async function () {
       sandbox.stub(webviewHelpers, 'getWebviews');
+      sandbox.stub(webviewHelpers, 'getWebViewsMapping');
       expect(await driver.getContexts()).to.not.include(CHROMIUM_WIN);
       webviewHelpers.getWebviews.calledOnce.should.be.true;
+      webviewHelpers.getWebViewsMapping.calledOnce.should.be.true;
     });
   });
   describe('setContext', function () {
     beforeEach(function () {
-      sandbox.stub(driver, 'getContexts').returns(['DEFAULT', 'WV', 'ANOTHER']);
+      sandbox.stub(webviewHelpers, 'getWebViewsMapping');
+      sandbox.stub(driver, 'getContextsWithWebviewMappings').returns(['DEFAULT', 'WV', 'ANOTHER']);
       sandbox.stub(driver, 'switchContext');
     });
     it('should switch to default context if name is null', async function () {

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -68,13 +68,13 @@ describe('Context', function () {
     it('should switch to default context if name is null', async function () {
       sandbox.stub(driver, 'defaultContextName').returns('DEFAULT');
       await driver.setContext(null);
-      driver.switchContext.calledWithExactly('DEFAULT').should.be.true;
+      driver.switchContext.calledWithExactly('DEFAULT', ['DEFAULT', 'WV', 'ANOTHER']).should.be.true;
       driver.curContext.should.be.equal('DEFAULT');
     });
     it('should switch to default web view if name is WEBVIEW', async function () {
       sandbox.stub(driver, 'defaultWebviewName').returns('WV');
       await driver.setContext(WEBVIEW_WIN);
-      driver.switchContext.calledWithExactly('WV').should.be.true;
+      driver.switchContext.calledWithExactly('WV', ['DEFAULT', 'WV', 'ANOTHER']).should.be.true;
       driver.curContext.should.be.equal('WV');
     });
     it('should throw error if context does not exist', async function () {
@@ -97,8 +97,8 @@ describe('Context', function () {
     });
     it('should start chrome driver proxy if requested context is webview', async function () {
       driver.isChromedriverContext.returns(true);
-      await driver.switchContext('context');
-      driver.startChromedriverProxy.calledWithExactly('context').should.be.true;
+      await driver.switchContext('context', ['current_cntx', 'context']);
+      driver.startChromedriverProxy.calledWithExactly('context', ['current_cntx', 'context']).should.be.true;
     });
     it('should stop chromedriver proxy if current context is webview and requested context is not', async function () {
       driver.opts = {recreateChromeDriverSessions: true};

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -55,10 +55,10 @@ describe('Context', function () {
       expect(await driver.getContexts()).to.include(CHROMIUM_WIN);
     });
     it('should use ADB to figure out which webviews are available', async function () {
-      sandbox.stub(webviewHelpers, 'getWebviews').returns(['DEFAULT', 'VW', 'ANOTHER']);
+      sandbox.stub(webviewHelpers, 'parseWebviewNames').returns(['DEFAULT', 'VW', 'ANOTHER']);
       sandbox.stub(webviewHelpers, 'getWebViewsMapping');
       expect(await driver.getContexts()).to.not.include(CHROMIUM_WIN);
-      webviewHelpers.getWebviews.calledOnce.should.be.true;
+      webviewHelpers.parseWebviewNames.calledOnce.should.be.true;
       webviewHelpers.getWebViewsMapping.calledOnce.should.be.true;
     });
   });

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -64,20 +64,23 @@ describe('Context', function () {
   });
   describe('setContext', function () {
     beforeEach(function () {
-      sandbox.stub(webviewHelpers, 'getWebViewsMapping');
-      sandbox.stub(driver, 'getContextsWithWebviewMappings').returns(['DEFAULT', 'WV', 'ANOTHER']);
+      sandbox.stub(webviewHelpers, 'getWebViewsMapping').returns(
+          [{'webviewName': 'DEFAULT'}, {'webviewName': 'WV'}, {'webviewName': 'ANOTHER'}]
+      );
       sandbox.stub(driver, 'switchContext');
     });
     it('should switch to default context if name is null', async function () {
       sandbox.stub(driver, 'defaultContextName').returns('DEFAULT');
       await driver.setContext(null);
-      driver.switchContext.calledWithExactly('DEFAULT', ['DEFAULT', 'WV', 'ANOTHER']).should.be.true;
+      driver.switchContext.calledWithExactly(
+          'DEFAULT', [{'webviewName': 'DEFAULT'}, {'webviewName': 'WV'}, {'webviewName': 'ANOTHER'}]).should.be.true;
       driver.curContext.should.be.equal('DEFAULT');
     });
     it('should switch to default web view if name is WEBVIEW', async function () {
       sandbox.stub(driver, 'defaultWebviewName').returns('WV');
       await driver.setContext(WEBVIEW_WIN);
-      driver.switchContext.calledWithExactly('WV', ['DEFAULT', 'WV', 'ANOTHER']).should.be.true;
+      driver.switchContext.calledWithExactly(
+          'WV', [{'webviewName': 'DEFAULT'}, {'webviewName': 'WV'}, {'webviewName': 'ANOTHER'}]).should.be.true;
       driver.curContext.should.be.equal('WV');
     });
     it('should throw error if context does not exist', async function () {

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -55,7 +55,7 @@ describe('Context', function () {
       expect(await driver.getContexts()).to.include(CHROMIUM_WIN);
     });
     it('should use ADB to figure out which webviews are available', async function () {
-      sandbox.stub(webviewHelpers, 'getWebviews');
+      sandbox.stub(webviewHelpers, 'getWebviews').returns(['DEFAULT', 'VW', 'ANOTHER']);
       sandbox.stub(webviewHelpers, 'getWebViewsMapping');
       expect(await driver.getContexts()).to.not.include(CHROMIUM_WIN);
       webviewHelpers.getWebviews.calledOnce.should.be.true;

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -24,7 +24,7 @@ describe('Webview Helpers', function () {
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
         });
         const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'webview_devtools_remote_123'});
-        webViews = helpers.getWebviews(webviewsMapping);
+        webViews = helpers.parseWebviewNames(webviewsMapping);
       });
 
       it('then the unix sockets are queried', function () {
@@ -51,7 +51,7 @@ describe('Webview Helpers', function () {
         });
 
         const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'chrome_devtools_remote'});
-        webViews = helpers.getWebviews(webviewsMapping);
+        webViews = helpers.parseWebviewNames(webviewsMapping);
       });
 
       it('then the unix sockets are queried', function () {
@@ -77,7 +77,7 @@ describe('Webview Helpers', function () {
         });
 
         const webviewsMapping = await helpers.getWebViewsMapping(adb);
-        webViews = helpers.getWebviews(webviewsMapping);
+        webViews = helpers.parseWebviewNames(webviewsMapping);
       });
 
       it('then the unix sockets are queried', function () {
@@ -106,7 +106,7 @@ describe('Webview Helpers', function () {
       describe('and the device socket is not specified', function () {
         beforeEach(async function () {
           const webviewsMapping = await helpers.getWebViewsMapping(adb);
-          webViews = helpers.getWebviews(webviewsMapping);
+          webViews = helpers.parseWebviewNames(webviewsMapping);
         });
 
         it('then the unix sockets are queried', function () {
@@ -123,7 +123,7 @@ describe('Webview Helpers', function () {
       describe('and the device socket is specified', function () {
         beforeEach(async function () {
           const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'com.application.myapp_devtools_remote'});
-          webViews = helpers.getWebviews(webviewsMapping);
+          webViews = helpers.parseWebviewNames(webviewsMapping);
         });
 
         it('then the unix sockets are queried', function () {
@@ -140,7 +140,7 @@ describe('Webview Helpers', function () {
       describe('and the device socket is specified but is not found', function () {
         beforeEach(async function () {
           const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'com.application.myotherapp_devtools_remote'});
-          webViews = helpers.getWebviews(webviewsMapping);
+          webViews = helpers.parseWebviewNames(webviewsMapping);
         });
 
         it('then the unix sockets are queried', function () {

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -23,8 +23,8 @@ describe('Webview Helpers', function () {
                 '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @webview_devtools_remote_123\n' +
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
         });
-
-        webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'webview_devtools_remote_123'});
+        const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'webview_devtools_remote_123'});
+        webViews = helpers.getWebviews(webviewsMapping);
       });
 
       it('then the unix sockets are queried', function () {
@@ -50,7 +50,8 @@ describe('Webview Helpers', function () {
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
         });
 
-        webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'chrome_devtools_remote'});
+        const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'chrome_devtools_remote'});
+        webViews = helpers.getWebviews(webviewsMapping);
       });
 
       it('then the unix sockets are queried', function () {
@@ -75,7 +76,8 @@ describe('Webview Helpers', function () {
                 '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
         });
 
-        webViews = await helpers.getWebviews(adb);
+        const webviewsMapping = await helpers.getWebViewsMapping(adb);
+        webViews = helpers.getWebviews(webviewsMapping);
       });
 
       it('then the unix sockets are queried', function () {
@@ -103,7 +105,8 @@ describe('Webview Helpers', function () {
 
       describe('and the device socket is not specified', function () {
         beforeEach(async function () {
-          webViews = await helpers.getWebviews(adb);
+          const webviewsMapping = await helpers.getWebViewsMapping(adb);
+          webViews = helpers.getWebviews(webviewsMapping);
         });
 
         it('then the unix sockets are queried', function () {
@@ -119,7 +122,8 @@ describe('Webview Helpers', function () {
 
       describe('and the device socket is specified', function () {
         beforeEach(async function () {
-          webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'com.application.myapp_devtools_remote'});
+          const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'com.application.myapp_devtools_remote'});
+          webViews = helpers.getWebviews(webviewsMapping);
         });
 
         it('then the unix sockets are queried', function () {
@@ -135,7 +139,8 @@ describe('Webview Helpers', function () {
 
       describe('and the device socket is specified but is not found', function () {
         beforeEach(async function () {
-          webViews = await helpers.getWebviews(adb, {androidDeviceSocket: 'com.application.myotherapp_devtools_remote'});
+          const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'com.application.myotherapp_devtools_remote'});
+          webViews = helpers.getWebviews(webviewsMapping);
         });
 
         it('then the unix sockets are queried', function () {


### PR DESCRIPTION
When setting WEBVIEW_chrome context, appium-android-driver assumes that an AUT is com.android.chrome.
It is correct in most cases. However, it can be wrong when it comes to testing Chrome beta, etc.

In this PR, I would like to provide a way to test Android Chrome beta under web context.
