### PR TITLE
fix: revert --pct-syskeys 0

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -55,8 +55,9 @@ commands.queryAppState = async function queryAppState (appId) {
  */
 commands.activateApp = async function activateApp (appId) {
   this.log.debug(`Activating '${appId}'`);
+  const apiLevel = await this.adb.getApiLevel();
   // Fallback to Monkey in older APIs
-  if (await this.adb.getApiLevel() < 24) {
+  if (apiLevel < 24) {
     // The monkey command could raise an issue as https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
     // but '--pct-syskeys 0' could cause another background process issue. https://github.com/appium/appium/issues/16941#issuecomment-1129837285
     // We should not add it to avoid it.
@@ -78,7 +79,7 @@ commands.activateApp = async function activateApp (appId) {
   }
 
   const stdout = await this.adb.shell([
-    'am', 'start',
+    'am', (apiLevel < 26) ? 'start' : 'start-activity',
     '-a', 'android.intent.action.MAIN',
     '-c', 'android.intent.category.LAUNCHER',
     // FLAG_ACTIVITY_REORDER_TO_FRONT | FLAG_ACTIVITY_BROUGHT_TO_FRONT | FLAG_ACTIVITY_NEW_TASK

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -57,9 +57,10 @@ commands.activateApp = async function activateApp (appId) {
   this.log.debug(`Activating '${appId}'`);
   // Fallback to Monkey in older APIs
   if (await this.adb.getApiLevel() < 24) {
+    // The monkey command could raise an issue as https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
+    // but '--pct-syskeys 0' could cause another background process issue. https://github.com/appium/appium/issues/16941#issuecomment-1129837285
+    // We should not add it to avoid it.
     const cmd = ['monkey',
-      // https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
-      '--pct-syskeys', '0',
       '-p', appId,
       '-c', 'android.intent.category.LAUNCHER',
       '1'];


### PR DESCRIPTION
Revert the argument, `--pct-syskeys 0`.

`activateApp` does not use `am start` method for API level 24 with current implementation, so this revert also should not affect widely.

Btw, I remember we use `start-activity` instead of `start` for Android 8+, so this PR includes it.