### PR TITLE
fix: make request timeout an option in mobileStopMediaProjectionRecording

### DIFF
--- a/lib/commands/media-projection.js
+++ b/lib/commands/media-projection.js
@@ -27,12 +27,13 @@ async function uploadRecordedMedia (localFile, remotePath = null, uploadOptions 
     return (await util.toInMemoryBase64(localFile)).toString();
   }
 
-  const {user, pass, method, headers, fileFieldName, formFields} = uploadOptions;
+  const {user, pass, method, headers, fileFieldName, formFields, timeout} = uploadOptions;
   const options = {
     method: method || 'PUT',
     headers,
     fileFieldName,
     formFields,
+    timeout,
   };
   if (user && pass) {
     options.auth = {user, pass};
@@ -232,6 +233,7 @@ commands.mobileIsMediaProjectionRecordingRunning = async function mobileIsMediaP
  * @property {string?} fileFieldName [file] The name of the form field, where the file content BLOB should be stored for
  * http(s) uploads
  * @property {Object|Array<Pair>?} formFields Additional form fields for multipart http(s) uploads
+ * @property {number?} timeout - The actual request timeout in milliseconds; defaults to @appium/support net DEFAULT_TIMEOUT_MS
  */
 
 /**


### PR DESCRIPTION
Now it's not possible to adjust the file upload timeout. With the change it's possible to provide timeout parameter in the mobile: stopMediaProjectionRecording to set the request timeout.

Over 45 minute file upload to S3 can take over 4 minutes (current default).

Fixes: https://github.com/appium/appium/issues/18549