### PR TITLE
fix: Parsing of extra arguments

### DIFF
--- a/lib/commands/intent.js
+++ b/lib/commands/intent.js
@@ -53,24 +53,30 @@ function parseIntentSpec (opts = {}) {
       throw new errors.InvalidArgumentError(`'extras' must be an array`);
     }
     for (const item of extras) {
-      let type;
-      let value;
-      if (_.isArray(item)) {
-        [type, value] = item;
-      } else {
-        type = item;
+      if (!_.isArray(item)) {
+        throw new errors.InvalidArgumentError(`Extra argument '${item}' must be an array`);
       }
+      const [type, key, value] = item;
       if (!_.includes(SUPPORTED_EXTRA_TYPES, type)) {
-        throw new errors.InvalidArgumentError(`Intent argument type '${type}' is not known. ` +
-          `Supported intent argument types are: ${SUPPORTED_EXTRA_TYPES}`);
+        throw new errors.InvalidArgumentError(
+          `Extra argument type '${type}' is not known. ` +
+          `Supported intent argument types are: ${SUPPORTED_EXTRA_TYPES}`
+        );
+      }
+      if (_.isEmpty(key) || (_.isString(key) && _.trim(key) === '')) {
+        throw new errors.InvalidArgumentError(
+          `Extra argument's key in '${JSON.stringify(item)}' must be a valid string identifier`
+        );
       }
       if (type === NO_VALUE_ARG_TYPE) {
-        resultArgs.push(`--e${type}`);
+        resultArgs.push(`--e${type}`, key);
       } else if (_.isUndefined(value)) {
-        throw new errors.InvalidArgumentError(`Intent argument type '${type}' requires a ` +
-          `value to be provided`);
+        throw new errors.InvalidArgumentError(
+          `Intent argument type '${type}' in '${JSON.stringify(item)}' requires a ` +
+          `valid value to be provided`
+        );
       } else {
-        resultArgs.push(`--e${type}`, value);
+        resultArgs.push(`--e${type}`, key, value);
       }
     }
   }
@@ -104,7 +110,8 @@ function parseIntentSpec (opts = {}) {
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
  * @property {Array<string|Array<string>>} extras - Optional intent arguments. Must be represented
- * as array of arrays, where each subarray item contains two items: value type and the value itself.
+ * as array of arrays, where each subarray item contains two or three string items:
+ * value type, key name and the value itself.
  * Supported value types are:
  * - s: string. Value must be a valid string
  * - sn: null. Value is ignored for this type
@@ -124,7 +131,7 @@ function parseIntentSpec (opts = {}) {
  * escape it using "\,"
  * - sal: List<String>. Value must be comma-separated strings. To embed a comma into a string,
  * escape it using "\,"
- * For example: [['s', 'My String1'], ['s', 'My String2'], ['ia', '1,2,3,4']]
+ * For example: [['s', 'varName1', 'My String1'], ['s', 'varName2', 'My String2'], ['ia', 'arrName', '1,2,3,4']]
  * @property {?string} flags - Intent startup-specific flags as a hexadecimal string.
  * See https://developer.android.com/reference/android/content/Intent.html
  * for the list of available flag values (constants starting with FLAG_ACTIVITY_).
@@ -188,7 +195,7 @@ commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
  * @property {?string} identifier - Optional identifier
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
- * @property {Array<string|Array<string>>} extras - Optional intent arguments.
+ * @property {Array<Array<string>>} extras - Optional intent arguments.
  * See above for the detailed description.
  * @property {?string} flags - Intent startup-specific flags as a hexadecimal string.
  * See above for the detailed description.
@@ -238,7 +245,7 @@ commands.mobileBroadcast = async function mobileBroadcast (opts = {}) {
  * @property {?string} identifier - Optional identifier
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
- * @property {Array<string|Array<string>>} extras - Optional intent arguments.
+ * @property {Array<Array<string>>} extras - Optional intent arguments.
  * See above for the detailed description.
  * @property {?string} flags - Intent startup-specific flags as a hexadecimal string.
  * See above for the detailed description.
@@ -282,7 +289,7 @@ commands.mobileStartService = async function mobileStartService (opts = {}) {
  * @property {?string} identifier - Optional identifier
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
- * @property {Array<string|Array<string>>} extras - Optional intent arguments.
+ * @property {Array<Array<string>>} extras - Optional intent arguments.
  * See above for the detailed description.
  * @property {?string} flags - See above for the detailed description.
  */


### PR DESCRIPTION
I forgot about key names presence requirement for extras. Now it's fixed