### PR TITLE
perf: check the device state via waitForDevice only for a emulator

### DIFF
--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -797,7 +797,11 @@ helpers.initDevice = async function initDevice (adb, opts) {
   if (skipDeviceInitialization) {
     logger.info(`'skipDeviceInitialization' is set. Skipping device initialization.`);
   } else {
-    await adb.waitForDevice();
+    if (helpers.isEmulator(adb, opts)) {
+      // Check the device wake up only for emulators.
+      // It takes 1 second or around even when the device is awake in a real device.
+      await adb.waitForDevice();
+    }
     // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+
 
     // Some feature such as location/wifi are not necessary for all users,

--- a/lib/android-helpers.js
+++ b/lib/android-helpers.js
@@ -798,8 +798,8 @@ helpers.initDevice = async function initDevice (adb, opts) {
     logger.info(`'skipDeviceInitialization' is set. Skipping device initialization.`);
   } else {
     if (helpers.isEmulator(adb, opts)) {
-      // Check the device wake up only for emulators.
-      // It takes 1 second or around even when the device is awake in a real device.
+      // Check if the device wake up only for an emulator.
+      // It takes 1 second or so even when the device is already awake in a real device.
       await adb.waitForDevice();
     }
     // pushSettingsApp required before calling ensureDeviceLocale for API Level 24+

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -12,7 +12,6 @@ import B from 'bluebird';
 
 const should = chai.should();
 const REMOTE_TEMP_PATH = '/data/local/tmp';
-let sandbox = sinon.createSandbox();
 chai.use(chaiAsPromised);
 
 
@@ -745,7 +744,6 @@ describe('Android Helpers', function () {
   describe('initDevice', withMocks({helpers, adb}, (mocks) => {
     it('should init a real device', async function () {
       const opts = {language: 'en', locale: 'us', localeScript: 'Script'};
-      sandbox.stub(helpers, 'isEmulator').returns(false);
       mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -12,6 +12,7 @@ import B from 'bluebird';
 
 const should = chai.should();
 const REMOTE_TEMP_PATH = '/data/local/tmp';
+let sandbox = sinon.createSandbox();
 chai.use(chaiAsPromised);
 
 
@@ -742,9 +743,10 @@ describe('Android Helpers', function () {
     });
   }));
   describe('initDevice', withMocks({helpers, adb}, (mocks) => {
-    it('should init device', async function () {
+    it('should init a real device', async function () {
       const opts = {language: 'en', locale: 'us', localeScript: 'Script'};
-      mocks.adb.expects('waitForDevice').once();
+      sandbox.stub(helpers, 'isEmulator').returns(false);
+      mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
       mocks.helpers.expects('ensureDeviceLocale').withExactArgs(adb, opts.language, opts.locale, opts.localeScript).once();
@@ -755,7 +757,7 @@ describe('Android Helpers', function () {
     });
     it('should init device without locale and language', async function () {
       const opts = {};
-      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
       mocks.helpers.expects('ensureDeviceLocale').never();
@@ -766,7 +768,7 @@ describe('Android Helpers', function () {
     });
     it('should init device with either locale or language', async function () {
       const opts = {language: 'en'};
-      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
       mocks.helpers.expects('ensureDeviceLocale').withExactArgs(adb, opts.language, opts.locale, opts.localeScript).once();
@@ -788,7 +790,7 @@ describe('Android Helpers', function () {
     });
     it('should return defaultIME if unicodeKeyboard is setted to true', async function () {
       const opts = {unicodeKeyboard: true};
-      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
       mocks.helpers.expects('ensureDeviceLocale').never();
@@ -800,7 +802,7 @@ describe('Android Helpers', function () {
     });
     it('should return undefined if unicodeKeyboard is setted to false', async function () {
       const opts = {unicodeKeyboard: false};
-      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
       mocks.helpers.expects('ensureDeviceLocale').never();
@@ -812,7 +814,7 @@ describe('Android Helpers', function () {
     });
     it('should not push unlock app if unlockType is defined', async function () {
       const opts = {unlockType: 'unlock_type'};
-      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').once();
       mocks.helpers.expects('pushSettingsApp').once();
       mocks.helpers.expects('ensureDeviceLocale').never();
@@ -824,7 +826,7 @@ describe('Android Helpers', function () {
     });
     it('should init device without starting logcat', async function () {
       const opts = { skipLogcatCapture: true };
-      mocks.adb.expects('waitForDevice').once();
+      mocks.adb.expects('waitForDevice').never();
       mocks.adb.expects('startLogcat').never();
       mocks.helpers.expects('pushSettingsApp').once();
       mocks.helpers.expects('ensureDeviceLocale').never();


### PR DESCRIPTION
`initDevice` has `adb.waitForDevice()` to check if the connected device is ready. My understanding for this purpose is to ensure the connected device, especially an emulator, is ready for testing.

In my local comparison, the method could take 1 sec or around even if the connected device is ready. So far, Appium could generate an emulator in a new session request. Then, such wait for launch method is necessary to handle the device up state properly while a real device is not necessary since we expect a real device is already up. (I mean Appium does not have a feature to restart a real device in a new session request).

Thus, we can skip the device wake up check for a real device. **It will improve 1 sec and a fe**w in a new session request speed.


```
2023-04-11 06:02:07:523 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell 'settings put global hidden_api_policy_pre_p_apps 1;settings put global hidden_api_policy_p_apps 1;settings put global hidden_api_policy 1''

2023-04-11 06:02:08:257 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 wait-for-device'
2023-04-11 06:02:08:578 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell echo ping'
2023-04-11 06:02:09:230 - [debug] [AndroidDriver] Pushing settings apk to device...

2023-04-11 06:02:09:234 - [debug] [ADB] Getting install status for io.appium.settings
2023-04-11 06:02:09:234 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell dumpsys package io.appium.settings'
```

---


Not this module, but probably we can optimize the settings app installation...? (e.g. reduce `shell dumpsys package` call. then 1 sec or so can be reduced) 

```
2023-04-11 06:02:09:234 - [debug] [ADB] Getting install status for io.appium.settings
2023-04-11 06:02:09:234 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell dumpsys package io.appium.settings'
2023-04-11 06:02:09:963 - [debug] [ADB] 'io.appium.settings' is installed
2023-04-11 06:02:09:963 - [debug] [ADB] Getting package info for 'io.appium.settings'
2023-04-11 06:02:09:963 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell dumpsys package io.appium.settings'
2023-04-11 06:02:10:674 - [debug] [ADB] The version name of the installed 'io.appium.settings' is greater or equal to the application version name ('4.2.3' >= '4.2.3')
2023-04-11 06:02:10:675 - [debug] [ADB] There is no need to install/upgrade '/Users/kazu/.appium/node_modules/appium-uiautomator2-driver/node_modules/io.appium.settings/apks/settings_apk-debug.apk'
2023-04-11 06:02:10:675 - [debug] [ADB] Getting IDs of all 'io.appium.settings' processes
2023-04-11 06:02:10:676 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell 'pgrep --help; echo $?''
2023-04-11 06:02:11:345 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell pgrep -f \(\[\[:blank:\]\]\|\^\)io\.appium\.settings\(\[\[:blank:\]\]\|\$\)'
2023-04-11 06:02:12:077 - [debug] [AndroidDriver] io.appium.settings is already running. There is no need to reset its permissions.
2023-04-11 06:02:12:078 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell appops set io.appium.settings android:mock_location allow'
2023-04-11 06:02:12:757 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell "[ -e '/data/local/tmp/mock_apps.json' ] && echo __PASS__"'
2023-04-11 06:02:13:414 - [debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 shell cat /data/local/tmp/mock_apps.json'
2023-04-11 06:02:14:084 - [debug] [Logcat] Starting logs capture with command: /Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s D0AA002182JC0202126 logcat -v threadtime
2023-04-11 06:02:14:742 - [debug] [AndroidUiautomator2Driver@389d (595f5eb5)] Forwarding UiAutomator2 Server port 6790 to local port 8200
2023-04-11 06:02:14:746 - [debug] [ADB] Forwarding system: 8200 to device: 6790
```