### PR TITLE
fix: add --pct-syskeys 0 for monkey command

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -54,6 +54,8 @@ commands.queryAppState = async function queryAppState (appId) {
  */
 commands.activateApp = async function activateApp (appId) {
   const cmd = ['monkey',
+    // https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
+    '--pct-syskeys', '0',
     '-p', appId,
     '-c', 'android.intent.category.LAUNCHER',
     '1'];


### PR DESCRIPTION
Fixes https://github.com/appium/appium/issues/16427

Initially I noticed the `monkey` command failed on CI in ruby_lib_core repo.
According to https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical , it works with `--pct-syskeys 0`.
Actually it works without issues in my local env against real/emulator devices, while my env had no issues without `--pct-syskeys 0`. So, I think this should not break anything.

```
% adb -P 5037 -s D0AA002182JC0202126 shell monkey  --pct-syskeys 0 -p io.appium.android.apis -c android.intent.category.LAUNCHER 1
  bash arg: --pct-syskeys
  bash arg: 0
  bash arg: -p
  bash arg: io.appium.android.apis
  bash arg: -c
  bash arg: android.intent.category.LAUNCHER
  bash arg: 1
args: [--pct-syskeys, 0, -p, io.appium.android.apis, -c, android.intent.category.LAUNCHER, 1]
 arg: "--pct-syskeys"
 arg: "0"
 arg: "-p"
 arg: "io.appium.android.apis"
 arg: "-c"
 arg: "android.intent.category.LAUNCHER"
 arg: "1"
arg="--pct-syskeys" mCurArgData="null" mNextArg=1 argwas="--pct-syskeys" nextarg="0"
data="0"
data="io.appium.android.apis"
data="android.intent.category.LAUNCHER"
Events injected: 1
## Network stats: elapsed time=25ms (0ms mobile, 0ms wifi, 25ms not connected)
kazuaki@kazus-MB-pro tmp % echo $?
0
```