### PR TITLE
feat: Add package option to the broadcast extension

### DIFF
--- a/lib/commands/intent.js
+++ b/lib/commands/intent.js
@@ -48,6 +48,9 @@ function parseIntentSpec (opts = {}) {
   if (component) {
     resultArgs.push('-n', component);
   }
+  if (opts.package) {
+    resultArgs.push('-p', opts.package);
+  }
   if (extras) {
     if (!_.isArray(extras)) {
       throw new errors.InvalidArgumentError(`'extras' must be an array`);
@@ -104,6 +107,7 @@ function parseIntentSpec (opts = {}) {
  * @property {?string} intent - The name of the activity intent to start, for example
  * `com.some.package.name/.YourServiceSubClassName`
  * @property {?string} action - Action name
+ * @property {?string} package - Package name
  * @property {?string} uri - Unified resource identifier
  * @property {?string} mimeType - Mime type
  * @property {?string} identifier - Optional identifier
@@ -187,6 +191,8 @@ commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
  * @property {?string|number} user ['all'] - The user ID for which the broadcast is sent.
  * The `current` alias assumes the current user ID.
  * @property {?string} receiverPermission - Require receiver to hold the given permission.
+ * @property {?boolean} allowBackgroundActivityStarts [false] - Whether the receiver may
+ * start activities even if in the background.
  * @property {?string} intent - The name of the intent to broadcast to, for example
  * `com.some.package.name/.YourServiceSubClassName`.
  * @property {?string} action - Action name
@@ -195,6 +201,7 @@ commands.mobileStartActivity = async function mobileStartActivity (opts = {}) {
  * @property {?string} identifier - Optional identifier
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
+ * @property {?string} package - Package name
  * @property {Array<Array<string>>} extras - Optional intent arguments.
  * See above for the detailed description.
  * @property {?string} flags - Intent startup-specific flags as a hexadecimal string.
@@ -245,6 +252,7 @@ commands.mobileBroadcast = async function mobileBroadcast (opts = {}) {
  * @property {?string} identifier - Optional identifier
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
+ * @property {?string} package - Package name
  * @property {Array<Array<string>>} extras - Optional intent arguments.
  * See above for the detailed description.
  * @property {?string} flags - Intent startup-specific flags as a hexadecimal string.
@@ -289,6 +297,7 @@ commands.mobileStartService = async function mobileStartService (opts = {}) {
  * @property {?string} identifier - Optional identifier
  * @property {?string|Array<string>} categories - One or more category names
  * @property {?string} component - Component name
+ * @property {?string} package - Package name
  * @property {Array<Array<string>>} extras - Optional intent arguments.
  * See above for the detailed description.
  * @property {?string} flags - See above for the detailed description.


### PR DESCRIPTION
Not sure why, but the `-p` argument of `broadcast` is not documented in the `am` output. Perhaps, it was deprecated in the recent toolkit releases?