### PR TITLE
feat: Provide `mobile:` wrappers for app management commands

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -7,7 +7,23 @@ import { errors } from 'appium/driver';
 const APP_EXTENSIONS = ['.apk', '.apks'];
 const RESOLVER_ACTIVITY_NAME = 'android/com.android.internal.app.ResolverActivity';
 
-let commands = {};
+const commands = {};
+
+/**
+ * Assert the presence of particular keys in the given object
+ *
+ * @param {string|Array<string>} argNames one or more key names
+ * @param {Object} opts the object to check
+ * @returns {Object} the same given object
+ */
+function requireArgs (argNames, opts = {}) {
+  for (const argName of (_.isArray(argNames) ? argNames : [argNames])) {
+    if (!_.has(opts, argName)) {
+      throw new errors.InvalidArgumentError(`'${argName}' argument must be provided`);
+    }
+  }
+  return opts;
+}
 
 /**
  * Verify whether an application is installed or not
@@ -17,6 +33,22 @@ let commands = {};
  */
 commands.isAppInstalled = async function isAppInstalled (appId) {
   return await this.adb.isAppInstalled(appId);
+};
+
+/**
+ * @typedef {Object} MobileAppInstalledOptions
+ * @property {string} appId - Application package identifier. Must be always provided.
+ */
+
+/**
+ * Verify whether an application is installed or not
+ *
+ * @param {MobileAppInstalledOptions} opts
+ * @returns {boolean} Same as in `isAppInstalled`
+ */
+commands.mobileIsAppInstalled = async function mobileIsAppInstalled (opts = {}) {
+  const { appId } = requireArgs('appId', opts);
+  return await this.isAppInstalled(appId);
 };
 
 /**
@@ -48,11 +80,28 @@ commands.queryAppState = async function queryAppState (appId) {
 };
 
 /**
+ * @typedef {Object} MobileQueryAppStateOptions
+ * @property {string} appId - Application package identifier. Must be always provided.
+ */
+
+/**
+ * Queries the current state of the app.
+ *
+ * @param {MobileQueryAppStateOptions} opts
+ * @returns {number} Same as in `queryAppState`
+ */
+commands.mobileQueryAppState = async function mobileQueryAppState (opts = {}) {
+  const { appId } = requireArgs('appId', opts);
+  return await this.queryAppState(appId);
+};
+
+/**
  * Activates the given application or launches it if necessary.
- * The action is done with monkey tool and literally simulates
+ * The action literally simulates
  * clicking the corresponding application icon on the dashboard.
  *
  * @param {string} appId - Application package identifier
+ * @throws {Error} If the app cannot be activated
  */
 commands.activateApp = async function activateApp (appId) {
   this.log.debug(`Activating '${appId}'`);
@@ -105,6 +154,24 @@ commands.activateApp = async function activateApp (appId) {
 };
 
 /**
+ * @typedef {Object} MobileActivateAppOptions
+ * @property {string} appId - Application package identifier. Must be always provided.
+ */
+
+/**
+ * Activates the given application or launches it if necessary.
+ * The action literally simulates
+ * clicking the corresponding application icon on the dashboard.
+ *
+ * @param {MobileActivateAppOptions} opts
+ * @throws {Error} If the app cannot be activated
+ */
+commands.mobileActivateApp = async function mobileActivateApp (opts = {}) {
+  const { appId } = requireArgs('appId', opts);
+  return await this.activateApp(appId);
+};
+
+/**
  * @typedef {Object} UninstallOptions
  * @property {number} timeout [20000] - The count of milliseconds to wait until the
  *                                      app is uninstalled.
@@ -123,6 +190,23 @@ commands.activateApp = async function activateApp (appId) {
  */
 commands.removeApp = async function removeApp (appId, options = {}) {
   return await this.adb.uninstallApk(appId, options);
+};
+
+/**
+ * @typedef {Object} MobileRemoveAppOptions
+ * @property {string} appId - Application package identifier. Must be always provided.
+ */
+
+/**
+ * Remove the corresponding application if is installed.
+ * The call is ignored if the app is not installed.
+ *
+ * @param {MobileRemoveAppOptions} opts
+ * @returns {boolean} Same as in `removeApp`
+ */
+commands.mobileRemoveApp = async function mobileRemoveApp (opts = {}) {
+  const { appId } = requireArgs('appId', opts);
+  return await this.removeApp(appId, opts);
 };
 
 /**
@@ -158,6 +242,25 @@ commands.terminateApp = async function terminateApp (appId, options = {}) {
 };
 
 /**
+ * @typedef {Object} MobileTerminateAppOptions
+ * @property {string} appId - Application package identifier. Must be always provided.
+ * @property {number|string} timeout [500] - The count of milliseconds to wait until the
+ *                                           app is terminated.
+ */
+
+/**
+ * Terminates the app if it is running.
+ *
+ * @param {MobileTerminateAppOptions} opts
+ * @returns {boolean} Same as in `terminateApp`
+ * @throws {Error} if the app has not been terminated within the given timeout.
+ */
+commands.mobileTerminateApp = async function mobileTerminateApp (opts = {}) {
+  const { appId } = requireArgs('appId', opts);
+  return await this.terminateApp(appId, opts);
+};
+
+/**
  * @typedef {Object} InstallOptions
  * @property {number} timeout [60000] - The count of milliseconds to wait until the
  *                                      app is installed.
@@ -184,6 +287,35 @@ commands.terminateApp = async function terminateApp (appId, options = {}) {
 commands.installApp = async function installApp (appPath, options = {}) {
   const localPath = await this.helpers.configureApp(appPath, APP_EXTENSIONS);
   await this.adb.install(localPath, options);
+};
+
+/**
+ * @typedef {Object} MobileInstallAppOptions
+ * @property {string} appPath - The local apk path or a remote url. Must be always provided.
+ * @property {number} timeout [60000] - The count of milliseconds to wait until the
+ *                                      app is installed.
+ * @property {boolean} allowTestPackages [false] - Set to true in order to allow test
+ *                                                 packages installation.
+ * @property {boolean} useSdcard [false] - Set to true to install the app on sdcard
+ *                                         instead of the device memory.
+ * @property {boolean} grantPermissions [false] - Set to true in order to grant all the
+ *                                                permissions requested in the application's manifest
+ *                                                automatically after the installation is completed
+ *                                                under Android 6+.
+ * @property {boolean} replace [true] - Set it to false if you don't want
+ *                                      the application to be upgraded/reinstalled
+ *                                      if it is already present on the device.
+ */
+
+/**
+ * Installs the given application to the device under test
+ *
+ * @param {MobileInstallAppOptions} opts
+ * @throws {Error} if the given apk does not exist or is not reachable
+ */
+commands.mobileInstallApp = async function mobileInstallApp (opts = {}) {
+  const { appPath } = requireArgs('appPath', opts);
+  return await this.installApp(appPath, opts);
 };
 
 /**

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -48,6 +48,12 @@ extensions.executeMobile = async function executeMobile (mobileCommand, opts = {
 
     deleteFile: 'mobileDeleteFile',
 
+    isAppInstalled: 'mobileIsAppInstalled',
+    queryAppState: 'mobileQueryAppState',
+    activateApp: 'mobileActivateApp',
+    removeApp: 'mobileRemoveApp',
+    terminateApp: 'mobileTerminateApp',
+    installApp: 'mobileInstallApp',
     clearApp: 'mobileClearApp',
 
     startService: 'mobileStartService',


### PR DESCRIPTION
It is more convenient to have mobile extensions for app management commands as these could be called in the same way from different clients and don't depend on the particular client API implementation