### PR TITLE
fix: keep resume behavior as activateApp

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -55,34 +55,13 @@ commands.queryAppState = async function queryAppState (appId) {
  */
 commands.activateApp = async function activateApp (appId) {
   this.log.debug(`Activating '${appId}'`);
-  const apiLevel = await this.adb.getApiLevel();
-  // Fallback to Monkey in older APIs
-  if (apiLevel < 24) {
-    // The monkey command could raise an issue as https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
-    // but '--pct-syskeys 0' could cause another background process issue. https://github.com/appium/appium/issues/16941#issuecomment-1129837285
-    const cmd = ['monkey',
-      '-p', appId,
-      '-c', 'android.intent.category.LAUNCHER',
-      '1'];
-    let output = '';
-    try {
-      output = await this.adb.shell(cmd);
-      this.log.debug(`Command stdout: ${output}`);
-    } catch (e) {
-      this.log.errorAndThrow(`Cannot activate '${appId}'. Original error: ${e.message}`);
-    }
-    if (output.includes('monkey aborted')) {
-      this.log.errorAndThrow(`Cannot activate '${appId}'. Are you sure it is installed?`);
-    }
-    return;
-  }
-
   const stdout = await this.adb.shell([
-    'am', (apiLevel < 26) ? 'start' : 'start-activity',
+    'am', (await this.adb.getApiLevel() < 26) ? 'start' : 'start-activity',
     '-a', 'android.intent.action.MAIN',
     '-c', 'android.intent.category.LAUNCHER',
-    // FLAG_ACTIVITY_NEW_TASK || FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
-    // https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK , https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+    // FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+    // https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK
+    // https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
     '-f', '0x10200000',
     '-n', await this.adb.resolveLaunchableActivity(appId),
   ]);

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -55,8 +55,30 @@ commands.queryAppState = async function queryAppState (appId) {
  */
 commands.activateApp = async function activateApp (appId) {
   this.log.debug(`Activating '${appId}'`);
+  const apiLevel = await this.adb.getApiLevel();
+  // Fallback to Monkey in older APIs
+  if (apiLevel < 24) {
+    // The monkey command could raise an issue as https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
+    // but '--pct-syskeys 0' could cause another background process issue. https://github.com/appium/appium/issues/16941#issuecomment-1129837285
+    const cmd = ['monkey',
+      '-p', appId,
+      '-c', 'android.intent.category.LAUNCHER',
+      '1'];
+    let output = '';
+    try {
+      output = await this.adb.shell(cmd);
+      this.log.debug(`Command stdout: ${output}`);
+    } catch (e) {
+      this.log.errorAndThrow(`Cannot activate '${appId}'. Original error: ${e.message}`);
+    }
+    if (output.includes('monkey aborted')) {
+      this.log.errorAndThrow(`Cannot activate '${appId}'. Are you sure it is installed?`);
+    }
+    return;
+  }
+
   const stdout = await this.adb.shell([
-    'am', (await this.adb.getApiLevel() < 26) ? 'start' : 'start-activity',
+    'am', (apiLevel < 26) ? 'start' : 'start-activity',
     '-a', 'android.intent.action.MAIN',
     '-c', 'android.intent.category.LAUNCHER',
     // FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_RESET_TASK_IF_NEEDED

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -81,6 +81,9 @@ commands.activateApp = async function activateApp (appId) {
     'am', (apiLevel < 26) ? 'start' : 'start-activity',
     '-a', 'android.intent.action.MAIN',
     '-c', 'android.intent.category.LAUNCHER',
+    // FLAG_ACTIVITY_NEW_TASK to resume the app as https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK
+    // see also: https://android.googlesource.com/platform/development/+/ecc1a3d0cf3af3dbbf4c190e1060fc1c0f8fb8a6/cmds/monkey/src/com/android/commands/monkey/MonkeyActivityEvent.java?autodive=0%2F#43
+    '-f', '0x10000000',
     '-n', await this.adb.resolveLaunchableActivity(appId),
   ]);
   this.log.debug(stdout);

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -56,34 +56,10 @@ commands.queryAppState = async function queryAppState (appId) {
 commands.activateApp = async function activateApp (appId) {
   this.log.debug(`Activating '${appId}'`);
   const apiLevel = await this.adb.getApiLevel();
-  // Fallback to Monkey in older APIs
-  if (apiLevel < 24) {
-    // The monkey command could raise an issue as https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
-    // but '--pct-syskeys 0' could cause another background process issue. https://github.com/appium/appium/issues/16941#issuecomment-1129837285
-    const cmd = ['monkey',
-      '-p', appId,
-      '-c', 'android.intent.category.LAUNCHER',
-      '1'];
-    let output = '';
-    try {
-      output = await this.adb.shell(cmd);
-      this.log.debug(`Command stdout: ${output}`);
-    } catch (e) {
-      this.log.errorAndThrow(`Cannot activate '${appId}'. Original error: ${e.message}`);
-    }
-    if (output.includes('monkey aborted')) {
-      this.log.errorAndThrow(`Cannot activate '${appId}'. Are you sure it is installed?`);
-    }
-    return;
-  }
-
   const stdout = await this.adb.shell([
     'am', (apiLevel < 26) ? 'start' : 'start-activity',
-    '-a', 'android.intent.action.MAIN',
-    '-c', 'android.intent.category.LAUNCHER',
-    // FLAG_ACTIVITY_REORDER_TO_FRONT | FLAG_ACTIVITY_BROUGHT_TO_FRONT | FLAG_ACTIVITY_NEW_TASK
-    '-f', '0x10420000',
-    '-n', await this.adb.resolveLaunchableActivity(appId),
+    '-p', appId,
+    '-c', 'android.intent.category.LAUNCHER'
   ]);
   this.log.debug(stdout);
   if (/^error:/mi.test(stdout)) {

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -56,10 +56,32 @@ commands.queryAppState = async function queryAppState (appId) {
 commands.activateApp = async function activateApp (appId) {
   this.log.debug(`Activating '${appId}'`);
   const apiLevel = await this.adb.getApiLevel();
+  // Fallback to Monkey in older APIs
+  if (apiLevel < 24) {
+    // The monkey command could raise an issue as https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
+    // but '--pct-syskeys 0' could cause another background process issue. https://github.com/appium/appium/issues/16941#issuecomment-1129837285
+    const cmd = ['monkey',
+      '-p', appId,
+      '-c', 'android.intent.category.LAUNCHER',
+      '1'];
+    let output = '';
+    try {
+      output = await this.adb.shell(cmd);
+      this.log.debug(`Command stdout: ${output}`);
+    } catch (e) {
+      this.log.errorAndThrow(`Cannot activate '${appId}'. Original error: ${e.message}`);
+    }
+    if (output.includes('monkey aborted')) {
+      this.log.errorAndThrow(`Cannot activate '${appId}'. Are you sure it is installed?`);
+    }
+    return;
+  }
+
   const stdout = await this.adb.shell([
     'am', (apiLevel < 26) ? 'start' : 'start-activity',
-    '-p', appId,
-    '-c', 'android.intent.category.LAUNCHER'
+    '-a', 'android.intent.action.MAIN',
+    '-c', 'android.intent.category.LAUNCHER',
+    '-n', await this.adb.resolveLaunchableActivity(appId),
   ]);
   this.log.debug(stdout);
   if (/^error:/mi.test(stdout)) {

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -81,9 +81,9 @@ commands.activateApp = async function activateApp (appId) {
     'am', (apiLevel < 26) ? 'start' : 'start-activity',
     '-a', 'android.intent.action.MAIN',
     '-c', 'android.intent.category.LAUNCHER',
-    // FLAG_ACTIVITY_NEW_TASK to resume the app as https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK
-    // see also: https://android.googlesource.com/platform/development/+/ecc1a3d0cf3af3dbbf4c190e1060fc1c0f8fb8a6/cmds/monkey/src/com/android/commands/monkey/MonkeyActivityEvent.java?autodive=0%2F#43
-    '-f', '0x10000000',
+    // FLAG_ACTIVITY_NEW_TASK || FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+    // https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK , https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+    '-f', '0x10200000',
     '-n', await this.adb.resolveLaunchableActivity(appId),
   ]);
   this.log.debug(stdout);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@appium/base-driver": "^8.5.2",
     "@appium/support": "^2.58.0",
     "@babel/runtime": "^7.0.0",
-    "appium-adb": "^9.5.0",
+    "appium-adb": "^9.6.0",
     "appium-chromedriver": "^5.0.1",
     "asyncbox": "^2.8.0",
     "axios": "^0.x",


### PR DESCRIPTION
https://github.com/appium/appium/issues/16941#issuecomment-1132448650

I found the monkey command worked kind of "resume" the app.
`adb shell am start -p <package> -c android.intent.category.LAUNCHER` seems work as same.

I'm testing on lower android such as android 6, but maybe it would be nice to keep the "resume" behavior for this.



closes https://github.com/appium/appium/issues/16967