### PR TITLE
fix: Update parse memory data for Android 11(API 30)

### DIFF
--- a/lib/commands/performance.js
+++ b/lib/commands/performance.js
@@ -3,19 +3,31 @@ import { retryInterval } from 'asyncbox';
 import log from '../logger';
 
 
-let commands = {}, helpers = {}, extensions = {};
+let commands = {}, helpers = {}, extensions = {}, memoryParsers = {};
 
 const NETWORK_KEYS = [['bucketStart', 'activeTime', 'rxBytes', 'rxPackets', 'txBytes', 'txPackets', 'operations', 'bucketDuration'], ['st', 'activeTime', 'rb', 'rp', 'tb', 'tp', 'op', 'bucketDuration']];
 const CPU_KEYS = ['user', 'kernel'];
 const BATTERY_KEYS = ['power'];
-const MEMORY_KEYS = ['totalPrivateDirty', 'nativePrivateDirty', 'dalvikPrivateDirty', 'eglPrivateDirty', 'glPrivateDirty', 'totalPss', 'nativePss', 'dalvikPss', 'eglPss', 'glPss', 'nativeHeapAllocatedSize', 'nativeHeapSize'];
-
+const MEMORY_KEYS = ['totalPrivateDirty', 'nativePrivateDirty', 'dalvikPrivateDirty', 'eglPrivateDirty', 'glPrivateDirty',
+  'totalPss', 'nativePss', 'dalvikPss', 'eglPss', 'glPss',
+  'nativeHeapAllocatedSize', 'nativeHeapSize',
+  'nativeRss', 'dalvikRss', 'totalRss'];
 const SUPPORTED_PERFORMANCE_DATA_TYPES = {
   cpuinfo: 'the amount of cpu by user and kernel process - cpu information for applications on real devices and simulators',
   memoryinfo: 'the amount of memory used by the process - memory information for applications on real devices and simulators',
   batteryinfo: 'the remaining battery power - battery power information for applications on real devices and simulators',
   networkinfo: 'the network statistics - network rx/tx information for applications on real devices and simulators'
 };
+const MEMORY_CONSTANT = {
+  NATIVE: 'Native',
+  DALVIK: 'Dalvik',
+  EGL: 'EGL',
+  GL: 'GL',
+  MTRACK: 'mtrack',
+  TOTAL: 'TOTAL',
+  HEAP: 'Heap'
+};
+
 
 const RETRY_PAUSE = 1000;
 
@@ -59,6 +71,59 @@ commands.getPerformanceData = async function getPerformanceData (packageName, da
       throw new Error(`No performance data of type '${dataType}' found.`);
   }
   return data;
+};
+
+// API level 30 and above
+//   ['<System Type>', '<Memory Type>', <pss total>, <private dirty>, <private clean>, <swapPss dirty>, <rss total>, <heap size>, <heap alloc>, <heap free>]
+memoryParsers.Api30AndAbove = function Api30AndAbove (entries, valDict) {
+  const [type, subType] = entries;
+  if (type === MEMORY_CONSTANT.NATIVE && subType === MEMORY_CONSTANT.HEAP) {
+    [,, valDict.nativePss, valDict.nativePrivateDirty,,, valDict.nativeRss, valDict.nativeHeapSize, valDict.nativeHeapAllocatedSize] = entries;
+  } else if (type === MEMORY_CONSTANT.DALVIK && subType === MEMORY_CONSTANT.HEAP) {
+    [,, valDict.dalvikPss, valDict.dalvikPrivateDirty,,, valDict.dalvikRss] = entries;
+  } else if (type === MEMORY_CONSTANT.EGL && subType === MEMORY_CONSTANT.MTRACK) {
+    [,, valDict.eglPss, valDict.eglPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.GL && subType === MEMORY_CONSTANT.MTRACK) {
+    [,, valDict.glPss, valDict.glPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.TOTAL && entries.length === 9) {
+    // has 9 entries
+    [, valDict.totalPss, valDict.totalPrivateDirty,,, valDict.totalRss] = entries;
+  }
+};
+
+// API level between 18 and 30
+//   ['<System Type>', '<Memory Type>', <pss total>, <private dirty>, <private clean>, <swapPss dirty>, <heap size>, <heap alloc>, <heap free>]
+// except 'TOTAL', which skips the second type name
+memoryParsers.Api18And30 = function Api18And30 (entries, valDict) {
+  const [type, subType] = entries;
+  if (type === MEMORY_CONSTANT.NATIVE && subType === MEMORY_CONSTANT.HEAP) {
+    [,, valDict.nativePss, valDict.nativePrivateDirty,,, valDict.nativeHeapSize, valDict.nativeHeapAllocatedSize] = entries;
+  } else if (type === MEMORY_CONSTANT.DALVIK && subType === MEMORY_CONSTANT.HEAP) {
+    [,, valDict.dalvikPss, valDict.dalvikPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.EGL && subType === MEMORY_CONSTANT.MTRACK) {
+    [,, valDict.eglPss, valDict.eglPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.GL && subType === MEMORY_CONSTANT.MTRACK) {
+    [,, valDict.glPss, valDict.glPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.TOTAL && entries.length === 8) {
+    // there are two totals, and we only want the full listing, which has 8 entries
+    [, valDict.totalPss, valDict.totalPrivateDirty] = entries;
+  }
+};
+
+//   ['<System Type', '<pps>', '<shared dirty>', '<private dirty>', '<heap size>', '<heap alloc>', '<heap free>']
+memoryParsers.Api18AndBelow = function Api18AndBelow (entries, valDict) {
+  let type = entries[0];
+  if (type === MEMORY_CONSTANT.NATIVE) {
+    [, valDict.nativePss,, valDict.nativePrivateDirty, valDict.nativeHeapSize, valDict.nativeHeapAllocatedSize] = entries;
+  } else if (type === MEMORY_CONSTANT.DALVIK) {
+    [, valDict.dalvikPss,, valDict.dalvikPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.EGL) {
+    [, valDict.eglPss,, valDict.eglPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.GL) {
+    [, valDict.glPss,, valDict.glPrivateDirty] = entries;
+  } else if (type === MEMORY_CONSTANT.TOTAL) {
+    [, valDict.totalPss,, valDict.totalPrivateDirty] = entries;
+  }
 };
 
 helpers.getCPUInfo = async function getCPUInfo (packageName, dataReadTimeout = 2) {
@@ -112,75 +177,22 @@ helpers.getMemoryInfo = async function getMemoryInfo (packageName, dataReadTimeo
     let cmd = ['dumpsys', 'meminfo', `'${packageName}'`, '|', 'grep', '-E', "'Native|Dalvik|EGL|GL|TOTAL'"];
     let data = await this.adb.shell(cmd);
     if (!data) throw new Error('No data from dumpsys'); //eslint-disable-line curly
-
-    let totalPrivateDirty, totalPss,
-        nativePrivateDirty, nativePss, nativeHeapSize, nativeHeapAllocatedSize,
-        dalvikPrivateDirty, dalvikPss,
-        eglPrivateDirty, eglPss,
-        glPrivateDirty, glPss;
-    let apilevel = await this.adb.getApiLevel();
+    let valDict = { totalPrivateDirty: ''};
+    let apiLevel = await this.adb.getApiLevel();
     for (let line of data.split('\n')) {
       let entries = line.trim().split(' ').filter(Boolean);
-      // entries will have the values
-      //   ['<System Type>', '<Memory Type>', <pss total>, <private dirty>, <private clean>, <swapPss dirty>, <heap size>, <heap alloc>, <heap free>]
-      // except 'TOTAL', which skips the second type name
-      //
-      // and on API level 18 and below
-      //   ['<System Type', '<pps>', '<shared dirty>', '<private dirty>', '<heap size>', '<heap alloc>', '<heap free>']
-
-      if (apilevel > 18) {
-        let type = entries[0];
-        let subType = entries[1];
-        if (type === 'Native' && subType === 'Heap') {
-          // native heap
-          nativePss = entries[2];
-          nativePrivateDirty = entries[3];
-          nativeHeapSize = entries[6];
-          nativeHeapAllocatedSize = entries[7];
-        } else if (type === 'Dalvik' && subType === 'Heap') {
-          // dalvik heap
-          dalvikPss = entries[2];
-          dalvikPrivateDirty = entries[3];
-        } else if (type === 'EGL' && subType === 'mtrack') {
-          // egl
-          eglPss = entries[2];
-          eglPrivateDirty = entries[3];
-        } else if (type === 'GL' && subType === 'mtrack') {
-          // gl
-          glPss = entries[2];
-          glPrivateDirty = entries[3];
-        } else if (type === 'TOTAL' && entries.length === 8) {
-          // there are two totals, and we only want the full listing, which has 8 entries
-          totalPss = entries[1];
-          totalPrivateDirty = entries[2];
-        }
+      if (apiLevel >= 30) {
+        memoryParsers.Api30AndAbove(entries, valDict);
+      } else if (apiLevel > 18 && apiLevel < 30) {
+        memoryParsers.Api18And30(entries, valDict);
       } else {
-        let type = entries[0];
-        if (type === 'Native') {
-          nativePss = entries[1];
-          nativePrivateDirty = entries[3];
-          nativeHeapSize = entries[4];
-          nativeHeapAllocatedSize = entries[5];
-        } else if (type === 'Dalvik') {
-          dalvikPss = entries[1];
-          dalvikPrivateDirty = entries[3];
-        } else if (type === 'EGL') {
-          eglPss = entries[1];
-          eglPrivateDirty = entries[3];
-        } else if (type === 'GL') {
-          glPss = entries[1];
-          glPrivateDirty = entries[3];
-        } else if (type === 'TOTAL') {
-          totalPss = entries[1];
-          totalPrivateDirty = entries[3];
-        }
+        memoryParsers.Api18AndBelow(entries, valDict);
       }
     }
-
-    if (totalPrivateDirty && totalPrivateDirty !== 'nodex') {
+    if (valDict.totalPrivateDirty && valDict.totalPrivateDirty !== 'nodex') {
       let headers = _.clone(MEMORY_KEYS);
-      let data = [totalPrivateDirty, nativePrivateDirty, dalvikPrivateDirty, eglPrivateDirty, glPrivateDirty, totalPss, nativePss, dalvikPss, eglPss, glPss, nativeHeapAllocatedSize, nativeHeapSize];
-      return [headers, data];
+      let values = headers.map((header) => valDict[header]);
+      return [headers, values];
     } else {
       throw new Error(`Unable to parse memory data: '${data}'`);
     }
@@ -346,3 +358,4 @@ export {
   BATTERY_KEYS, NETWORK_KEYS,
 };
 export default extensions;
+


### PR DESCRIPTION
getPerformanceData() get memoryinfo return : Error: Unable to parse memory data for Android 11(API 30) .

Android 11 (API 30) dumpsys meminfo adds "Rss Total" column before "Heap Size"