### PR TITLE
fix: returns all available webview information by CDP endpoints in mobile:getContexts as same as Appium 1.21.0

### DIFF
--- a/lib/commands/context.js
+++ b/lib/commands/context.js
@@ -25,8 +25,7 @@ commands.getCurrentContext = async function getCurrentContext () { // eslint-dis
 };
 
 commands.getContexts = async function getContexts () {
-  const opts = Object.assign({isChromeSession: this.isChromeSession}, this.opts);
-  const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, opts);
+  const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   return this.assignContexts(webviewsMapping);
 };
 
@@ -42,8 +41,7 @@ commands.setContext = async function setContext (name) {
     return;
   }
 
-  const opts = Object.assign({isChromeSession: this.isChromeSession}, this.opts);
-  const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, opts);
+  const webviewsMapping = await webviewHelpers.getWebViewsMapping(this.adb, this.opts);
   const contexts = this.assignContexts(webviewsMapping);
   // if the context we want doesn't exist, fail
   if (!_.includes(contexts, name)) {
@@ -105,8 +103,7 @@ commands.mobileGetContexts = async function mobileGetContexts () {
     androidDeviceSocket: this.opts.androidDeviceSocket,
     ensureWebviewsHavePages: true,
     webviewDevtoolsPort: this.opts.webviewDevtoolsPort,
-    enableWebviewDetailsCollection: true,
-    isChromeSession: this.isChromeSession
+    enableWebviewDetailsCollection: true
   };
   return await webviewHelpers.getWebViewsMapping(this.adb, opts);
 };

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -382,13 +382,8 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
   androidDeviceSocket = null,
   ensureWebviewsHavePages = true,
   webviewDevtoolsPort = null,
-  enableWebviewDetailsCollection = true,
-  isChromeSession = false
+  enableWebviewDetailsCollection = true
 } = {}) {
-  if (isChromeSession) {
-    return [];
-  }
-
   logger.debug('Getting a list of available webviews');
   const webviewsMapping = await webviewsFromProcs(adb, androidDeviceSocket);
 

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -348,7 +348,6 @@ helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
  * @property {boolean} enableWebviewDetailsCollection [true] - whether to collect
  * web view details and send them to Chromedriver constructor, so it could
  * select a binary more precisely based on this info.
- * @property {boolean} isChromeSession [false] - true if ChromeSession
  */
 
 /**

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -54,8 +54,10 @@ describe('Context', function () {
   });
   describe('getContexts', function () {
     it('should get Chromium context where appropriate', async function () {
+      sandbox.stub(webviewHelpers, 'getWebViewsMapping');
       driver = new AndroidDriver({browserName: 'Chrome'});
       expect(await driver.getContexts()).to.include(CHROMIUM_WIN);
+      webviewHelpers.getWebViewsMapping.calledOnce.should.be.true;
     });
     it('should use ADB to figure out which webviews are available', async function () {
       sandbox.stub(webviewHelpers, 'parseWebviewNames').returns(['DEFAULT', 'VW', 'ANOTHER']);


### PR DESCRIPTION
`isChromeSession` in `getWebViewsMapping` changed the behavior since 1.22.0, especially `mobile:getContexts`.

The option affected only `browserName: chrome` case. Then, `mobile:getContexts` returned `[]` while general get context endpoint returned `CHROME` as expected. `mobile:getContexts` and general getContext returned available contexts when non-`browserName: chrome`. It included chrome browser as well.

`Returns a webviewsMapping based on CDP endpoints` is also the description of `mobile:getContexts`.

Thus, `mobile:getContexts` returns `[]` only when `browserName: chrome` is probably no makes sense.
cc @mwakizaka 

--

for https://github.com/appium/appium/issues/16721 and https://github.com/appium/appium-android-driver/pull/699