### PR TITLE
use getRunningAVDWithRetry instead of getRunningAVD

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -158,7 +158,7 @@ helpers.prepareEmulator = async function prepareEmulator (adb, opts) {
   }
 
   const avdName = avd.replace('@', '');
-  const runningAVD = await adb.getRunningAVD(avdName);
+  const runningAVD = await adb.getRunningAVDWithRetry(avdName);
   const args = prepareAvdArgs(adb, opts);
   if (runningAVD) {
     if (args.includes('-wipe-data')) {

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -38,7 +38,7 @@ describe('Android Helpers', function () {
   describe('prepareEmulator', withMocks({adb, helpers}, (mocks) => {
     const opts = {avd: 'foo@bar', avdArgs: '', language: 'en', locale: 'us'};
     it('should not launch avd if one is already running', async function () {
-      mocks.adb.expects('getRunningAVD').withExactArgs('foobar')
+      mocks.adb.expects('getRunningAVDWithRetry').withExactArgs('foobar')
         .returns('foo');
       mocks.adb.expects('launchAVD').never();
       mocks.adb.expects('killEmulator').never();
@@ -46,7 +46,7 @@ describe('Android Helpers', function () {
       mocks.adb.verify();
     });
     it('should launch avd if one is already running', async function () {
-      mocks.adb.expects('getRunningAVD').withExactArgs('foobar')
+      mocks.adb.expects('getRunningAVDWithRetry').withExactArgs('foobar')
         .returns(null);
       mocks.adb.expects('launchAVD').withExactArgs('foo@bar', {
         args: [],
@@ -68,7 +68,7 @@ describe('Android Helpers', function () {
           k2: 'v2',
         }
       };
-      mocks.adb.expects('getRunningAVD').withExactArgs('foobar')
+      mocks.adb.expects('getRunningAVDWithRetry').withExactArgs('foobar')
         .returns(null);
       mocks.adb.expects('launchAVD').withExactArgs('foobar', {
         args: ['--arg1', 'value 1', '--arg2', 'value 2'],
@@ -89,7 +89,7 @@ describe('Android Helpers', function () {
         avd: 'foobar',
         avdArgs: ['--arg1', 'value 1', '--arg2', 'value 2'],
       };
-      mocks.adb.expects('getRunningAVD').withExactArgs('foobar')
+      mocks.adb.expects('getRunningAVDWithRetry').withExactArgs('foobar')
         .returns(null);
       mocks.adb.expects('launchAVD').withExactArgs('foobar', {
         args: ['--arg1', 'value 1', '--arg2', 'value 2'],
@@ -104,7 +104,7 @@ describe('Android Helpers', function () {
     });
     it('should kill emulator if avdArgs contains -wipe-data', async function () {
       const opts = {avd: 'foo@bar', avdArgs: '-wipe-data'};
-      mocks.adb.expects('getRunningAVD').withExactArgs('foobar').returns('foo');
+      mocks.adb.expects('getRunningAVDWithRetry').withExactArgs('foobar').returns('foo');
       mocks.adb.expects('killEmulator').withExactArgs('foobar').once();
       mocks.adb.expects('launchAVD').once();
       await helpers.prepareEmulator(adb, opts);
@@ -203,7 +203,7 @@ describe('Android Helpers', function () {
           getPortFromEmulatorString () {
             return 1234;
           },
-          getRunningAVD () {
+          getRunningAVDWithRetry () {
             return {udid: 'emulator-1234', port: 1234};
           },
           setDeviceId (udid) {


### PR DESCRIPTION
Hi, team. Could we use [getRunningAVDWithRetry()](https://github.com/appium/appium-adb/blob/d047d68ed1784af88777f55b313ee466ff54cc2f/lib/tools/system-calls.js#L713) instead of getRunningAVD() ?

I occasionally run into an issue where getRunningAVD() timeouts.
```
2022-08-29 10:25:01:887 [W3C] Encountered internal error running command: Error: Error getting AVD. Original error: Did not get the initial response from the Emulator console at 127.0.0.1:5554 after 5000ms
```
I feel this is more likely to happen when running many emulator sessions in parallel. I hope retrying would mitigate this. I use old uiatutomator2 (1.57) but I believe [it happens with the latest version](https://github.com/appium/appium-uiautomator2-driver/blob/e35f1d872242c483af61a2751783e2f759ff3a39/lib/driver.js#L348). 