### PR TITLE
feat: Add 'hideKeyboard' capability

### DIFF
--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -1,4 +1,4 @@
-// @ts-check
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import {mixin} from './mixins';
 import {retryInterval} from 'asyncbox';
@@ -30,19 +30,12 @@ const ElementMixin = {
   },
 
   async setElementValue(keys, elementId, replace = false) {
-    let text = keys;
-    if (keys instanceof Array) {
-      text = keys.join('');
-    }
-
-    let params = {
+    const text = keys instanceof Array ? keys.join('') : keys;
+    return await this.doSetElementValue({
       elementId,
       text: String(text),
       replace,
-      unicodeKeyboard: this.opts.unicodeKeyboard,
-    };
-
-    return await this.doSetElementValue(params);
+    });
   },
 
   /**

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -1,4 +1,4 @@
-// @ts-check
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {util} from '@appium/support';
 import {longSleep} from 'asyncbox';
 import _ from 'lodash';
@@ -19,17 +19,10 @@ const GeneralMixin = {
   async keys(keys) {
     // Protocol sends an array; rethink approach
     keys = _.isArray(keys) ? keys.join('') : keys;
-    /**
-     * @type {import('./types').SendKeysOpts}
-     */
-    const params = {
+    await this.doSendKeys({
       text: keys,
       replace: false,
-    };
-    if (this.opts.unicodeKeyboard) {
-      params.unicodeKeyboard = true;
-    }
-    await this.doSendKeys(params);
+    });
   },
 
   async doSendKeys(params) {

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -253,7 +253,6 @@ export interface DoSetElementValueOpts {
   elementId: string;
   text: string;
   replace: boolean;
-  unicodeKeyboard?: boolean;
 }
 
 export interface ExecOptions {
@@ -331,7 +330,6 @@ export interface SendKeysOpts {
   text: string;
   // XXX: unclear if this is required
   replace?: boolean;
-  unicodeKeyboard?: boolean;
 }
 
 export interface DeviceTimeOpts {

--- a/lib/constraints.ts
+++ b/lib/constraints.ts
@@ -132,7 +132,11 @@ export const ANDROID_DRIVER_CONSTRAINTS = {
   dontStopAppOnReset: {
     isBoolean: true,
   },
+  /** @deprecated Use hideKeyboard instead */
   unicodeKeyboard: {
+    isBoolean: true,
+  },
+  hideKeyboard: {
     isBoolean: true,
   },
   noSign: {

--- a/lib/helpers/android.ts
+++ b/lib/helpers/android.ts
@@ -1027,6 +1027,10 @@ const AndroidHelpers: AndroidHelpers = {
     }
 
     if (unicodeKeyboard) {
+      logger.warn(
+        `The 'unicodeKeyboard' capability has been deprecated and will be removed. ` +
+        `Set the 'hideKeyboard' capability to 'true' in order to make the on-screen keyboard invisible.`
+      );
       return await AndroidHelpers.initUnicodeKeyboard(adb);
     }
   },

--- a/lib/helpers/android.ts
+++ b/lib/helpers/android.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {fs, tempDir, util} from '@appium/support';
 import type {AppiumServer, StringRecord} from '@appium/types';
 import {ADB} from 'appium-adb';
@@ -67,6 +68,7 @@ const APP_STATE = {
   RUNNING_IN_BACKGROUND: 3,
   RUNNING_IN_FOREGROUND: 4,
 } as const;
+const EMPTY_IME = `${SETTINGS_HELPER_PKG_ID}/.EmptyIME`;
 
 function ensureNetworkSpeed(adb: ADB, networkSpeed: string) {
   if (networkSpeed.toUpperCase() in adb.NETWORK_SPEED) {
@@ -175,9 +177,10 @@ interface AndroidHelpers {
    */
   getThirdPartyPackages(adb: ADB, filterPackages?: string[]): Promise<string[]>;
   /**
-   * @privateRemarks FIXME: return value is unknown to me
+   * @deprecated Use hideKeyboard instead
    */
   initUnicodeKeyboard(adb: ADB): Promise<any>;
+  hideKeyboard(adb: ADB): Promise<void>;
   setMockLocationApp(adb: ADB, app: string): Promise<void>;
   resetMockLocation(adb: ADB): Promise<void>;
   installHelperApp(adb: ADB, apkPath: string, packageId: string): Promise<void>;
@@ -690,6 +693,12 @@ const AndroidHelpers: AndroidHelpers = {
     return defaultIME;
   },
 
+  async hideKeyboard(adb) {
+    logger.debug(`Hiding the on-screen keyboard by setting IME to '${EMPTY_IME}'`);
+    await adb.enableIME(EMPTY_IME);
+    await adb.setIME(EMPTY_IME);
+  },
+
   async setMockLocationApp(adb, app) {
     try {
       if ((await adb.getApiLevel()) < 23) {
@@ -958,6 +967,7 @@ const AndroidHelpers: AndroidHelpers = {
       language,
       localeScript,
       unicodeKeyboard,
+      hideKeyboard,
       disableWindowAnimation,
       skipUnlock,
       mockLocationApp,
@@ -984,6 +994,7 @@ const AndroidHelpers: AndroidHelpers = {
           locale ||
           localeScript ||
           unicodeKeyboard ||
+          hideKeyboard ||
           disableWindowAnimation ||
           !skipUnlock
       );
@@ -1009,6 +1020,10 @@ const AndroidHelpers: AndroidHelpers = {
         format: logcatFormat,
         filterSpecs: logcatFilterSpecs,
       });
+    }
+
+    if (hideKeyboard) {
+      await AndroidHelpers.hideKeyboard(adb);
     }
 
     if (unicodeKeyboard) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "asyncbox": "^2.8.0",
     "axios": "^1.x",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^5.0.0",
+    "io.appium.settings": "^5.2.0",
     "lodash": "^4.17.4",
     "lru-cache": "^10.0.1",
     "moment": "^2.24.0",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -631,18 +631,6 @@ describe('Android Helpers', function () {
     })
   );
   describe(
-    'initUnicodeKeyboard',
-    withMocks({adb}, (mocks) => {
-      it('should install and enable unicodeIME', async function () {
-        mocks.adb.expects('defaultIME').once().returns('defaultIME');
-        mocks.adb.expects('enableIME').once().returns('');
-        mocks.adb.expects('setIME').once().returns('');
-        await helpers.initUnicodeKeyboard(adb);
-        mocks.adb.verify();
-      });
-    })
-  );
-  describe(
     'pushSettingsApp',
     withMocks({adb}, (mocks) => {
       it('should skip granting permissions if the app is already running on over API level 23+ devices', async function () {
@@ -915,7 +903,22 @@ describe('Android Helpers', function () {
         mocks.helpers.verify();
         mocks.adb.verify();
       });
-      it('should return defaultIME if unicodeKeyboard is setted to true', async function () {
+      it('should set empty IME if hideKeyboard is set to true', async function () {
+        const opts = {hideKeyboard: true};
+        mocks.adb.expects('waitForDevice').never();
+        mocks.adb.expects('startLogcat').once();
+        mocks.helpers.expects('pushSettingsApp').once();
+        mocks.helpers.expects('ensureDeviceLocale').never();
+        mocks.helpers.expects('setMockLocationApp').once();
+        mocks.helpers
+          .expects('hideKeyboard')
+          .withExactArgs(adb)
+          .once();
+        await helpers.initDevice(adb, opts);
+        mocks.helpers.verify();
+        mocks.adb.verify();
+      });
+      it('should return defaultIME if unicodeKeyboard is set to true', async function () {
         const opts = {unicodeKeyboard: true};
         mocks.adb.expects('waitForDevice').never();
         mocks.adb.expects('startLogcat').once();
@@ -931,7 +934,7 @@ describe('Android Helpers', function () {
         mocks.helpers.verify();
         mocks.adb.verify();
       });
-      it('should return undefined if unicodeKeyboard is setted to false', async function () {
+      it('should return undefined if unicodeKeyboard is set to false', async function () {
         const opts = {unicodeKeyboard: false};
         mocks.adb.expects('waitForDevice').never();
         mocks.adb.expects('startLogcat').once();


### PR DESCRIPTION
Based on https://github.com/appium/io.appium.settings/pull/126

I would like to deprecate the `unicodeKeyboard` capability in the future as it is anyway not needed.
Also, the option has been removed from input APIs as it is not used there and is a leftover from the legacy bootstrap implementation.