### PR TITLE
feat: skip checking the app state in the terminate app

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -218,7 +218,8 @@ commands.terminateApp = async function terminateApp (appId, options = {}) {
   const timeout = util.hasValue(options.timeout) && !isNaN(options.timeout) ? parseInt(options.timeout, 10) : 500;
 
   if (timeout <= 0) {
-    this.log.info(`Skip checking the application process state since the timeout was set as ${timeout}ms. `);
+    this.log.info(`'${appId}' has been terminated. Skip checking the application process state ` +
+      `since the timeout was set as ${timeout}ms`);
     return true;
   }
 

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -216,6 +216,12 @@ commands.terminateApp = async function terminateApp (appId, options = {}) {
   }
   await this.adb.forceStop(appId);
   const timeout = util.hasValue(options.timeout) && !isNaN(options.timeout) ? parseInt(options.timeout, 10) : 500;
+
+  if (timeout <= 0) {
+    this.log.info(`Skip checking the application process state since the timeout was set as ${timeout}ms. `);
+    return true;
+  }
+
   try {
     await waitForCondition(async () => await this.queryAppState(appId) <= APP_STATE.NOT_RUNNING,
       {waitMs: timeout, intervalMs: 100});

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -199,11 +199,13 @@ commands.mobileRemoveApp = async function mobileRemoveApp (opts = {}) {
  * @property {number|string} timeout [500] - The count of milliseconds to wait until the
  *                                           app is terminated. The method will skip
  *                                           checking the app state check if the timeout
- *                                           was lower or equal to zero.
+ *                                           was lower or equal to zero. Then, the return
+ *                                           value will be true.
  */
 
 /**
- * Terminates the app if it is running.
+ * Terminates the app if it is running. If the given timeout was lower or equal to zero,
+ * it returns true after terminating the app without checking the app state.
  *
  * @param {string} appId - Application package identifier
  * @param {?TerminateOptions} options - The set of application termination options

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -197,7 +197,9 @@ commands.mobileRemoveApp = async function mobileRemoveApp (opts = {}) {
 /**
  * @typedef {Object} TerminateOptions
  * @property {number|string} timeout [500] - The count of milliseconds to wait until the
- *                                           app is terminated.
+ *                                           app is terminated. The method will skip
+ *                                           checking the app state check if the timeout
+ *                                           was lower or equal to zero.
  */
 
 /**


### PR DESCRIPTION
I observed a case an app process stopped by the forceStop, but Android restarted the process immediately. (maybe the restarted app had some service) Then, the default timeout (500ms) resulted failed to terminate the app error. This behavior itself is expected right now. The `waitForCondition` calls the given func once at least, so giving zero did not help in the case.

A user can call the same killing an app process via adb command (without the app state check after it), but it would be nice to provide a way to call only the forceStop without the app state check via the same API as terminateApp.
(I'll do later, but we should address this app state check in readme. e.g. https://github.com/appium/appium-uiautomator2-driver#mobile-terminateapp)