### PR TITLE
fix: Prefer file-based lock to acquire devtools port

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import logger from './logger';
 import axios from 'axios';
 import { util } from 'appium-support';
-import { findAPortNotInUse } from 'portscanner';
+import { findAPortNotInUse, checkPortStatus } from 'portscanner';
 import LRU from 'lru-cache';
 import B from 'bluebird';
 import path from 'path';
@@ -155,6 +155,11 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
   if (webviewDevtoolsPort) {
     logger.debug(`Forwarding remote port ${remotePort} to local ` +
       `webviewDevtoolsPort ${webviewDevtoolsPort}`);
+    if ((await checkPortStatus(webviewDevtoolsPort, '127.0.0.1')) === 'open') {
+      logger.errorAndThrow(`The Devtools client cannot start because the local ` +
+        `port #${webviewDevtoolsPort} is busy. Make sure the port number you ` +
+        `provide via 'webviewDevtoolsPort' capability is free`);
+    }
     await adb.adbExec(['forward', `tcp:${webviewDevtoolsPort}`, `localabstract:${remotePort}`]);
     return webviewDevtoolsPort;
   }

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -149,13 +149,19 @@ async function webviewsFromProcs (adb, deviceSocket = null) {
  * @throws {Error} If there was an error while allocating the local port
  */
 async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null) {
-  const startPort = webviewDevtoolsPort || DEVTOOLS_PORTS_RANGE[0];
-  const endPort = startPort + DEVTOOLS_PORTS_RANGE[1] - DEVTOOLS_PORTS_RANGE[0];
   // socket names come with '@', but this should not be a part of the abstract
   // remote port, so remove it
   const remotePort = socketName.replace(/^@/, '');
+  if (webviewDevtoolsPort) {
+    logger.debug(`Forwarding remote port ${remotePort} to local ` +
+      `webviewDevtoolsPort ${webviewDevtoolsPort}`);
+    await adb.adbExec(['forward', `tcp:${webviewDevtoolsPort}`, `localabstract:${remotePort}`]);
+    return webviewDevtoolsPort;
+  }
+
   return await DEVTOOLS_PORT_ALLOCATION_GUARD(async () => {
     let localPort;
+    const [startPort, endPort] = DEVTOOLS_PORTS_RANGE;
     try {
       localPort = await findAPortNotInUse(startPort, endPort);
     } catch (e) {
@@ -163,6 +169,8 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
         `in range ${startPort}..${endPort}. You could set the starting port number ` +
         `manually by providing the 'webviewDevtoolsPort' capability`);
     }
+    logger.debug(`Forwarding remote port ${remotePort} to local ` +
+      `webviewDevtoolsPort ${localPort}`);
     await adb.adbExec(['forward', `tcp:${localPort}`, `localabstract:${remotePort}`]);
     return localPort;
   });

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -3,9 +3,10 @@ import logger from './logger';
 import axios from 'axios';
 import { util } from 'appium-support';
 import { findAPortNotInUse } from 'portscanner';
-import AsyncLock from 'async-lock';
 import LRU from 'lru-cache';
 import B from 'bluebird';
+import path from 'path';
+import os from 'os';
 
 const NATIVE_WIN = 'NATIVE_APP';
 const WEBVIEW_WIN = 'WEBVIEW';
@@ -24,12 +25,15 @@ const KNOWN_CHROME_PACKAGE_NAMES = [
   'com.chrome.canary',
 ];
 const DEVTOOLS_PORTS_RANGE = [10900, 11000];
-const PORT_ALLOCATION_GUARD = new AsyncLock();
 const WEBVIEWS_DETAILS_CACHE = new LRU({
   max: 100,
   updateAgeOnGet: true,
 });
 const CDP_REQ_TIMEOUT = 2000; // ms
+const DEVTOOLS_PORT_ALLOCATION_GUARD = util.getLockFileGuard(
+  path.resolve(os.tmpdir(), 'android_devtools_port_guard'),
+  {timeout: 7, tryRecovery: true}
+);
 
 const helpers = {};
 
@@ -145,20 +149,20 @@ async function webviewsFromProcs (adb, deviceSocket = null) {
  * @throws {Error} If there was an error while allocating the local port
  */
 async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null) {
-  return await PORT_ALLOCATION_GUARD.acquire('DevtoolsPortAllocator', async () => {
-    const startPort = webviewDevtoolsPort || DEVTOOLS_PORTS_RANGE[0];
-    const endPort = startPort + DEVTOOLS_PORTS_RANGE[1] - DEVTOOLS_PORTS_RANGE[0];
+  const startPort = webviewDevtoolsPort || DEVTOOLS_PORTS_RANGE[0];
+  const endPort = startPort + DEVTOOLS_PORTS_RANGE[1] - DEVTOOLS_PORTS_RANGE[0];
+  // socket names come with '@', but this should not be a part of the abstract
+  // remote port, so remove it
+  const remotePort = socketName.replace(/^@/, '');
+  return await DEVTOOLS_PORT_ALLOCATION_GUARD(async () => {
     let localPort;
     try {
       localPort = await findAPortNotInUse(startPort, endPort);
     } catch (e) {
       throw new Error(`Cannot find any free port to forward the devtools socket ` +
-        `in range ${startPort}..${endPort}}. You can set the starting port number ` +
+        `in range ${startPort}..${endPort}. You could set the starting port number ` +
         `manually by providing the 'webviewDevtoolsPort' capability`);
     }
-    // socket names come with '@', but this should not be a part of the abstract
-    // remote port, so remove it
-    const remotePort = socketName.replace(/^@/, '');
     await adb.adbExec(['forward', `tcp:${localPort}`, `localabstract:${remotePort}`]);
     return localPort;
   });

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -158,8 +158,11 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
     startPort = webviewDevtoolsPort;
   }
   logger.debug(`Forwarding remote port ${remotePort} to a local ` +
-    `port in range ${startPort}..${endPort}. Use the 'webviewDevtoolsPort' ` +
-    `capability to customize the starting port number`);
+    `port in range ${startPort}..${endPort}`);
+  if (!webviewDevtoolsPort) {
+    logger.debug(`You could use the 'webviewDevtoolsPort' capability to customize ` +
+      `the starting port number`);
+  }
   return await DEVTOOLS_PORT_ALLOCATION_GUARD(async () => {
     let localPort;
     try {

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -158,7 +158,8 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
     startPort = webviewDevtoolsPort;
   }
   logger.debug(`Forwarding remote port ${remotePort} to a local ` +
-    `port in range ${startPort}..${endPort}`);
+    `port in range ${startPort}..${endPort}. Use the 'webviewDevtoolsPort' ` +
+    `capability to customize the starting port number`);
   return await DEVTOOLS_PORT_ALLOCATION_GUARD(async () => {
     let localPort;
     try {

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import logger from './logger';
 import axios from 'axios';
 import { util } from 'appium-support';
-import { findAPortNotInUse, checkPortStatus } from 'portscanner';
+import { findAPortNotInUse } from 'portscanner';
 import LRU from 'lru-cache';
 import B from 'bluebird';
 import path from 'path';
@@ -152,30 +152,22 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
   // socket names come with '@', but this should not be a part of the abstract
   // remote port, so remove it
   const remotePort = socketName.replace(/^@/, '');
+  let [startPort, endPort] = DEVTOOLS_PORTS_RANGE;
   if (webviewDevtoolsPort) {
-    logger.debug(`Forwarding remote port ${remotePort} to local ` +
-      `webviewDevtoolsPort ${webviewDevtoolsPort}`);
-    if ((await checkPortStatus(webviewDevtoolsPort, '127.0.0.1')) === 'open') {
-      throw new Error(`The Devtools client cannot start because the local ` +
-        `port #${webviewDevtoolsPort} is busy. Make sure the port number you ` +
-        `provide via 'webviewDevtoolsPort' capability is free`);
-    }
-    await adb.adbExec(['forward', `tcp:${webviewDevtoolsPort}`, `localabstract:${remotePort}`]);
-    return webviewDevtoolsPort;
+    endPort = webviewDevtoolsPort + (endPort - startPort);
+    startPort = webviewDevtoolsPort;
   }
-
+  logger.debug(`Forwarding remote port ${remotePort} to a local ` +
+    `port in range ${startPort}..${endPort}`);
   return await DEVTOOLS_PORT_ALLOCATION_GUARD(async () => {
     let localPort;
-    const [startPort, endPort] = DEVTOOLS_PORTS_RANGE;
     try {
       localPort = await findAPortNotInUse(startPort, endPort);
     } catch (e) {
-      throw new Error(`Cannot find any free port to forward the devtools socket ` +
+      throw new Error(`Cannot find any free port to forward the Devtools socket ` +
         `in range ${startPort}..${endPort}. You could set the starting port number ` +
         `manually by providing the 'webviewDevtoolsPort' capability`);
     }
-    logger.debug(`Forwarding remote port ${remotePort} to local ` +
-      `webviewDevtoolsPort ${localPort}`);
     await adb.adbExec(['forward', `tcp:${localPort}`, `localabstract:${remotePort}`]);
     return localPort;
   });

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -142,7 +142,7 @@ async function webviewsFromProcs (adb, deviceSocket = null) {
  *
  * @param {ADB} adb ADB instance
  * @param {string} socketName The remote Unix socket name
- * @param {?string|number} webviewDevtoolsPort The local port number or null to apply
+ * @param {?number} webviewDevtoolsPort The local port number or null to apply
  * autodetection
  * @returns {number} The local port number if the remote socket has been forwarded
  * successfully or `null` otherwise

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -156,7 +156,7 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
     logger.debug(`Forwarding remote port ${remotePort} to local ` +
       `webviewDevtoolsPort ${webviewDevtoolsPort}`);
     if ((await checkPortStatus(webviewDevtoolsPort, '127.0.0.1')) === 'open') {
-      logger.errorAndThrow(`The Devtools client cannot start because the local ` +
+      throw new Error(`The Devtools client cannot start because the local ` +
         `port #${webviewDevtoolsPort} is busy. Make sure the port number you ` +
         `provide via 'webviewDevtoolsPort' capability is free`);
     }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "appium-base-driver": "^7.0.0",
     "appium-chromedriver": "^4.13.0",
     "appium-support": "^2.47.1",
-    "async-lock": "^1.2.2",
     "asyncbox": "^2.8.0",
     "axios": "^0.x",
     "bluebird": "^3.4.7",


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/15390#issuecomment-868864881

I still wouldn't rely on the automated port detection thing though and advice to set the `webviewDevtoolsPort` value manually for each parallel session though.