### PR TITLE
chore: ignore an error in collectWebviewsDetails

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -257,7 +257,11 @@ async function collectWebviewsDetails (adb, webviewsMapping, opts = {}) {
         logger.debug(e);
       } finally {
         if (localPort) {
-          await adb.removePortForward(localPort);
+          try {
+            await adb.removePortForward(localPort);
+          } catch (e) {
+            logger.debug(e);
+          }
         }
       }
     })());


### PR DESCRIPTION
I observed possible exception here in the middle of `mobile:getContext` command itself., but it could be ignored. Lets leave the exception as a debug log, but allow appium to proceed the `mobile:getContext` command itself. This was randomly (and occasionally) happened in my observation

```
2023-03-24 06:37:23:726 - [debug] [AndroidDriver] You could use the 'webviewDevtoolsPort' capability to customize the starting port number
2023-03-24 06:37:23:769 - [debug] [ADB] Running '/Users/kazu/android/platform-tools/adb -P 5037 -s RFCTA0CNDAL forward tcp:10900 localabstract:webview_devtools_remote_12982'
2023-03-24 06:37:23:850 - [debug] [ADB] Removing forwarded port socket connection: 10900
2023-03-24 06:37:23:850 - [debug] [ADB] Running '/Users/kazu/android/platform-tools/adb -P 5037 -s RFCTA0CNDAL forward --remove tcp:10900'
2023-03-24 06:37:23:969 - [debug] [W3C (617d65f0)] Encountered internal error running command: Error executing adbExec. Original error: 'Command '/Users/kazu/android/platform-tools/adb -P 5037 -s RFCTA0CNDAL forward --remove tcp\:10900' exited with code 1'; Command output: adb: error: listener 'tcp:10900' not found
2023-03-24 06:37:23:969 - [debug] [W3C (617d65f0)]
2023-03-24 06:37:23:969 - [debug] [W3C (617d65f0)] Error: Command '/Users/kazu/android/platform-tools/adb -P 5037 -s RFCTA0CNDAL forward --remove tcp\:10900' exited with code 1
2023-03-24 06:37:23:969 - [debug] [W3C (617d65f0)]     at ChildProcess.<anonymous> (/Users/kazu/appium/1.22.3/node_modules/appium/node_modules/teen_process/lib/exec.js:113:19)
2023-03-24 06:37:23:970 - [debug] [W3C (617d65f0)]     at ChildProcess.emit (events.js:400:28)
2023-03-24 06:37:23:970 - [debug] [W3C (617d65f0)]     at maybeClose (internal/child_process.js:1058:16)
2023-03-24 06:37:23:970 - [debug] [W3C (617d65f0)]     at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5)
2023-03-24 06:37:24:431 - [HTTP] <-- POST /wd/hub/session/617d65f0-4f77-4a41-b336-e7ac5862c636/execute/sync 500 835 ms - 1047
2023-03-24 06:37:24:433 - [HTTP]
```