### PR TITLE
fix: stop parsing unreachable webview names

### DIFF
--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -191,7 +191,7 @@ export interface WebviewsMapping {
   /**
    * Webview pages list as it is retrieved by `/json/list` CDP endpoint
    */
-  pages: StringRecord[];
+  pages?: StringRecord[];
   /**
    * An actual webview name for switching context.
    *

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -1081,7 +1081,7 @@ export type SwipeAction = [
   NonReleaseTouchAction,
   NonReleaseTouchAction,
   NonReleaseTouchAction,
-  ReleaseTouchAction
+  ReleaseTouchAction,
 ];
 
 export type TouchDragAction = [NonReleaseTouchAction, NonReleaseTouchAction, ReleaseTouchAction];
@@ -1096,16 +1096,23 @@ export interface LockOpts {
 
 export interface DeviceidleOpts {
   /** The action name to execute */
-  action: 'whitelistAdd'|'whitelistRemove';
+  action: 'whitelistAdd' | 'whitelistRemove';
   /** Either a single package or multiple packages to add or remove from the idle whitelist */
-  packages?: string|string[];
+  packages?: string | string[];
 }
 
 export interface SendTrimMemoryOpts {
   /** The package name to send the `trimMemory` event to */
   pkg: string;
   /** The actual memory trim level to be sent */
-  level: 'COMPLETE' | 'MODERATE' | 'BACKGROUND' | 'UI_HIDDEN' | 'RUNNING_CRITICAL' | 'RUNNING_LOW' | 'RUNNING_MODERATE';
+  level:
+    | 'COMPLETE'
+    | 'MODERATE'
+    | 'BACKGROUND'
+    | 'UI_HIDDEN'
+    | 'RUNNING_CRITICAL'
+    | 'RUNNING_LOW'
+    | 'RUNNING_MODERATE';
 }
 
 export interface SetUiModeOpts {
@@ -1134,14 +1141,14 @@ export interface GetUiModeOpts {
 export interface SmsListResultItem {
   id: string;
   address: string;
-  person: string|null;
+  person: string | null;
   date: string;
   read: string;
   status: string;
   type: string;
-  subject: string|null;
+  subject: string | null;
   body: string;
-  serviceCenter: string|null;
+  serviceCenter: string | null;
 }
 
 export interface SmsListResult {

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -186,10 +186,14 @@ export interface WebviewsMapping {
   webview: string;
   /**
    * Webview information as it is retrieved by `/json/version` CDP endpoint
+   *
+   * This value becomes `undefined` when the retrieval failed.
    */
   info?: StringRecord;
   /**
    * Webview pages list as it is retrieved by `/json/list` CDP endpoint
+   *
+   * This value becomes `undefined` when the retrieval failed.
    */
   pages?: StringRecord[];
   /**

--- a/lib/helpers/webview.ts
+++ b/lib/helpers/webview.ts
@@ -396,12 +396,18 @@ const WebviewHelpers: WebviewHelpers = {
 
     const result: string[] = [];
     for (const {webview, pages, proc, webviewName} of webviewsMapping) {
-      if (ensureWebviewsHavePages && pages?.length === 0) {
-        logger.info(
-          `Skipping the webview '${webview}' at '${proc}' ` +
-            `since it has reported having zero pages`,
-        );
-        continue;
+      if (ensureWebviewsHavePages) {
+        if (_.isUndefined(pages)) {
+          logger.info(`Skipping the webview '${webview}' at '${proc}' since it is unreachable`);
+          continue;
+        }
+        if (pages.length === 0) {
+          logger.info(
+            `Skipping the webview '${webview}' at '${proc}' ` +
+              `since it has reported having zero pages`,
+          );
+          continue;
+        }
       }
       if (webviewName) {
         result.push(webviewName);

--- a/lib/helpers/webview.ts
+++ b/lib/helpers/webview.ts
@@ -323,8 +323,8 @@ async function collectWebviewsDetails(
   for (const item of webviewsMapping) {
     detailCollectors.push(
       (async () => {
-        let port: number|undefined;
-        let host: string|undefined;
+        let port: number | undefined;
+        let host: string | undefined;
         try {
           [host, port] = await allocateDevtoolsChannel(adb, item.proc, webviewDevtoolsPort);
           if (enableWebviewDetailsCollection) {

--- a/lib/helpers/webview.ts
+++ b/lib/helpers/webview.ts
@@ -401,7 +401,7 @@ const WebviewHelpers: WebviewHelpers = {
           logger.info(`Skipping the webview '${webview}' at '${proc}' since it is unreachable`);
           continue;
         }
-        if (pages.length === 0) {
+        if (!pages?.length) {
           logger.info(
             `Skipping the webview '${webview}' at '${proc}' ` +
               `since it has reported having zero pages`,

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -69,18 +69,20 @@ describe('Context', function () {
   });
   describe('setContext', function () {
     beforeEach(function () {
-      sandbox
-        .stub(webviewHelpers, 'getWebViewsMapping')
-        .returns([{webviewName: 'DEFAULT'}, {webviewName: 'WV'}, {webviewName: 'ANOTHER'}]);
+      sandbox.stub(webviewHelpers, 'getWebViewsMapping').returns([
+        {webviewName: 'DEFAULT', pages: ['PAGE']},
+        {webviewName: 'WV', pages: ['PAGE']},
+        {webviewName: 'ANOTHER', pages: ['PAGE']},
+      ]);
       sandbox.stub(driver, 'switchContext');
     });
     it('should switch to default context if name is null', async function () {
       sandbox.stub(driver, 'defaultContextName').returns('DEFAULT');
       await driver.setContext(null);
       driver.switchContext.calledWithExactly('DEFAULT', [
-        {webviewName: 'DEFAULT'},
-        {webviewName: 'WV'},
-        {webviewName: 'ANOTHER'},
+        {webviewName: 'DEFAULT', pages: ['PAGE']},
+        {webviewName: 'WV', pages: ['PAGE']},
+        {webviewName: 'ANOTHER', pages: ['PAGE']},
       ]).should.be.true;
       driver.curContext.should.be.equal('DEFAULT');
     });
@@ -88,9 +90,9 @@ describe('Context', function () {
       sandbox.stub(driver, 'defaultWebviewName').returns('WV');
       await driver.setContext(WEBVIEW_WIN);
       driver.switchContext.calledWithExactly('WV', [
-        {webviewName: 'DEFAULT'},
-        {webviewName: 'WV'},
-        {webviewName: 'ANOTHER'},
+        {webviewName: 'DEFAULT', pages: ['PAGE']},
+        {webviewName: 'WV', pages: ['PAGE']},
+        {webviewName: 'ANOTHER', pages: ['PAGE']},
       ]).should.be.true;
       driver.curContext.should.be.equal('WV');
     });

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -42,7 +42,9 @@ describe('Webview Helpers', function () {
           const webviewsMapping = await helpers.getWebViewsMapping(adb, {
             androidDeviceSocket: 'webview_devtools_remote_123',
           });
-          webViews = helpers.parseWebviewNames(webviewsMapping);
+          webViews = helpers.parseWebviewNames(webviewsMapping, {
+            ensureWebviewsHavePages: false,
+          });
         });
 
         it('then the unix sockets are queried', function () {
@@ -73,7 +75,9 @@ describe('Webview Helpers', function () {
           const webviewsMapping = await helpers.getWebViewsMapping(adb, {
             androidDeviceSocket: 'chrome_devtools_remote',
           });
-          webViews = helpers.parseWebviewNames(webviewsMapping);
+          webViews = helpers.parseWebviewNames(webviewsMapping, {
+            ensureWebviewsHavePages: false,
+          });
         });
 
         it('then the unix sockets are queried', function () {
@@ -132,7 +136,9 @@ describe('Webview Helpers', function () {
         describe('and the device socket is not specified', function () {
           beforeEach(async function () {
             const webviewsMapping = await helpers.getWebViewsMapping(adb);
-            webViews = helpers.parseWebviewNames(webviewsMapping);
+            webViews = helpers.parseWebviewNames(webviewsMapping, {
+              ensureWebviewsHavePages: false,
+            });
           });
 
           it('then the unix sockets are queried', function () {
@@ -151,7 +157,9 @@ describe('Webview Helpers', function () {
             const webviewsMapping = await helpers.getWebViewsMapping(adb, {
               androidDeviceSocket: 'com.application.myapp_devtools_remote',
             });
-            webViews = helpers.parseWebviewNames(webviewsMapping);
+            webViews = helpers.parseWebviewNames(webviewsMapping, {
+              ensureWebviewsHavePages: false,
+            });
           });
 
           it('then the unix sockets are queried', function () {

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -152,6 +152,26 @@ describe('Webview Helpers', function () {
             webViews.length.should.equal(0);
           });
         });
+
+        describe('and webviews have no pages', function () {
+          beforeEach(async function () {
+            const webviewsMapping = await helpers.getWebViewsMapping(adb, {
+              androidDeviceSocket: 'webview_devtools_remote_123',
+            });
+            webviewsMapping.length.should.equal(1);
+            webviewsMapping[0].pages = [];
+            webViews = helpers.parseWebviewNames(webviewsMapping);
+          });
+
+          it('then the unix sockets are queried', function () {
+            adb.shell.calledOnce.should.be.true;
+            adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
+          });
+
+          it('then no webviews are returned', function () {
+            webViews.length.should.equal(0);
+          });
+        });
       });
 
       describe('and crosswalk webviews exist', function () {

--- a/test/unit/webview-helper-specs.js
+++ b/test/unit/webview-helper-specs.js
@@ -118,6 +118,42 @@ describe('Webview Helpers', function () {
         });
       });
 
+      describe('and page existence is ensured', function () {
+        let webViews;
+
+        beforeEach(async function () {
+          sandbox.stub(adb, 'shell').callsFake(function () {
+            return (
+              'Num       RefCount Protocol Flags    Type St Inode Path\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2818 /dev/socket/ss_conn_daemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  9231 @mcdaemon\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01 245445 @webview_devtools_remote_123\n' +
+              '0000000000000000: 00000002 00000000 00010000 0001 01  2826 /dev/socket/installd\n'
+            );
+          });
+        });
+
+        describe('and webviews are unreachable', function () {
+          beforeEach(async function () {
+            const webviewsMapping = await helpers.getWebViewsMapping(adb, {
+              androidDeviceSocket: 'webview_devtools_remote_123',
+            });
+            webviewsMapping.length.should.equal(1);
+            webviewsMapping[0].should.not.have.key('pages');
+            webViews = helpers.parseWebviewNames(webviewsMapping);
+          });
+
+          it('then the unix sockets are queried', function () {
+            adb.shell.calledOnce.should.be.true;
+            adb.shell.getCall(0).args[0].should.deep.equal(['cat', '/proc/net/unix']);
+          });
+
+          it('then no webviews are returned', function () {
+            webViews.length.should.equal(0);
+          });
+        });
+      });
+
       describe('and crosswalk webviews exist', function () {
         let webViews;
 


### PR DESCRIPTION
## Intent

Currently, `getContexts` returns the webview names including the unreachable ones. This PR modifies the behavior not to return those.

## Confirmed

- ✅ unit test

With Android emulator,

1. Make an unreachable webview socket by the procedure described in https://issuetracker.google.com/issues/320819731 
2. Verify `getContexts` doesn't return the unreachable webview name
