### PR TITLE
fix: increase pull recent timeout

### DIFF
--- a/lib/commands/media-projection.js
+++ b/lib/commands/media-projection.js
@@ -121,7 +121,8 @@ class MediaProjectionRecorder {
     }
 
     const dstPath = path.join(await tempDir.openDir(), recordings[0]);
-    await this.adb.pull(`${RECORDINGS_ROOT}/${recordings[0]}`, dstPath);
+    // increase timeout to 5 minutes because it might take a while to pull a large video file
+    await this.adb.pull(`${RECORDINGS_ROOT}/${recordings[0]}`, dstPath, {timeout: 300000});
     return dstPath;
   }
 


### PR DESCRIPTION
Increase timeout of the pull command in pullRecent to 5 minutes. Videos longer than 30 minutes can take over 60s to pull.

Fixes: https://github.com/appium/appium/issues/18522