### PR TITLE
feat: Use APIs imported from the io.appium.settings package

### DIFF
--- a/lib/commands/file-actions.js
+++ b/lib/commands/file-actions.js
@@ -37,18 +37,17 @@ function parseContainerPath(remotePath) {
  * and adds matching items to the device's media library.
  * Exceptions are ignored and written into the log.
  *
- * @param {ADB} adb ADB instance
+ * @this {import('../driver').AndroidDriver}
  * @param {string} remotePath The file/folder path on the remote device
- * @param {import('@appium/types').AppiumLogger} [log] Logger instance
  */
-async function scanMedia(adb, remotePath, log) {
-  log?.debug(`Performing media scan of '${remotePath}'`);
+async function scanMedia(remotePath) {
+  this.log.debug(`Performing media scan of '${remotePath}'`);
   try {
     // https://github.com/appium/appium/issues/16184
-    if ((await adb.getApiLevel()) >= 29) {
-      await adb.scanMedia(remotePath);
+    if ((await this.adb.getApiLevel()) >= 29) {
+      await this.settingsApp.scanMedia(remotePath);
     } else {
-      await adb.shell([
+      await this.adb.shell([
         'am',
         'broadcast',
         '-a',
@@ -60,7 +59,7 @@ async function scanMedia(adb, remotePath, log) {
   } catch (e) {
     const err = /** @type {any} */ (e);
     // FIXME: what has a `stderr` prop?
-    log?.warn(
+    this.log.warn(
       `Ignoring an unexpected error upon media scanning of '${remotePath}': ${
         err.stderr ?? err.message
       }`
@@ -183,7 +182,7 @@ const FileActionsMixin = {
 
         // if we have pushed a file, it might be a media file, so ensure that
         // apps know about it
-        await scanMedia(this.adb, remotePath, this.log);
+        await scanMedia.bind(this)(remotePath);
       }
     } finally {
       if (await fs.exists(localFile)) {

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -301,21 +301,20 @@ const GeneralMixin = {
       this.log.debug(`Parsed density value was NaN: "${out}"`);
     }
     // couldn't get anything, so error out
-    this.log.errorAndThrow('Failed to get display density property.');
-    throw new Error(); // unreachable
+    throw this.log.errorAndThrow('Failed to get display density property.');
   },
 
   async mobilePerformEditorAction(opts) {
     const {action} = requireArgs('action', opts);
-    await this.adb.performEditorAction(action);
+    await this.settingsApp.performEditorAction(action);
   },
 
   async mobileGetNotifications() {
-    return await this.adb.getNotifications();
+    return await this.settingsApp.getNotifications();
   },
 
   async mobileListSms(opts) {
-    return await this.adb.getSmsList(opts);
+    return await this.settingsApp.getSmsList(opts);
   },
 
   async mobileUnlock(opts = {}) {

--- a/lib/commands/media-projection.js
+++ b/lib/commands/media-projection.js
@@ -1,24 +1,12 @@
-// @ts-check
-
-import {fs, net, tempDir, util} from '@appium/support';
-import {waitForCondition} from 'asyncbox';
-import B from 'bluebird';
+import {fs, net, util} from '@appium/support';
 import _ from 'lodash';
 import moment from 'moment';
 import path from 'node:path';
-import {SETTINGS_HELPER_PKG_ID} from '../helpers';
 import {mixin} from './mixins';
 
 // https://github.com/appium/io.appium.settings#internal-audio--video-recording
 const DEFAULT_EXT = '.mp4';
-const RECORDING_STARTUP_TIMEOUT_MS = 3 * 1000;
-const RECORDING_STOP_TIMEOUT_MS = 3 * 1000;
 const MIN_API_LEVEL = 29;
-const RECORDING_SERVICE_NAME = `${SETTINGS_HELPER_PKG_ID}/.recorder.RecorderService`;
-const RECORDING_ACTIVITY_NAME = `${SETTINGS_HELPER_PKG_ID}/io.appium.settings.Settings`;
-const RECORDING_ACTION_START = `${SETTINGS_HELPER_PKG_ID}.recording.ACTION_START`;
-const RECORDING_ACTION_STOP = `${SETTINGS_HELPER_PKG_ID}.recording.ACTION_STOP`;
-const RECORDINGS_ROOT = `/storage/emulated/0/Android/data/${SETTINGS_HELPER_PKG_ID}/files`;
 const DEFAULT_FILENAME_FORMAT = 'YYYY-MM-DDTHH-mm-ss';
 
 /**
@@ -82,109 +70,6 @@ async function verifyMediaProjectionRecordingIsSupported(adb) {
   }
 }
 
-class MediaProjectionRecorder {
-  /**
-   * @param {ADB} adb
-   */
-  constructor(adb) {
-    this.adb = adb;
-  }
-
-  async isRunning() {
-    const stdout = await this.adb.shell([
-      'dumpsys',
-      'activity',
-      'services',
-      RECORDING_SERVICE_NAME,
-    ]);
-    return stdout.includes(RECORDING_SERVICE_NAME);
-  }
-
-  /**
-   *
-   * @param {import('./types').StartMediaProjectionRecordingOpts} opts
-   * @returns {Promise<boolean>}
-   */
-  async start(opts = {}) {
-    if (await this.isRunning()) {
-      return false;
-    }
-
-    await this.cleanup();
-    const {filename, maxDurationSec, priority, resolution} = opts;
-    const args = ['am', 'start', '-n', RECORDING_ACTIVITY_NAME, '-a', RECORDING_ACTION_START];
-    if (filename) {
-      args.push('--es', 'filename', filename);
-    }
-    if (maxDurationSec) {
-      args.push('--es', 'max_duration_sec', `${maxDurationSec}`);
-    }
-    if (priority) {
-      args.push('--es', 'priority', priority);
-    }
-    if (resolution) {
-      args.push('--es', 'resolution', resolution);
-    }
-    await this.adb.shell(args);
-    await new B((resolve, reject) => {
-      setTimeout(async () => {
-        if (!(await this.isRunning())) {
-          return reject(
-            new Error(
-              `The media projection recording is not running after ${RECORDING_STARTUP_TIMEOUT_MS}ms. ` +
-                `Please check the logcat output for more details.`
-            )
-          );
-        }
-        resolve();
-      }, RECORDING_STARTUP_TIMEOUT_MS);
-    });
-    return true;
-  }
-
-  async cleanup() {
-    await this.adb.shell([`rm -f ${RECORDINGS_ROOT}/*`]);
-  }
-
-  async pullRecent() {
-    const recordings = await this.adb.ls(RECORDINGS_ROOT, ['-tr']);
-    if (_.isEmpty(recordings)) {
-      return null;
-    }
-
-    const dstPath = path.join(await tempDir.openDir(), recordings[0]);
-    // increase timeout to 5 minutes because it might take a while to pull a large video file
-    await this.adb.pull(`${RECORDINGS_ROOT}/${recordings[0]}`, dstPath, {timeout: 300000});
-    return dstPath;
-  }
-
-  async stop() {
-    if (!(await this.isRunning())) {
-      return false;
-    }
-
-    await this.adb.shell([
-      'am',
-      'start',
-      '-n',
-      RECORDING_ACTIVITY_NAME,
-      '-a',
-      RECORDING_ACTION_STOP,
-    ]);
-    try {
-      await waitForCondition(async () => !(await this.isRunning()), {
-        waitMs: RECORDING_STOP_TIMEOUT_MS,
-        intervalMs: 500,
-      });
-    } catch (e) {
-      throw new Error(
-        `The attempt to stop the current media projection recording timed out after ` +
-          `${RECORDING_STOP_TIMEOUT_MS}ms`
-      );
-    }
-    return true;
-  }
-}
 /**
  * @type {import('./mixins').MediaProjectionMixin & ThisType<import('../driver').AndroidDriver>}
  * @satisfies {import('@appium/types').ExternalDriver}
@@ -194,7 +79,7 @@ const MediaProjectionMixin = {
     await verifyMediaProjectionRecordingIsSupported(this.adb);
 
     const {resolution, priority, maxDurationSec, filename} = options;
-    const recorder = new MediaProjectionRecorder(this.adb);
+    const recorder = this.settingsApp.makeMediaProjectionRecorder();
     const fname = adjustMediaExtension(filename || moment().format(DEFAULT_FILENAME_FORMAT));
     const didStart = await recorder.start({
       resolution,
@@ -215,14 +100,14 @@ const MediaProjectionMixin = {
   async mobileIsMediaProjectionRecordingRunning() {
     await verifyMediaProjectionRecordingIsSupported(this.adb);
 
-    const recorder = new MediaProjectionRecorder(this.adb);
+    const recorder = this.settingsApp.makeMediaProjectionRecorder();
     return await recorder.isRunning();
   },
 
   async mobileStopMediaProjectionRecording(options = {}) {
     await verifyMediaProjectionRecordingIsSupported(this.adb);
 
-    const recorder = new MediaProjectionRecorder(this.adb);
+    const recorder = this.settingsApp.makeMediaProjectionRecorder();
     if (await recorder.stop()) {
       this.log.info(
         'Successfully stopped a media projection recording. Pulling the recorded media'

--- a/lib/commands/mixins.ts
+++ b/lib/commands/mixins.ts
@@ -711,6 +711,7 @@ export interface NetworkMixin {
    * decoupling to override behaviour in other drivers like UiAutomator2.
    */
   setWifiState(state: boolean): Promise<void>;
+  setDataState(state: boolean): Promise<void>;
   toggleData(): Promise<void>;
   toggleWiFi(): Promise<void>;
   toggleFlightMode(): Promise<void>;

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {mixin} from './mixins';
 import _ from 'lodash';
 import {errors} from 'appium/driver';
@@ -67,10 +65,10 @@ const NetworkMixin = {
     /** @type {(Promise<any>|(() => Promise<any>))[]} */
     const setters = [];
     if (!_.isUndefined(wifi) && currentState.wifi !== Boolean(wifi)) {
-      setters.push(this.adb.setWifiState(wifi, this.isEmulator()));
+      setters.push(this.setWifiState(wifi));
     }
     if (!_.isUndefined(data) && currentState.data !== Boolean(data)) {
-      setters.push(this.adb.setDataState(data, this.isEmulator()));
+      setters.push(this.setDataState(data));
     }
     if (!_.isUndefined(airplaneMode) && currentState.airplaneMode !== Boolean(airplaneMode)) {
       setters.push(async () => {
@@ -170,26 +168,30 @@ const NetworkMixin = {
           `${shouldEnableDataConnection ? 'enabled' : 'disabled'}`
       );
     } else {
-      await this.adb.setDataState(shouldEnableDataConnection, this.isEmulator());
+      await this.setDataState(shouldEnableDataConnection);
     }
 
     return await this.getNetworkConnection();
   },
 
-  async setWifiState(wifi) {
-    await this.adb.setWifiState(wifi, this.isEmulator());
+  async setWifiState(isOn) {
+    await this.settingsApp.setWifiState(isOn, this.isEmulator());
+  },
+
+  async setDataState(isOn) {
+    await this.settingsApp.setDataState(isOn, this.isEmulator());
   },
 
   async toggleData() {
-    let data = !(await this.adb.isDataOn());
-    this.log.info(`Turning network data ${data ? 'on' : 'off'}`);
-    await this.adb.setWifiAndData({data}, this.isEmulator());
+    const isOn = await this.adb.isDataOn();
+    this.log.info(`Turning network data ${!isOn ? 'on' : 'off'}`);
+    await this.setDataState(!isOn);
   },
 
   async toggleWiFi() {
-    let wifi = !(await this.adb.isWifiOn());
-    this.log.info(`Turning WiFi ${wifi ? 'on' : 'off'}`);
-    await this.adb.setWifiAndData({wifi}, this.isEmulator());
+    const isOn = await this.adb.isWifiOn();
+    this.log.info(`Turning WiFi ${!isOn ? 'on' : 'off'}`);
+    await this.setWifiState(!isOn);
   },
 
   async toggleFlightMode() {
@@ -206,7 +208,7 @@ const NetworkMixin = {
   },
 
   async setGeoLocation(location) {
-    await this.adb.setGeoLocation(location, this.isEmulator());
+    await this.settingsApp.setGeoLocation(location, this.isEmulator());
     try {
       return await this.getGeoLocation();
     } catch (e) {
@@ -224,11 +226,11 @@ const NetworkMixin = {
 
   async mobileRefreshGpsCache(opts = {}) {
     const {timeoutMs} = opts;
-    await this.adb.refreshGeoLocationCache(timeoutMs);
+    await this.settingsApp.refreshGeoLocationCache(timeoutMs);
   },
 
   async getGeoLocation() {
-    const {latitude, longitude, altitude} = await this.adb.getGeoLocation();
+    const {latitude, longitude, altitude} = await this.settingsApp.getGeoLocation();
     return {
       latitude: parseFloat(String(latitude)) || GEO_EPSILON,
       longitude: parseFloat(String(longitude)) || GEO_EPSILON,

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -16,6 +16,7 @@ import {BaseDriver} from 'appium/driver';
 import ANDROID_DRIVER_CONSTRAINTS, {AndroidDriverConstraints} from './constraints';
 import {helpers} from './helpers';
 import {newMethodMap} from './method-map';
+import { SettingsApp } from 'io.appium.settings';
 
 export type AndroidDriverCaps = DriverCaps<AndroidDriverConstraints>;
 export type W3CAndroidDriverCaps = W3CDriverCaps<AndroidDriverConstraints>;
@@ -30,6 +31,8 @@ class AndroidDriver
   jwpProxyAvoid: RouteMatcher[];
 
   adb: ADB;
+
+  _settingsApp: SettingsApp;
 
   unlocker: typeof helpers.unlocker;
 
@@ -73,6 +76,13 @@ class AndroidDriver
 
     this.curContext = this.defaultContextName();
     this.opts = opts as AndroidDriverOpts;
+  }
+
+  get settingsApp() {
+    if (!this._settingsApp) {
+      this._settingsApp = new SettingsApp({adb: this.adb});
+    }
+    return this._settingsApp;
   }
 
   isEmulator() {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,10 @@ export type * from './commands';
 export {ANDROID_DRIVER_CONSTRAINTS as commonCapConstraints} from './constraints';
 export * from './driver';
 export * as doctor from './doctor/checks';
-export {SETTINGS_HELPER_PKG_ID, default as androidHelpers} from './helpers/android';
+export {
+  SETTINGS_HELPER_ID as SETTINGS_HELPER_PKG_ID,
+  default as androidHelpers
+} from './helpers/android';
 export type * from './helpers/types';
 export {
   CHROMIUM_WIN,

--- a/lib/stubs.ts
+++ b/lib/stubs.ts
@@ -1,7 +1,0 @@
-/**
- * This module contains delcaration stubs for dependencies that are untyped.
- * @module
- */
-
-// @ts-ignore It is expected this module is untyped
-declare module 'io.appium.settings';

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "asyncbox": "^3.0.0",
     "axios": "^1.x",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^5.3.0",
+    "io.appium.settings": "^5.7.1",
     "lodash": "^4.17.4",
     "lru-cache": "^10.0.1",
     "moment": "^2.24.0",

--- a/test/unit/android-helper-specs.js
+++ b/test/unit/android-helper-specs.js
@@ -155,59 +155,6 @@ describe('Android Helpers', function () {
       ensureNetworkSpeed(adb, 'invalid').should.be.equal('full');
     });
   });
-  describe(
-    'ensureDeviceLocale',
-    withMocks({adb}, (mocks) => {
-      it('should call setDeviceLanguageCountry', async function () {
-        mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US', undefined).once();
-        mocks.adb
-          .expects('ensureCurrentLocale')
-          .withExactArgs('en', 'US', undefined)
-          .once()
-          .returns(true);
-        await helpers.ensureDeviceLocale(adb, 'en', 'US', undefined);
-        mocks.adb.verify();
-      });
-      it('should call setDeviceLanguageCountry without script', async function () {
-        mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('en', 'US', undefined).once();
-        mocks.adb
-          .expects('ensureCurrentLocale')
-          .withExactArgs('en', 'US', undefined)
-          .once()
-          .returns(true);
-        await helpers.ensureDeviceLocale(adb, 'en', 'US', undefined);
-        mocks.adb.verify();
-      });
-      it('should call setDeviceLanguageCountry with script', async function () {
-        mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('zh', 'CN', 'Hans').once();
-        mocks.adb
-          .expects('ensureCurrentLocale')
-          .withExactArgs('zh', 'CN', 'Hans')
-          .once()
-          .returns(true);
-        await helpers.ensureDeviceLocale(adb, 'zh', 'CN', 'Hans');
-        mocks.adb.verify();
-      });
-      it('should never call setDeviceLanguageCountry', async function () {
-        mocks.adb.expects('setDeviceLanguageCountry').never();
-        mocks.adb.expects('getApiLevel').never();
-        await helpers.ensureDeviceLocale(adb);
-        mocks.adb.verify();
-      });
-      it('should call setDeviceLanguageCountry with throw', async function () {
-        mocks.adb.expects('setDeviceLanguageCountry').withExactArgs('fr', 'FR', undefined).once();
-        mocks.adb
-          .expects('ensureCurrentLocale')
-          .withExactArgs('fr', 'FR', undefined)
-          .once()
-          .returns(false);
-        await helpers
-          .ensureDeviceLocale(adb, 'fr', 'FR')
-          .should.be.rejectedWith(Error, `Failed to set language: fr and country: FR`);
-        mocks.adb.verify();
-      });
-    })
-  );
 
   describe('getDeviceInfoFromCaps', function () {
     // list of device/emu udids to their os versions
@@ -626,52 +573,6 @@ describe('Android Helpers', function () {
       it('should call adb.installOrUpgrade twice if otherApps has two item', async function () {
         mocks.adb.expects('installOrUpgrade').twice();
         await helpers.installOtherApks([fakeApk, otherFakeApk], adb, opts);
-        mocks.adb.verify();
-      });
-    })
-  );
-  describe(
-    'pushSettingsApp',
-    withMocks({adb}, (mocks) => {
-      it('should skip granting permissions if the app is already running on over API level 23+ devices', async function () {
-        mocks.adb.expects('installOrUpgrade').once().returns(true);
-        mocks.adb.expects('isSettingsAppServiceRunningInForeground').once().returns(true);
-        mocks.adb.expects('getApiLevel').never();
-        mocks.adb.expects('grantPermissions').never();
-        await helpers.pushSettingsApp(adb);
-        mocks.adb.verify();
-      });
-      it('should not skip granting permissions if the app is already running on under API level 22 devices', async function () {
-        mocks.adb.expects('installOrUpgrade').once().returns(true);
-        mocks.adb.expects('isSettingsAppServiceRunningInForeground').once().returns(true);
-        mocks.adb.expects('getApiLevel').never();
-        mocks.adb.expects('grantPermissions').never();
-        await helpers.pushSettingsApp(adb);
-        mocks.adb.verify();
-      });
-      it('should launch settings app if it isnt running on over API level 24 devices', async function () {
-        mocks.adb.expects('installOrUpgrade').once().returns(true);
-        mocks.adb.expects('isSettingsAppServiceRunningInForeground').once().returns(false);
-        mocks.adb.expects('getApiLevel').once().returns(24);
-        mocks.adb.expects('requireRunningSettingsApp').once();
-        await helpers.pushSettingsApp(adb);
-        mocks.adb.verify();
-      });
-      it('should launch settings app if it isnt running on under API level 23 devices', async function () {
-        mocks.adb.expects('installOrUpgrade').once().returns(true);
-        mocks.adb.expects('isSettingsAppServiceRunningInForeground').once().returns(false);
-        mocks.adb.expects('getApiLevel').once().returns(23);
-        mocks.adb
-          .expects('grantPermissions')
-          .once()
-          .withExactArgs('io.appium.settings', [
-            'android.permission.SET_ANIMATION_SCALE',
-            'android.permission.CHANGE_CONFIGURATION',
-            'android.permission.ACCESS_FINE_LOCATION',
-          ])
-          .returns(true);
-        mocks.adb.expects('requireRunningSettingsApp').once();
-        await helpers.pushSettingsApp(adb);
         mocks.adb.verify();
       });
     })


### PR DESCRIPTION
This is the part of the refactoring which is supposed to move all Settings App-related APIs into the corresponding package and incapsulate them there instead of abusing appium-adb for this purpose.