### PR TITLE
fix: Update parse memory data for Android 11(API 30)

### DIFF
--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -8,7 +8,7 @@ let commands = {}, helpers = {}, extensions = {};
 const NETWORK_KEYS = [['bucketStart', 'activeTime', 'rxBytes', 'rxPackets', 'txBytes', 'txPackets', 'operations', 'bucketDuration'], ['st', 'activeTime', 'rb', 'rp', 'tb', 'tp', 'op', 'bucketDuration']];
 const CPU_KEYS = ['user', 'kernel'];
 const BATTERY_KEYS = ['power'];
-const MEMORY_KEYS = ['totalPrivateDirty', 'nativePrivateDirty', 'dalvikPrivateDirty', 'eglPrivateDirty', 'glPrivateDirty', 'totalPss', 'nativePss', 'dalvikPss', 'eglPss', 'glPss', 'nativeHeapAllocatedSize', 'nativeHeapSize'];
+const MEMORY_KEYS = ['totalPrivateDirty', 'nativePrivateDirty', 'dalvikPrivateDirty', 'eglPrivateDirty', 'glPrivateDirty', 'totalPss', 'nativePss', 'dalvikPss', 'eglPss', 'glPss', 'nativeHeapAllocatedSize', 'nativeHeapSize', 'nativeRss', 'dalvikRss', 'totalRss'];
 
 const SUPPORTED_PERFORMANCE_DATA_TYPES = {
   cpuinfo: 'the amount of cpu by user and kernel process - cpu information for applications on real devices and simulators',
@@ -113,22 +113,25 @@ helpers.getMemoryInfo = async function getMemoryInfo (packageName, dataReadTimeo
     let data = await this.adb.shell(cmd);
     if (!data) throw new Error('No data from dumpsys'); //eslint-disable-line curly
 
-    let totalPrivateDirty, totalPss,
-        nativePrivateDirty, nativePss, nativeHeapSize, nativeHeapAllocatedSize,
-        dalvikPrivateDirty, dalvikPss,
+    let totalPrivateDirty, totalPss, totalRss,
+        nativePrivateDirty, nativePss, nativeHeapSize, nativeHeapAllocatedSize, nativeRss,
+        dalvikPrivateDirty, dalvikPss, dalvikRss,
         eglPrivateDirty, eglPss,
         glPrivateDirty, glPss;
     let apilevel = await this.adb.getApiLevel();
     for (let line of data.split('\n')) {
       let entries = line.trim().split(' ').filter(Boolean);
-      // entries will have the values
+      // API level 30 and above
+      //   ['<System Type>', '<Memory Type>', <pss total>, <private dirty>, <private clean>, <swapPss dirty>, <rss total>, <heap size>, <heap alloc>, <heap free>]
+      //
+      // API level between 30 and 18
       //   ['<System Type>', '<Memory Type>', <pss total>, <private dirty>, <private clean>, <swapPss dirty>, <heap size>, <heap alloc>, <heap free>]
       // except 'TOTAL', which skips the second type name
       //
       // and on API level 18 and below
       //   ['<System Type', '<pps>', '<shared dirty>', '<private dirty>', '<heap size>', '<heap alloc>', '<heap free>']
 
-      if (apilevel > 18) {
+      if (apilevel > 18 && apilevel < 30) {
         let type = entries[0];
         let subType = entries[1];
         if (type === 'Native' && subType === 'Heap') {
@@ -153,6 +156,35 @@ helpers.getMemoryInfo = async function getMemoryInfo (packageName, dataReadTimeo
           // there are two totals, and we only want the full listing, which has 8 entries
           totalPss = entries[1];
           totalPrivateDirty = entries[2];
+        }
+      } else if (apilevel >= 30) {
+        let type = entries[0];
+        let subType = entries[1];
+        if (type === 'Native' && subType === 'Heap') {
+          // native heap
+          nativePss = entries[2];
+          nativePrivateDirty = entries[3];
+          nativeRss = entries[6];
+          nativeHeapSize = entries[7];
+          nativeHeapAllocatedSize = entries[8];
+        } else if (type === 'Dalvik' && subType === 'Heap') {
+          // dalvik heap
+          dalvikPss = entries[2];
+          dalvikPrivateDirty = entries[3];
+          dalvikRss = entries[6];
+        } else if (type === 'EGL' && subType === 'mtrack') {
+          // egl
+          eglPss = entries[2];
+          eglPrivateDirty = entries[3];
+        } else if (type === 'GL' && subType === 'mtrack') {
+          // gl
+          glPss = entries[2];
+          glPrivateDirty = entries[3];
+        } else if (type === 'TOTAL' && entries.length === 9) {
+          // which has 9 entries
+          totalPss = entries[1];
+          totalPrivateDirty = entries[2];
+          totalRss = entries[6];
         }
       } else {
         let type = entries[0];
@@ -179,7 +211,7 @@ helpers.getMemoryInfo = async function getMemoryInfo (packageName, dataReadTimeo
 
     if (totalPrivateDirty && totalPrivateDirty !== 'nodex') {
       let headers = _.clone(MEMORY_KEYS);
-      let data = [totalPrivateDirty, nativePrivateDirty, dalvikPrivateDirty, eglPrivateDirty, glPrivateDirty, totalPss, nativePss, dalvikPss, eglPss, glPss, nativeHeapAllocatedSize, nativeHeapSize];
+      let data = [totalPrivateDirty, nativePrivateDirty, dalvikPrivateDirty, eglPrivateDirty, glPrivateDirty, totalPss, nativePss, dalvikPss, eglPss, glPss, nativeHeapAllocatedSize, nativeHeapSize, nativeRss, dalvikRss, totalRss];
       return [headers, data];
     } else {
       throw new Error(`Unable to parse memory data: '${data}'`);


### PR DESCRIPTION
`getPerformanceData()` get memoryinfo  return : Error: Unable to parse memory data  for Android 11(API 30) .

Android 11 (API 30) dumpsys meminfo adds "Rss Total" column before "Heap Size"
