### PR TITLE
fix: specify supported non-standard commands in newMethodMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ import * as commandIndex from './lib/commands/index';
 import * as webview from './lib/webview-helpers';
 import * as caps from './lib/desired-caps';
 
-
 const { AndroidDriver } = driver;
 const { helpers: webviewHelpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE,
         CHROMIUM_WIN } = webview;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,6 +1,7 @@
 import { BaseDriver, DeviceSettings } from 'appium/driver';
 import desiredConstraints from './desired-caps';
 import commands from './commands/index';
+import { newMethodMap } from './method-map';
 import {
   helpers, ensureNetworkSpeed,
   SETTINGS_HELPER_PKG_ID,
@@ -33,6 +34,9 @@ const NO_PROXY = [
 ];
 
 class AndroidDriver extends BaseDriver {
+
+  static newMethodMap = newMethodMap;
+
   constructor (opts = {}, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
 

--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -1,0 +1,219 @@
+export const newMethodMap = /** @type {const} */ ({
+  '/session/:sessionId/timeouts/implicit_wait': {
+    POST: { command: 'implicitWait', payloadParams: { required: ['ms'] } }
+  },
+  '/session/:sessionId/ime/available_engines': { GET: { command: 'availableIMEEngines' } },
+  '/session/:sessionId/ime/active_engine': { GET: { command: 'getActiveIMEEngine' } },
+  '/session/:sessionId/ime/activated': { GET: { command: 'isIMEActivated' } },
+  '/session/:sessionId/ime/deactivate': { POST: { command: 'deactivateIMEEngine' } },
+  '/session/:sessionId/ime/activate': {
+    POST: {
+      command: 'activateIMEEngine',
+      payloadParams: { required: ['engine'] }
+    }
+  },
+  '/session/:sessionId/window/:windowhandle/size': { GET: { command: 'getWindowSize' } },
+  '/session/:sessionId/keys': {
+    POST: { command: 'keys', payloadParams: { required: ['value'] } }
+  },
+  '/session/:sessionId/element/:elementId/location': { GET: { command: 'getLocation' } },
+  '/session/:sessionId/element/:elementId/location_in_view': { GET: { command: 'getLocationInView' } },
+  '/session/:sessionId/element/:elementId/size': { GET: { command: 'getSize' } },
+  '/session/:sessionId/touch/click': {
+    POST: { command: 'click', payloadParams: { required: ['element'] } }
+  },
+  '/session/:sessionId/touch/down': {
+    POST: { command: 'touchDown', payloadParams: { required: ['x', 'y'] } }
+  },
+  '/session/:sessionId/touch/up': {
+    POST: { command: 'touchUp', payloadParams: { required: ['x', 'y'] } }
+  },
+  '/session/:sessionId/touch/move': {
+    POST: { command: 'touchMove', payloadParams: { required: ['x', 'y'] } }
+  },
+  '/session/:sessionId/touch/longclick': {
+    POST: {
+      command: 'touchLongClick',
+      payloadParams: { required: ['elements'] }
+    }
+  },
+  '/session/:sessionId/touch/flick': {
+    POST: {
+      command: 'flick',
+      payloadParams: {
+        optional: [
+          'element',
+          'xspeed',
+          'yspeed',
+          'xoffset',
+          'yoffset',
+          'speed'
+        ]
+      }
+    }
+  },
+  '/session/:sessionId/touch/perform': {
+    POST: {
+      command: 'performTouch',
+      payloadParams: { wrap: 'actions', required: ['actions'] }
+    }
+  },
+  '/session/:sessionId/touch/multi/perform': {
+    POST: {
+      command: 'performMultiAction',
+      payloadParams: { required: ['actions'], optional: ['elementId'] }
+    }
+  },
+  '/session/:sessionId/appium/device/lock': {
+    POST: { command: 'lock', payloadParams: { optional: ['seconds'] } }
+  },
+  '/session/:sessionId/appium/device/unlock': { POST: { command: 'unlock' } },
+  '/session/:sessionId/appium/device/is_locked': { POST: { command: 'isLocked' } },
+  '/session/:sessionId/appium/start_recording_screen': {
+    POST: {
+      command: 'startRecordingScreen',
+      payloadParams: { optional: ['options'] }
+    }
+  },
+  '/session/:sessionId/appium/stop_recording_screen': {
+    POST: {
+      command: 'stopRecordingScreen',
+      payloadParams: { optional: ['options'] }
+    }
+  },
+  '/session/:sessionId/appium/performanceData/types': { POST: { command: 'getPerformanceDataTypes' } },
+  '/session/:sessionId/appium/getPerformanceData': {
+    POST: {
+      command: 'getPerformanceData',
+      payloadParams: {
+        required: ['packageName', 'dataType'],
+        optional: ['dataReadTimeout']
+      }
+    }
+  },
+  '/session/:sessionId/appium/device/press_keycode': {
+    POST: {
+      command: 'pressKeyCode',
+      payloadParams: { required: ['keycode'], optional: ['metastate', 'flags'] }
+    }
+  },
+  '/session/:sessionId/appium/device/long_press_keycode': {
+    POST: {
+      command: 'longPressKeyCode',
+      payloadParams: { required: ['keycode'], optional: ['metastate', 'flags'] }
+    }
+  },
+  '/session/:sessionId/appium/device/finger_print': {
+    POST: {
+      command: 'fingerprint',
+      payloadParams: { required: ['fingerprintId'] }
+    }
+  },
+  '/session/:sessionId/appium/device/send_sms': {
+    POST: {
+      command: 'sendSMS',
+      payloadParams: { required: ['phoneNumber', 'message'] }
+    }
+  },
+  '/session/:sessionId/appium/device/gsm_call': {
+    POST: {
+      command: 'gsmCall',
+      payloadParams: { required: ['phoneNumber', 'action'] }
+    }
+  },
+  '/session/:sessionId/appium/device/gsm_signal': {
+    POST: {
+      command: 'gsmSignal',
+      payloadParams: { required: ['signalStrength'] }
+    }
+  },
+  '/session/:sessionId/appium/device/gsm_voice': {
+    POST: { command: 'gsmVoice', payloadParams: { required: ['state'] } }
+  },
+  '/session/:sessionId/appium/device/power_capacity': {
+    POST: {
+      command: 'powerCapacity',
+      payloadParams: { required: ['percent'] }
+    }
+  },
+  '/session/:sessionId/appium/device/power_ac': {
+    POST: { command: 'powerAC', payloadParams: { required: ['state'] } }
+  },
+  '/session/:sessionId/appium/device/network_speed': {
+    POST: {
+      command: 'networkSpeed',
+      payloadParams: { required: ['netspeed'] }
+    }
+  },
+  '/session/:sessionId/appium/device/keyevent': {
+    POST: {
+      command: 'keyevent',
+      payloadParams: { required: ['keycode'], optional: ['metastate'] }
+    }
+  },
+  '/session/:sessionId/appium/device/current_activity': { GET: { command: 'getCurrentActivity' } },
+  '/session/:sessionId/appium/device/current_package': { GET: { command: 'getCurrentPackage' } },
+  '/session/:sessionId/appium/device/app_state': {
+    POST: {
+      command: 'queryAppState',
+      payloadParams: { required: [['appId'], ['bundleId']] }
+    }
+  },
+  '/session/:sessionId/appium/device/toggle_airplane_mode': { POST: { command: 'toggleFlightMode' } },
+  '/session/:sessionId/appium/device/toggle_data': { POST: { command: 'toggleData' } },
+  '/session/:sessionId/appium/device/toggle_wifi': { POST: { command: 'toggleWiFi' } },
+  '/session/:sessionId/appium/device/toggle_location_services': { POST: { command: 'toggleLocationServices' } },
+  '/session/:sessionId/appium/device/open_notifications': { POST: { command: 'openNotifications' } },
+  '/session/:sessionId/appium/device/start_activity': {
+    POST: {
+      command: 'startActivity',
+      payloadParams: {
+        required: ['appPackage', 'appActivity'],
+        optional: [
+          'appWaitPackage',
+          'appWaitActivity',
+          'intentAction',
+          'intentCategory',
+          'intentFlags',
+          'optionalIntentArguments',
+          'dontStopAppOnReset'
+        ]
+      }
+    }
+  },
+  '/session/:sessionId/appium/device/system_bars': { GET: { command: 'getSystemBars' } },
+  '/session/:sessionId/appium/device/display_density': { GET: { command: 'getDisplayDensity' } },
+  '/session/:sessionId/appium/app/launch': { POST: { command: 'launchApp' } },
+  '/session/:sessionId/appium/app/close': { POST: { command: 'closeApp' } },
+  '/session/:sessionId/appium/app/reset': { POST: { command: 'reset' } },
+  '/session/:sessionId/appium/app/background': {
+    POST: {
+      command: 'background',
+      payloadParams: { required: ['seconds'] }
+    }
+  },
+  '/session/:sessionId/appium/app/end_test_coverage': {
+    POST: {
+      command: 'endCoverage',
+      payloadParams: { required: ['intent', 'path'] }
+    }
+  },
+  '/session/:sessionId/appium/app/strings': {
+    POST: {
+      command: 'getStrings',
+      payloadParams: { optional: ['language', 'stringFile'] }
+    }
+  },
+  '/session/:sessionId/appium/element/:elementId/value': {
+    POST: {
+      command: 'setValueImmediate',
+      payloadParams: { required: ['text'] }
+    }
+  },
+  '/session/:sessionId/appium/element/:elementId/replace_value': {
+    POST: {
+      command: 'replaceValue',
+      payloadParams: { required: ['text'] }
+    }
+  }
+});


### PR DESCRIPTION
here is my first stab at this. i wrote a little script to basically generate the new method map we need. this script could be copied and changed in minor ways for every driver. it outputs a javascript object which i simply copied into the new method map declaration.

```js
const {METHOD_MAP} = require('@appium/base-driver');
const {AndroidDriver} = require('.');
const util = require('util');

const deprecatedCommandNames = {};
for (const [route, methodSpec] of Object.entries(METHOD_MAP)) {
  for (const [method, commandSpec] of Object.entries(methodSpec)) {
    if (commandSpec.deprecated && commandSpec.command) {
      deprecatedCommandNames[commandSpec.command] = {
        route,
        method,
        commandSpec,
      };
    }
  }
}

const newMethodMap = {};

for (const [command, details] of Object.entries(deprecatedCommandNames)) {
  const {route, method, commandSpec} = details;
  const instance = new AndroidDriver();
  if (instance[command]) {
    if (!newMethodMap[route]) {
      newMethodMap[route] = {};
    }
    newMethodMap[route][method] = {...commandSpec};
    delete newMethodMap[route][method].deprecated;
  }
}

console.log(util.inspect(newMethodMap, {depth: 5})); // eslint-disable-line no-console
```