### PR TITLE
feat: grant permissions against installed app by skipping the installation by app

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -463,8 +463,8 @@ helpers.installApk = async function installApk (adb, opts = {}) {
     shouldGrantPermissions = false;
   }
 
-  // When the app has been installed, and has not get reset.
-  // Then, the installed app might have permissions not granted.
+  // When the app has been installed and has not get a reset,
+  // the installed app might have permissions that are not granted.
   if (shouldGrantPermissions) {
     if (app) {
       await adb.grantAllPermissions(appPackage, app);

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -448,13 +448,30 @@ helpers.installApk = async function installApk (adb, opts = {}) {
     enforceCurrentBuild: enforceAppInstall,
   });
 
+
+  let shouldGrantPermissions = autoGrantPermissions && [
+    adb.APP_INSTALL_STATE.NEWER_VERSION_INSTALLED, adb.APP_INSTALL_STATE.SAME_VERSION_INSTALLED
+  ].includes(appState);
+
   // There is no need to reset the newly installed app
   const isInstalledOverExistingApp = !wasUninstalled
     && appState !== adb.APP_INSTALL_STATE.NOT_INSTALLED;
   if (fastReset && isInstalledOverExistingApp) {
     logger.info(`Performing fast reset on '${appPackage}'`);
     await this.resetApp(adb, opts);
+    // already called
+    shouldGrantPermissions = false;
   }
+
+  // When the app has been installed, and has not get reset.
+  // Then, the installed app might have permissions not granted.
+  if (shouldGrantPermissions) {
+    if (app) {
+      await adb.grantAllPermissions(appPackage, app);
+    } else {
+      await adb.grantAllPermissions(appPackage);
+    }
+  };
 };
 
 /**


### PR DESCRIPTION
I haven't tested yet, so still draft.

Maybe related to https://github.com/appium/appium/issues/17542

When `app` installation is skipped and the app has not been granted, maybe grantPermissions (`grantAllPermissions`) should be called.


```
[AndroidDriver] Performing fast reset on 'com.notriddle.budget'
[debug] [ADB] Getting install status for com.notriddle.budget
[debug] [ADB] Running 'C:\Users\dvalb\AppData\Local\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell dumpsys package com.notriddle.budget'
[debug] [ADB] 'com.notriddle.budget' is installed
[debug] [ADB] Running 'C:\Users\dvalb\AppData\Local\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell am force-stop com.notriddle.budget'
[debug] [ADB] Running 'C:\Users\dvalb\AppData\Local\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell pm clear com.notriddle.budget'
[debug] [ADB] Running 'C:\Users\dvalb\AppData\Local\Android\Sdk\platform-tools\adb.exe -P 5037 -s emulator-5554 shell dumpsys package com.notriddle.budget'
[debug] [AndroidDriver] Performed fast reset on the installed 'com.notriddle.budget' application (stop and clear)
[debug] [UiAutomator2] Performing shallow cleanup of automation leftovers
```

I'll do test this situation later.