### PR TITLE
fix: relax webview match

### DIFF
--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import logger from './logger';
 import axios from 'axios';
-import { util } from '@appium/support';
-import { findAPortNotInUse } from 'portscanner';
+import {util} from '@appium/support';
+import {findAPortNotInUse} from 'portscanner';
 import LRU from 'lru-cache';
 import B from 'bluebird';
 import path from 'path';
@@ -14,7 +14,8 @@ const CHROMIUM_WIN = 'CHROMIUM';
 const WEBVIEW_BASE = `${WEBVIEW_WIN}_`;
 const WEBVIEW_PID_PATTERN = new RegExp(`^${WEBVIEW_BASE}(\\d+)`);
 const WEBVIEW_PKG_PATTERN = new RegExp(`^${WEBVIEW_BASE}([^\\d\\s][\\w.]*)`);
-const DEVTOOLS_SOCKET_PATTERN = /@[\w.]+_devtools_remote_?(\d+)?\b/;
+// const DEVTOOLS_SOCKET_PATTERN = /@[\w.]+_devtools_remote_?(\d+)?\b/;
+const DEVTOOLS_SOCKET_PATTERN = /@[\w.]+_devtools_remote_?([\w.]+_)?(\d+)?\b/;
 const CROSSWALK_SOCKET_PATTERN = /@([\w.]+)_devtools_remote\b/;
 const CHROMIUM_DEVTOOLS_SOCKET = 'chrome_devtools_remote';
 const CHROME_PACKAGE_NAME = 'com.android.chrome';
@@ -37,7 +38,7 @@ const DEVTOOLS_PORT_ALLOCATION_GUARD = util.getLockFileGuard(
 
 const helpers = {};
 
-function toDetailsCacheKey (adb, webview) {
+function toDetailsCacheKey(adb, webview) {
   return `${adb?.curDeviceId}:${webview}`;
 }
 
@@ -51,13 +52,13 @@ function toDetailsCacheKey (adb, webview) {
  *
  * @return {Array.<string>} - a list of matching webview socket names (including the leading '@')
  */
-async function getPotentialWebviewProcs (adb) {
+async function getPotentialWebviewProcs(adb) {
   const out = await adb.shell(['cat', '/proc/net/unix']);
   const names = [];
   const allMatches = [];
   for (const line of out.split('\n')) {
     // Num RefCount Protocol Flags Type St Inode Path
-    const [,,, flags,, st,, sockPath] = line.trim().split(/\s+/);
+    const [, , , flags, , st, , sockPath] = line.trim().split(/\s+/);
     if (!sockPath) {
       continue;
     }
@@ -79,8 +80,10 @@ async function getPotentialWebviewProcs (adb) {
       logger.debug(`Other sockets are: ${JSON.stringify(allMatches, null, 2)}`);
     }
   } else {
-    logger.debug(`Parsed ${names.length} active devtools ${util.pluralize('socket', names.length, false)}: ` +
-      JSON.stringify(names));
+    logger.debug(
+      `Parsed ${names.length} active devtools ${util.pluralize('socket', names.length, false)}: ` +
+        JSON.stringify(names)
+    );
   }
   // sometimes the webview process shows up multiple times per app
   return _.uniq(names);
@@ -104,7 +107,7 @@ async function getPotentialWebviewProcs (adb) {
  *
  * @return {Array.<WebviewProc>}
  */
-async function webviewsFromProcs (adb, deviceSocket = null) {
+async function webviewsFromProcs(adb, deviceSocket = null) {
   const socketNames = await getPotentialWebviewProcs(adb);
   const webviews = [];
   for (const socketName of socketNames) {
@@ -121,15 +124,15 @@ async function webviewsFromProcs (adb, deviceSocket = null) {
       continue;
     }
     const crosswalkMatch = CROSSWALK_SOCKET_PATTERN.exec(socketName);
-    if (!socketNameMatch[1] && !crosswalkMatch) {
+    if (!socketNameMatch[2] && !crosswalkMatch) {
       continue;
     }
 
-    if (deviceSocket && socketName === `@${deviceSocket}` || !deviceSocket) {
+    if ((deviceSocket && socketName === `@${deviceSocket}`) || !deviceSocket) {
       webviews.push({
         proc: socketName,
-        webview: socketNameMatch[1]
-          ? `${WEBVIEW_BASE}${socketNameMatch[1]}`
+        webview: socketNameMatch[2]
+          ? `${WEBVIEW_BASE}${socketNameMatch[2]}`
           : `${WEBVIEW_BASE}${crosswalkMatch[1]}`,
       });
     }
@@ -148,7 +151,7 @@ async function webviewsFromProcs (adb, deviceSocket = null) {
  * successfully or `null` otherwise
  * @throws {Error} If there was an error while allocating the local port
  */
-async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null) {
+async function allocateDevtoolsPort(adb, socketName, webviewDevtoolsPort = null) {
   // socket names come with '@', but this should not be a part of the abstract
   // remote port, so remove it
   const remotePort = socketName.replace(/^@/, '');
@@ -157,20 +160,25 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
     endPort = webviewDevtoolsPort + (endPort - startPort);
     startPort = webviewDevtoolsPort;
   }
-  logger.debug(`Forwarding remote port ${remotePort} to a local ` +
-    `port in range ${startPort}..${endPort}`);
+  logger.debug(
+    `Forwarding remote port ${remotePort} to a local ` + `port in range ${startPort}..${endPort}`
+  );
   if (!webviewDevtoolsPort) {
-    logger.debug(`You could use the 'webviewDevtoolsPort' capability to customize ` +
-      `the starting port number`);
+    logger.debug(
+      `You could use the 'webviewDevtoolsPort' capability to customize ` +
+        `the starting port number`
+    );
   }
   return await DEVTOOLS_PORT_ALLOCATION_GUARD(async () => {
     let localPort;
     try {
       localPort = await findAPortNotInUse(startPort, endPort);
     } catch (e) {
-      throw new Error(`Cannot find any free port to forward the Devtools socket ` +
-        `in range ${startPort}..${endPort}. You could set the starting port number ` +
-        `manually by providing the 'webviewDevtoolsPort' capability`);
+      throw new Error(
+        `Cannot find any free port to forward the Devtools socket ` +
+          `in range ${startPort}..${endPort}. You could set the starting port number ` +
+          `manually by providing the 'webviewDevtoolsPort' capability`
+      );
     }
     await adb.adbExec(['forward', `tcp:${localPort}`, `localabstract:${remotePort}`]);
     return localPort;
@@ -213,7 +221,7 @@ async function allocateDevtoolsPort (adb, socketName, webviewDevtoolsPort = null
  * `enableWebviewDetailsCollection` properties are falsy then no details collection
  * is performed
  */
-async function collectWebviewsDetails (adb, webviewsMapping, opts = {}) {
+async function collectWebviewsDetails(adb, webviewsMapping, opts = {}) {
   if (_.isEmpty(webviewsMapping)) {
     return;
   }
@@ -225,14 +233,18 @@ async function collectWebviewsDetails (adb, webviewsMapping, opts = {}) {
   } = opts;
 
   if (!ensureWebviewsHavePages) {
-    logger.info(`Not checking whether webviews have active pages; use the ` +
-      `'ensureWebviewsHavePages' cap to turn this check on`);
+    logger.info(
+      `Not checking whether webviews have active pages; use the ` +
+        `'ensureWebviewsHavePages' cap to turn this check on`
+    );
   }
 
   if (!enableWebviewDetailsCollection) {
-    logger.info(`Not collecting web view details. Details collection might help ` +
-      `to make Chromedriver initialization more precise. Use the 'enableWebviewDetailsCollection' ` +
-      `cap to turn it on`);
+    logger.info(
+      `Not collecting web view details. Details collection might help ` +
+        `to make Chromedriver initialization more precise. Use the 'enableWebviewDetailsCollection' ` +
+        `cap to turn it on`
+    );
   }
 
   if (!ensureWebviewsHavePages && !enableWebviewDetailsCollection) {
@@ -243,47 +255,53 @@ async function collectWebviewsDetails (adb, webviewsMapping, opts = {}) {
   logger.debug(`Collecting CDP data of ${util.pluralize('webview', webviewsMapping.length, true)}`);
   const detailCollectors = [];
   for (const item of webviewsMapping) {
-    detailCollectors.push((async () => {
-      let localPort;
-      try {
-        localPort = await allocateDevtoolsPort(adb, item.proc, webviewDevtoolsPort);
-        if (enableWebviewDetailsCollection) {
-          item.info = await cdpInfo(localPort);
-        }
-        if (ensureWebviewsHavePages) {
-          item.pages = await cdpList(localPort);
-        }
-      } catch (e) {
-        logger.debug(e);
-      } finally {
-        if (localPort) {
-          try {
-            await adb.removePortForward(localPort);
-          } catch (e) {
-            logger.debug(e);
+    detailCollectors.push(
+      (async () => {
+        let localPort;
+        try {
+          localPort = await allocateDevtoolsPort(adb, item.proc, webviewDevtoolsPort);
+          if (enableWebviewDetailsCollection) {
+            item.info = await cdpInfo(localPort);
+          }
+          if (ensureWebviewsHavePages) {
+            item.pages = await cdpList(localPort);
+          }
+        } catch (e) {
+          logger.debug(e);
+        } finally {
+          if (localPort) {
+            try {
+              await adb.removePortForward(localPort);
+            } catch (e) {
+              logger.debug(e);
+            }
           }
         }
-      }
-    })());
+      })()
+    );
   }
   await B.all(detailCollectors);
   logger.debug(`CDP data collection completed`);
 }
 
 // https://chromedevtools.github.io/devtools-protocol/
-async function cdpList (localPort) {
-  return (await axios({
-    url: `http://127.0.0.1:${localPort}/json/list`,
-    timeout: CDP_REQ_TIMEOUT,
-  })).data;
+async function cdpList(localPort) {
+  return (
+    await axios({
+      url: `http://127.0.0.1:${localPort}/json/list`,
+      timeout: CDP_REQ_TIMEOUT,
+    })
+  ).data;
 }
 
 // https://chromedevtools.github.io/devtools-protocol/
-async function cdpInfo (localPort) {
-  return (await axios({
-    url: `http://127.0.0.1:${localPort}/json/version`,
-    timeout: CDP_REQ_TIMEOUT,
-  })).data;
+async function cdpInfo(localPort) {
+  return (
+    await axios({
+      url: `http://127.0.0.1:${localPort}/json/version`,
+      timeout: CDP_REQ_TIMEOUT,
+    })
+  ).data;
 }
 
 /**
@@ -298,7 +316,7 @@ async function cdpInfo (localPort) {
  * @returns {string} - the package name of the app running the webview
  * @throws {Error} If there was a failure while retrieving the process name
  */
-helpers.procFromWebview = async function procFromWebview (adb, webview) {
+helpers.procFromWebview = async function procFromWebview(adb, webview) {
   const pidMatch = WEBVIEW_PID_PATTERN.exec(webview);
   if (!pidMatch) {
     throw new Error(`Could not find PID for webview '${webview}'`);
@@ -319,10 +337,10 @@ helpers.procFromWebview = async function procFromWebview (adb, webview) {
  * @param {GetWebviewsOpts} opts See note on getWebViewsMapping
  * @return {Array.<string>} - a list of webview names
  */
-helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
-  ensureWebviewsHavePages = true,
-  isChromeSession = false
-} = {}) {
+helpers.parseWebviewNames = function parseWebviewNames(
+  webviewsMapping,
+  {ensureWebviewsHavePages = true, isChromeSession = false} = {}
+) {
   if (isChromeSession) {
     return [CHROMIUM_WIN];
   }
@@ -330,15 +348,19 @@ helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
   const result = [];
   for (const {webview, pages, proc, webviewName} of webviewsMapping) {
     if (ensureWebviewsHavePages && pages?.length === 0) {
-      logger.info(`Skipping the webview '${webview}' at '${proc}' ` +
-        `since it has reported having zero pages`);
+      logger.info(
+        `Skipping the webview '${webview}' at '${proc}' ` +
+          `since it has reported having zero pages`
+      );
       continue;
     }
     if (webviewName) {
       result.push(webviewName);
     }
   }
-  logger.debug(`Found ${util.pluralize('webview', result.length, true)}: ${JSON.stringify(result)}`);
+  logger.debug(
+    `Found ${util.pluralize('webview', result.length, true)}: ${JSON.stringify(result)}`
+  );
   return result;
 };
 
@@ -381,12 +403,15 @@ helpers.parseWebviewNames = function parseWebviewNames (webviewsMapping, {
  *
  * @return {Array<WebviewsMapping>} webviewsMapping
  */
-helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
-  androidDeviceSocket = null,
-  ensureWebviewsHavePages = true,
-  webviewDevtoolsPort = null,
-  enableWebviewDetailsCollection = true
-} = {}) {
+helpers.getWebViewsMapping = async function getWebViewsMapping(
+  adb,
+  {
+    androidDeviceSocket = null,
+    ensureWebviewsHavePages = true,
+    webviewDevtoolsPort = null,
+    enableWebviewDetailsCollection = true,
+  } = {}
+) {
   logger.debug('Getting a list of available webviews');
   const webviewsMapping = await webviewsFromProcs(adb, androidDeviceSocket);
 
@@ -423,7 +448,7 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
     webviewMapping.webviewName = wvName;
     const key = toDetailsCacheKey(adb, wvName);
     if (info || process) {
-      WEBVIEWS_DETAILS_CACHE.set(key, { info, process });
+      WEBVIEWS_DETAILS_CACHE.set(key, {info, process});
     } else if (WEBVIEWS_DETAILS_CACHE.has(key)) {
       WEBVIEWS_DETAILS_CACHE.delete(key);
     }
@@ -458,7 +483,7 @@ helpers.getWebViewsMapping = async function getWebViewsMapping (adb, {
  * @param {string} webview The name of the web view
  * @returns {?WebViewDetails} Either `undefined` or the recent web view details
  */
-helpers.getWebviewDetails = function getWebviewDetails (adb, webview) {
+helpers.getWebviewDetails = function getWebviewDetails(adb, webview) {
   const key = toDetailsCacheKey(adb, webview);
   return WEBVIEWS_DETAILS_CACHE.get(key);
 };
@@ -473,12 +498,13 @@ helpers.getWebviewDetails = function getWebviewDetails (adb, webview) {
  * @returns {Object} The capabilities object.
  * See https://chromedriver.chromium.org/capabilities for more details.
  */
-helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId, webViewDetails) {
-  const caps = { chromeOptions: {} };
+helpers.createChromedriverCaps = function createChromedriverCaps(opts, deviceId, webViewDetails) {
+  const caps = {chromeOptions: {}};
 
-  const androidPackage = opts.chromeOptions?.androidPackage
-    || opts.appPackage
-    || webViewDetails?.info?.['Android-Package'];
+  const androidPackage =
+    opts.chromeOptions?.androidPackage ||
+    opts.appPackage ||
+    webViewDetails?.info?.['Android-Package'];
   if (androidPackage) {
     // chromedriver raises an invalid argument error when androidPackage is 'null'
     caps.chromeOptions.androidPackage = androidPackage;
@@ -524,13 +550,13 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
     caps.loggingPrefs = opts.chromeLoggingPrefs || opts.loggingPrefs;
   }
   if (opts.enablePerformanceLogging) {
-    logger.warn(`The 'enablePerformanceLogging' cap is deprecated; simply use ` +
-      `the 'chromeLoggingPrefs' cap instead, with a 'performance' key set to 'ALL'`);
+    logger.warn(
+      `The 'enablePerformanceLogging' cap is deprecated; simply use ` +
+        `the 'chromeLoggingPrefs' cap instead, with a 'performance' key set to 'ALL'`
+    );
     const newPref = {performance: 'ALL'};
     // don't overwrite other logging prefs that have been sent in if they exist
-    caps.loggingPrefs = caps.loggingPrefs
-      ? Object.assign({}, caps.loggingPrefs, newPref)
-      : newPref;
+    caps.loggingPrefs = caps.loggingPrefs ? Object.assign({}, caps.loggingPrefs, newPref) : newPref;
   }
 
   if (opts.chromeOptions?.Arguments) {
@@ -539,8 +565,9 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
     delete opts.chromeOptions.Arguments;
   }
 
-  logger.debug('Precalculated Chromedriver capabilities: ' +
-    JSON.stringify(caps.chromeOptions, null, 2));
+  logger.debug(
+    'Precalculated Chromedriver capabilities: ' + JSON.stringify(caps.chromeOptions, null, 2)
+  );
 
   const protectedCapNames = [];
   for (const [opt, val] of _.toPairs(opts.chromeOptions)) {
@@ -551,8 +578,10 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
     }
   }
   if (!_.isEmpty(protectedCapNames)) {
-    logger.info('The following Chromedriver capabilities cannot be overridden ' +
-      'by the provided chromeOptions:');
+    logger.info(
+      'The following Chromedriver capabilities cannot be overridden ' +
+        'by the provided chromeOptions:'
+    );
     for (const optName of protectedCapNames) {
       logger.info(`  ${optName} (${JSON.stringify(opts.chromeOptions[optName])})`);
     }
@@ -562,4 +591,12 @@ helpers.createChromedriverCaps = function createChromedriverCaps (opts, deviceId
 };
 
 export default helpers;
-export { helpers, NATIVE_WIN, WEBVIEW_WIN, WEBVIEW_BASE, CHROMIUM_WIN, KNOWN_CHROME_PACKAGE_NAMES };
+export {
+  helpers,
+  NATIVE_WIN,
+  WEBVIEW_WIN,
+  WEBVIEW_BASE,
+  CHROMIUM_WIN,
+  KNOWN_CHROME_PACKAGE_NAMES,
+  DEVTOOLS_SOCKET_PATTERN,
+};

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -14,7 +14,6 @@ const CHROMIUM_WIN = 'CHROMIUM';
 const WEBVIEW_BASE = `${WEBVIEW_WIN}_`;
 const WEBVIEW_PID_PATTERN = new RegExp(`^${WEBVIEW_BASE}(\\d+)`);
 const WEBVIEW_PKG_PATTERN = new RegExp(`^${WEBVIEW_BASE}([^\\d\\s][\\w.]*)`);
-// const DEVTOOLS_SOCKET_PATTERN = /@[\w.]+_devtools_remote_?(\d+)?\b/;
 const DEVTOOLS_SOCKET_PATTERN = /@[\w.]+_devtools_remote_?([\w.]+_)?(\d+)?\b/;
 const CROSSWALK_SOCKET_PATTERN = /@([\w.]+)_devtools_remote\b/;
 const CHROMIUM_DEVTOOLS_SOCKET = 'chrome_devtools_remote';

--- a/lib/webview-helpers.js
+++ b/lib/webview-helpers.js
@@ -122,16 +122,17 @@ async function webviewsFromProcs(adb, deviceSocket = null) {
     if (!socketNameMatch) {
       continue;
     }
+    const matchedSocketName = socketNameMatch[2];
     const crosswalkMatch = CROSSWALK_SOCKET_PATTERN.exec(socketName);
-    if (!socketNameMatch[2] && !crosswalkMatch) {
+    if (!matchedSocketName && !crosswalkMatch) {
       continue;
     }
 
     if ((deviceSocket && socketName === `@${deviceSocket}`) || !deviceSocket) {
       webviews.push({
         proc: socketName,
-        webview: socketNameMatch[2]
-          ? `${WEBVIEW_BASE}${socketNameMatch[2]}`
+        webview: matchedSocketName
+          ? `${WEBVIEW_BASE}${matchedSocketName}`
           : `${WEBVIEW_BASE}${crosswalkMatch[1]}`,
       });
     }

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import helpers from '../../lib/webview-helpers';
+import {helpers, DEVTOOLS_SOCKET_PATTERN} from '../../lib/webview-helpers';
 import ADB from 'appium-adb';
 
 let sandbox = sinon.createSandbox();
@@ -11,135 +11,93 @@ describe('Webview Helpers', function () {
     sandbox.restore();
   });
 
-  describe('When the webviews are obtained', function () {
-    describe('for an app that embeds Chromium', function () {
-      let webViews;
-
-      beforeEach(async function () {
-        sandbox.stub(adb, 'shell').callsFake(function () {
-          return 'Num       RefCount Protocol Flags    Type St Inode Path\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @webview_devtools_remote_123\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
-        });
-        const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'webview_devtools_remote_123'});
-        webViews = helpers.parseWebviewNames(webviewsMapping);
-      });
-
-      it('then the unix sockets are queried', function () {
-        adb.shell.calledOnce.should.be.true;
-        adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
-      });
-
-      it('then the webview is returned', function () {
-        webViews.length.should.equal(1);
-        webViews.should.deep.equal(['WEBVIEW_123']);
-      });
+  describe('DEVTOOLS_SOCKET_PATTERN', function () {
+    it('patting patterns with webview_devtools_remote_22138', function () {
+      DEVTOOLS_SOCKET_PATTERN.test('@webview_devtools_remote_22138').should.be.true;
     });
-
-    describe('for a Chromium webview', function () {
-      let webViews;
-
-      beforeEach(async function () {
-        sandbox.stub(adb, 'shell').callsFake(function () {
-          return 'Num       RefCount Protocol Flags    Type St Inode Path\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @chrome_devtools_remote\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
-        });
-
-        const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'chrome_devtools_remote'});
-        webViews = helpers.parseWebviewNames(webviewsMapping);
-      });
-
-      it('then the unix sockets are queried', function () {
-        adb.shell.calledOnce.should.be.true;
-        adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
-      });
-
-      it('then the webview is returned', function () {
-        webViews.length.should.equal(1);
-        webViews.should.deep.equal(['CHROMIUM']);
-      });
+    it('patting patterns with webview_devtools_remote_m6x_27719', function () {
+      DEVTOOLS_SOCKET_PATTERN.test('@webview_devtools_remote_m6x_27719').should.be.true;
     });
-
-    describe('and no webviews exist', function () {
-      let webViews;
-
-      beforeEach(async function () {
-        sandbox.stub(adb, 'shell').callsFake(function () {
-          return 'Num       RefCount Protocol Flags    Type St Inode Path\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
-        });
-
-        const webviewsMapping = await helpers.getWebViewsMapping(adb);
-        webViews = helpers.parseWebviewNames(webviewsMapping);
-      });
-
-      it('then the unix sockets are queried', function () {
-        adb.shell.calledOnce.should.be.true;
-        adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
-      });
-
-      it('then no webviews are returned', function () {
-        webViews.length.should.equal(0);
-      });
+    it('patting patterns with chrome_devtools_remote', function () {
+      DEVTOOLS_SOCKET_PATTERN.test('@chrome_devtools_remote').should.be.true;
     });
+  }),
+    describe('When the webviews are obtained', function () {
+      describe('for an app that embeds Chromium', function () {
+        let webViews;
 
-    describe('and crosswalk webviews exist', function () {
-      let webViews;
-
-      beforeEach(function () {
-        sandbox.stub(adb, 'shell').callsFake(function () {
-          return 'Num       RefCount Protocol Flags    Type St Inode Path\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @com.application.myapp_devtools_remote\n' +
-                '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n';
-        });
-      });
-
-      describe('and the device socket is not specified', function () {
         beforeEach(async function () {
+          sandbox.stub(adb, 'shell').callsFake(function () {
+            return (
+              'Num       RefCount Protocol Flags    Type St Inode Path\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @webview_devtools_remote_123\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n'
+            );
+          });
+          const webviewsMapping = await helpers.getWebViewsMapping(adb, {
+            androidDeviceSocket: 'webview_devtools_remote_123',
+          });
+          webViews = helpers.parseWebviewNames(webviewsMapping);
+        });
+
+        it('then the unix sockets are queried', function () {
+          adb.shell.calledOnce.should.be.true;
+          adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
+        });
+
+        it('then the webview is returned', function () {
+          webViews.length.should.equal(1);
+          webViews.should.deep.equal(['WEBVIEW_123']);
+        });
+      });
+
+      describe('for a Chromium webview', function () {
+        let webViews;
+
+        beforeEach(async function () {
+          sandbox.stub(adb, 'shell').callsFake(function () {
+            return (
+              'Num       RefCount Protocol Flags    Type St Inode Path\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @chrome_devtools_remote\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n'
+            );
+          });
+
+          const webviewsMapping = await helpers.getWebViewsMapping(adb, {
+            androidDeviceSocket: 'chrome_devtools_remote',
+          });
+          webViews = helpers.parseWebviewNames(webviewsMapping);
+        });
+
+        it('then the unix sockets are queried', function () {
+          adb.shell.calledOnce.should.be.true;
+          adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
+        });
+
+        it('then the webview is returned', function () {
+          webViews.length.should.equal(1);
+          webViews.should.deep.equal(['CHROMIUM']);
+        });
+      });
+
+      describe('and no webviews exist', function () {
+        let webViews;
+
+        beforeEach(async function () {
+          sandbox.stub(adb, 'shell').callsFake(function () {
+            return (
+              'Num       RefCount Protocol Flags    Type St Inode Path\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n'
+            );
+          });
+
           const webviewsMapping = await helpers.getWebViewsMapping(adb);
-          webViews = helpers.parseWebviewNames(webviewsMapping);
-        });
-
-        it('then the unix sockets are queried', function () {
-          adb.shell.calledOnce.should.be.true;
-          adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
-        });
-
-        it('then the webview is returned', function () {
-          webViews.length.should.equal(1);
-          webViews.should.deep.equal(['WEBVIEW_com.application.myapp']);
-        });
-      });
-
-      describe('and the device socket is specified', function () {
-        beforeEach(async function () {
-          const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'com.application.myapp_devtools_remote'});
-          webViews = helpers.parseWebviewNames(webviewsMapping);
-        });
-
-        it('then the unix sockets are queried', function () {
-          adb.shell.calledOnce.should.be.true;
-          adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
-        });
-
-        it('then the webview is returned', function () {
-          webViews.length.should.equal(1);
-          webViews.should.deep.equal(['WEBVIEW_com.application.myapp']);
-        });
-      });
-
-      describe('and the device socket is specified but is not found', function () {
-        beforeEach(async function () {
-          const webviewsMapping = await helpers.getWebViewsMapping(adb, {androidDeviceSocket: 'com.application.myotherapp_devtools_remote'});
           webViews = helpers.parseWebviewNames(webviewsMapping);
         });
 
@@ -152,6 +110,75 @@ describe('Webview Helpers', function () {
           webViews.length.should.equal(0);
         });
       });
+
+      describe('and crosswalk webviews exist', function () {
+        let webViews;
+
+        beforeEach(function () {
+          sandbox.stub(adb, 'shell').callsFake(function () {
+            return (
+              'Num       RefCount Protocol Flags    Type St Inode Path\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @com.application.myapp_devtools_remote\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n'
+            );
+          });
+        });
+
+        describe('and the device socket is not specified', function () {
+          beforeEach(async function () {
+            const webviewsMapping = await helpers.getWebViewsMapping(adb);
+            webViews = helpers.parseWebviewNames(webviewsMapping);
+          });
+
+          it('then the unix sockets are queried', function () {
+            adb.shell.calledOnce.should.be.true;
+            adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
+          });
+
+          it('then the webview is returned', function () {
+            webViews.length.should.equal(1);
+            webViews.should.deep.equal(['WEBVIEW_com.application.myapp']);
+          });
+        });
+
+        describe('and the device socket is specified', function () {
+          beforeEach(async function () {
+            const webviewsMapping = await helpers.getWebViewsMapping(adb, {
+              androidDeviceSocket: 'com.application.myapp_devtools_remote',
+            });
+            webViews = helpers.parseWebviewNames(webviewsMapping);
+          });
+
+          it('then the unix sockets are queried', function () {
+            adb.shell.calledOnce.should.be.true;
+            adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
+          });
+
+          it('then the webview is returned', function () {
+            webViews.length.should.equal(1);
+            webViews.should.deep.equal(['WEBVIEW_com.application.myapp']);
+          });
+        });
+
+        describe('and the device socket is specified but is not found', function () {
+          beforeEach(async function () {
+            const webviewsMapping = await helpers.getWebViewsMapping(adb, {
+              androidDeviceSocket: 'com.application.myotherapp_devtools_remote',
+            });
+            webViews = helpers.parseWebviewNames(webviewsMapping);
+          });
+
+          it('then the unix sockets are queried', function () {
+            adb.shell.calledOnce.should.be.true;
+            adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
+          });
+
+          it('then no webviews are returned', function () {
+            webViews.length.should.equal(0);
+          });
+        });
+      });
     });
-  });
 });


### PR DESCRIPTION
https://github.com/appium/appium/issues/17528

Most diff is by `prettier`... so let me list what I did here:

- Modify `DEVTOOLS_SOCKET_PATTERN` to accept https://github.com/appium/appium/issues/17528 naming logic as well
- Define `const matchedSocketName = socketNameMatch[2];` to reduce code duplications
- Add tests. `describe('DEVTOOLS_SOCKET_PATTERN', function () {`, to check the pattern


Local run:


```
npm run test
...

  438 passing (11s)
  3 pending
```