### PR TITLE
refactor: Add chromeLoggingPrefs to the list of desired capabilities

### DIFF
--- a/lib/desired-caps.js
+++ b/lib/desired-caps.js
@@ -114,6 +114,9 @@ let commonCapConstraints = {
   chromedriverDisableBuildCheck: {
     isBoolean: true
   },
+  chromeLoggingPrefs: {
+    isObject: true
+  },
   autoWebviewTimeout: {
     isNumber: true
   },

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -517,17 +517,20 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
   // add device id from adb
   caps.chromeOptions.androidDeviceSerial = deviceId;
 
-  if (opts.loggingPrefs) {
-    caps.loggingPrefs = opts.loggingPrefs;
+  if (_.isPlainObject(opts.loggingPrefs) || _.isPlainObject(opts.chromeLoggingPrefs)) {
+    if (opts.loggingPrefs) {
+      logger.warn(`The 'loggingPrefs' cap is deprecated; use the 'chromeLoggingPrefs' cap instead`);
+    }
+    caps.loggingPrefs = opts.chromeLoggingPrefs || opts.loggingPrefs;
   }
   if (opts.enablePerformanceLogging) {
     logger.warn(`The 'enablePerformanceLogging' cap is deprecated; simply use ` +
-      `the 'loggingPrefs' cap instead, with a 'performance' key set to 'ALL'`);
+      `the 'chromeLoggingPrefs' cap instead, with a 'performance' key set to 'ALL'`);
     const newPref = {performance: 'ALL'};
     // don't overwrite other logging prefs that have been sent in if they exist
-    caps.loggingPrefs = caps.loggingPrefs ?
-      Object.assign({}, caps.loggingPrefs, newPref) :
-      newPref;
+    caps.loggingPrefs = caps.loggingPrefs
+      ? Object.assign({}, caps.loggingPrefs, newPref)
+      : newPref;
   }
 
   if (opts.chromeOptions?.Arguments) {


### PR DESCRIPTION
Currently the `loggingPrefs` capability is not exposed through desired capabilities list. Also I think its current name is confusing, since it only affects chromedriver context, so I've changed it to `chromeLoggingPrefs` instead.