### PR TITLE
feat: Add a possibility to send an intent broadcast with a mobile command

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -52,6 +52,7 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
     startService: 'mobileStartService',
     stopService: 'mobileStopService',
     startActivity: 'mobileStartActivity',
+    broadcast: 'mobileBroadcast',
 
     getContexts: 'mobileGetContexts',
   };

--- a/lib/commands/intent.js
+++ b/lib/commands/intent.js
@@ -10,16 +10,9 @@ const API_LEVEL_ANDROID_8 = 26;
 
 const commands = {};
 
-function requireOptions (opts, requiredKeys = []) {
-  const missingKeys = _.difference(requiredKeys, _.keys(opts));
-  if (!_.isEmpty(missingKeys)) {
-    throw new errors.InvalidArgumentError(`The following options are required: ${missingKeys}`);
-  }
-  return opts;
-}
-
-function parseCommonIntentArguments (opts = {}) {
+function parseIntentSpec (opts = {}) {
   const {
+    intent,
     action,
     uri,
     mimeType,
@@ -30,6 +23,9 @@ function parseCommonIntentArguments (opts = {}) {
     flags,
   } = opts;
   const resultArgs = [];
+  if (intent) {
+    resultArgs.push(intent);
+  }
   if (action) {
     resultArgs.push('-a', action);
   }
@@ -86,8 +82,6 @@ function parseCommonIntentArguments (opts = {}) {
 
 /**
  * @typedef {Object} StartActivityOptions
- * @property {!string} intent - The name of the activity intent to start, for example
- * `com.some.package.name/.YourServiceSubClassName`. This option is mandatory.
  * @property {?string|number} user ['current'] - The user ID for which the service is started.
  * The `current` user id is used by default
  * @property {?boolean} wait [false] - Set it to `true` if you want to block the method call
@@ -101,6 +95,8 @@ function parseCommonIntentArguments (opts = {}) {
  * Check https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/app/WindowConfiguration.java
  * for more details on possible activity types (constants starting with `ACTIVITY_TYPE_`).
  * @property {?number|string} display - The display identifier to launch the activity into.
+ * @property {?string} intent - The name of the activity intent to start, for example
+ * `com.some.package.name/.YourServiceSubClassName`
  * @property {?string} action - Action name
  * @property {?string} uri - Unified resource identifier
  * @property {?string} mimeType - Mime type
@@ -147,14 +143,13 @@ function parseCommonIntentArguments (opts = {}) {
  */
 commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
   const {
-    intent,
     user,
     wait,
     stop,
     windowingMode,
     activityType,
     display,
-  } = requireOptions(opts, ['intent']);
+  } = opts;
   const cmd = [
     'am', (await this.adb.getApiLevel() < API_LEVEL_ANDROID_8) ? 'start' : 'start-activity',
   ];
@@ -176,54 +171,77 @@ commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
   if (!_.isNil(display)) {
     cmd.push('--display', display);
   }
-  cmd.push(...(parseCommonIntentArguments(opts)));
-  cmd.push(intent);
+  cmd.push(...(parseIntentSpec(opts)));
   return await this.adb.shell(cmd);
 };
 
 /**
- * @typedef {Object} StartServiceOptions
- * @property {!string} intent - The name of the service intent to start, for example
- * `com.some.package.name/.YourServiceSubClassName`. This option is mandatory.
- * @property {?string|number} user ['current'] - The user ID for which the service is started.
- * The `current` user id is used by default
- * @property {?boolean} foreground [false] - Set it to `true` if your service must be
- * started as foreground service. This option is ignored if the API level of the
- * device under test is below 26 (Android 8).
+ * @typedef {Object} BroadcastOptions
+ * @property {?string|number} user ['all'] - The user ID for which the broadcast is sent.
+ * The `current` alias assumes the current user ID.
+ * @property {?string} receiverPermission - Require receiver to hold the given permission.
+ * @property {?string} intent - The name of the intent to broadcast to, for example
+ * `com.some.package.name/.YourServiceSubClassName`.
  * @property {?string} action - Action name
  * @property {?string} uri - Unified resource identifier
  * @property {?string} mimeType - Mime type
  * @property {?string} identifier - Optional identifier
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
- * @property {Array<string|Array<string>>} extras - Optional intent arguments. Must be represented
- * as array of arrays, where each subarray item contains two items: value type and the value itself.
- * Supported value types are:
- * - s: string. Value must be a valid string
- * - sn: null. Value is ignored for this type
- * - z: boolean. Value must be either `true` or `false`
- * - i: integer. Value must be a valid 4-byte integer number
- * - l: long. Value must be a valid 8-byte long number
- * - f: float: Value must be a valid float number
- * - u: uri. Value must be a valid uniform resource identifier string
- * - cn: component name. Value must be a valid component name string
- * - ia: Integer[]. Value must be a string of comma-separated integers
- * - ial: List<Integer>. Value must be a string of comma-separated integers
- * - la: Long[]. Value must be a string of comma-separated long numbers
- * - lal: List<Long>. Value must be a string of comma-separated long numbers
- * - fa: Float[]. Value must be a string of comma-separated float numbers
- * - fal: List<Float>. Value must be a string of comma-separated float numbers
- * - sa: String[]. Value must be comma-separated strings. To embed a comma into a string,
- * escape it using "\,"
- * - sal: List<String>. Value must be comma-separated strings. To embed a comma into a string,
- * escape it using "\,"
- * For example: [['s', 'My String1'], ['s', 'My String2'], ['ia', '1,2,3,4']]
+ * @property {Array<string|Array<string>>} extras - Optional intent arguments.
+ * See above for the detailed description.
  * @property {?string} flags - Intent startup-specific flags as a hexadecimal string.
- * See https://developer.android.com/reference/android/content/Intent.html
- * for the list of available flag values (constants starting with FLAG_ACTIVITY_).
- * Flag values could be merged using the logical 'or' operation.
- * For example, 0x10200000 is the combination of two flags:
- * 0x10000000 `FLAG_ACTIVITY_NEW_TASK` | 0x00200000 `FLAG_ACTIVITY_RESET_TASK_IF_NEEDED`
+ * See above for the detailed description.
+ */
+
+
+/**
+ * Send a broadcast intent.
+ *
+ * @param {BroadcastOptions} opts
+ * @returns {string} The command output
+ * @throws {Error} If there was a failure while starting the activity
+ * or required options are missing
+ */
+commands.mobileBroadcast = async function mobileBroadcast (opts = {}) {
+  const {
+    user,
+    receiverPermission,
+    allowBackgroundActivityStarts,
+  } = opts;
+  const cmd = ['am', 'broadcast'];
+  if (!_.isNil(user)) {
+    cmd.push('--user', user);
+  }
+  if (receiverPermission) {
+    cmd.push('--receiver-permission', receiverPermission);
+  }
+  if (allowBackgroundActivityStarts) {
+    cmd.push('--allow-background-activity-starts');
+  }
+  cmd.push(...(parseIntentSpec(opts)));
+  return await this.adb.shell(cmd);
+};
+
+/**
+ * @typedef {Object} StartServiceOptions
+ * @property {?string|number} user ['current'] - The user ID for which the service is started.
+ * The `current` user id is used by default
+ * @property {?boolean} foreground [false] - Set it to `true` if your service must be
+ * started as foreground service. This option is ignored if the API level of the
+ * device under test is below 26 (Android 8).
+ * @property {?string} intent - The name of the service intent to start, for example
+ * `com.some.package.name/.YourServiceSubClassName`.
+ * @property {?string} action - Action name
+ * @property {?string} uri - Unified resource identifier
+ * @property {?string} mimeType - Mime type
+ * @property {?string} identifier - Optional identifier
+ * @property {?string|Array<string>} categories - One or more category names
+ * @property {?string} component - Component name
+ * @property {Array<string|Array<string>>} extras - Optional intent arguments.
+ * See above for the detailed description.
+ * @property {?string} flags - Intent startup-specific flags as a hexadecimal string.
+ * See above for the detailed description.
  */
 
 /**
@@ -236,10 +254,9 @@ commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
  */
 commands.mobileStartService = async function mobileStartService (opts = {}) {
   const {
-    intent,
     user,
     foreground,
-  } = requireOptions(opts, ['intent']);
+  } = opts;
   const cmd = ['am'];
   if (await this.adb.getApiLevel() < API_LEVEL_ANDROID_8) {
     cmd.push('startservice');
@@ -249,17 +266,25 @@ commands.mobileStartService = async function mobileStartService (opts = {}) {
   if (!_.isNil(user)) {
     cmd.push('--user', user);
   }
-  cmd.push(...(parseCommonIntentArguments(opts)));
-  cmd.push(intent);
+  cmd.push(...(parseIntentSpec(opts)));
   return await this.adb.shell(cmd);
 };
 
 /**
  * @typedef {Object} StopServiceOptions
- * @property {!string} intent - The name of the service intent to stop, for example
- * `com.some.package.name/.YourServiceSubClassName`. This option is mandatory.
  * @property {string|number} user ['current'] - The user ID for which the service is running.
  * The `current` user id is used by default
+ * @property {?string} intent - The name of the service intent to stop, for example
+ * `com.some.package.name/.YourServiceSubClassName`.
+ * @property {?string} action - Action name
+ * @property {?string} uri - Unified resource identifier
+ * @property {?string} mimeType - Mime type
+ * @property {?string} identifier - Optional identifier
+ * @property {?string|Array<string>} categories - One or more category names
+ * @property {?string} component - Component name
+ * @property {Array<string|Array<string>>} extras - Optional intent arguments.
+ * See above for the detailed description.
+ * @property {?string} flags - See above for the detailed description.
  */
 
 /**
@@ -272,9 +297,8 @@ commands.mobileStartService = async function mobileStartService (opts = {}) {
  */
 commands.mobileStopService = async function mobileStopService (opts = {}) {
   const {
-    intent,
     user,
-  } = requireOptions(opts, ['intent']);
+  } = opts;
   const cmd = [
     'am',
     (await this.adb.getApiLevel() < API_LEVEL_ANDROID_8) ? 'stopservice' : 'stop-service'
@@ -282,8 +306,7 @@ commands.mobileStopService = async function mobileStopService (opts = {}) {
   if (!_.isNil(user)) {
     cmd.push('--user', user);
   }
-  cmd.push(...(parseCommonIntentArguments(opts)));
-  cmd.push(intent);
+  cmd.push(...(parseIntentSpec(opts)));
   return await this.adb.shell(cmd);
 };
 


### PR DESCRIPTION
Also refactored existing intent-based helpers, so the intent name is not required anymore since `am` also allows to also provide the target name as a combination of `-a`/`-n` arguments