### PR TITLE
chore: add patch release as chore

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,12 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    "@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "releaseRules": [
+        {"type": "chore", "release": "patch"}
+        
+      ]
+    }
     "@semantic-release/npm",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/git", {


### PR DESCRIPTION
Let me merge this to check the rule. The expected result will be a patch release.
in addition to https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js