### PR TITLE
fix: calls this.opts for createBaseADB

### DIFF
--- a/lib/commands/device/common.js
+++ b/lib/commands/device/common.js
@@ -130,10 +130,10 @@ export async function getDeviceInfoFromCaps() {
  * @property {(AndroidDriverOpts & {emPort?: number})?} [opts=null]
  * @returns {Promise<import('appium-adb').ADB>}
  */
-export async function createADB(opts = null) {
+export async function createADB() {
   // @ts-expect-error do not put arbitrary properties on opts
-  const {udid, emPort} = opts ?? {};
-  const adb = await createBaseADB(opts);
+  const {udid, emPort} = this.opts ?? {};
+  const adb = await createBaseADB(this.opts);
   adb.setDeviceId(udid ?? '');
   if (emPort) {
     adb.setEmulatorPort(emPort);

--- a/lib/commands/device/common.js
+++ b/lib/commands/device/common.js
@@ -87,7 +87,7 @@ export async function getDeviceInfoFromCaps() {
           ((!_.includes(this.opts.platformVersion, '.') &&
             /** @type {semver.SemVer} */ (semverPV).major ===
               /** @type {semver.SemVer} */ (semverDO).major) ||
-            /** @type {semver.SemVer} */ ((semverPV).major ===
+            (/** @type {semver.SemVer} */ (semverPV).major ===
               /** @type {semver.SemVer} */ (semverDO).major &&
               /** @type {semver.SemVer} */ (semverPV).minor ===
                 /** @type {semver.SemVer} */ (semverDO).minor)) &&

--- a/lib/commands/device/common.js
+++ b/lib/commands/device/common.js
@@ -87,7 +87,7 @@ export async function getDeviceInfoFromCaps() {
           ((!_.includes(this.opts.platformVersion, '.') &&
             /** @type {semver.SemVer} */ (semverPV).major ===
               /** @type {semver.SemVer} */ (semverDO).major) ||
-            (/** @type {semver.SemVer} */ (semverPV).major ===
+            /** @type {semver.SemVer} */ ((semverPV).major ===
               /** @type {semver.SemVer} */ (semverDO).major &&
               /** @type {semver.SemVer} */ (semverPV).minor ===
                 /** @type {semver.SemVer} */ (semverDO).minor)) &&
@@ -127,12 +127,11 @@ export async function getDeviceInfoFromCaps() {
 
 /**
  * @this {AndroidDriver}
- * @property {(AndroidDriverOpts & {emPort?: number})?} [opts=null]
  * @returns {Promise<import('appium-adb').ADB>}
  */
 export async function createADB() {
   // @ts-expect-error do not put arbitrary properties on opts
-  const {udid, emPort} = this.opts ?? {};
+  const {udid, emPort} = this.opts;
   const adb = await createBaseADB(this.opts);
   adb.setDeviceId(udid ?? '');
   if (emPort) {

--- a/test/unit/commands/device-specs.js
+++ b/test/unit/commands/device-specs.js
@@ -3,12 +3,11 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import ADB from 'appium-adb';
 import _ from 'lodash';
-import { AndroidDriver } from '../../../lib/driver';
-import { prepareAvdArgs, prepareEmulator } from '../../../lib/commands/device/utils';
+import {AndroidDriver} from '../../../lib/driver';
+import {prepareAvdArgs, prepareEmulator} from '../../../lib/commands/device/utils';
 import * as deviceUtils from '../../../lib/commands/device/utils';
 import * as geolocationHelpers from '../../../lib/commands/geolocation';
 import * as keyboardHelpers from '../../../lib/commands/keyboard';
-
 
 chai.use(chaiAsPromised);
 
@@ -71,7 +70,8 @@ describe('Device Helpers', function () {
     });
     it('should launch avd if one is not running', async function () {
       sandbox.stub(adb, 'getRunningAVDWithRetry').withArgs('foobar').throws();
-      sandbox.stub(adb, 'launchAVD')
+      sandbox
+        .stub(adb, 'launchAVD')
         .withArgs('foo@bar', {
           args: [],
           env: undefined,
@@ -91,9 +91,10 @@ describe('Device Helpers', function () {
           k1: 'v1',
           k2: 'v2',
         },
-      };;
+      };
       sandbox.stub(adb, 'getRunningAVDWithRetry').withArgs('foobar').throws();
-      sandbox.stub(adb, 'launchAVD')
+      sandbox
+        .stub(adb, 'launchAVD')
         .withArgs('foobar', {
           args: ['--arg1', 'value 1', '--arg2', 'value 2'],
           env: {
@@ -112,9 +113,10 @@ describe('Device Helpers', function () {
       driver.opts = {
         avd: 'foobar',
         avdArgs: ['--arg1', 'value 1', '--arg2', 'value 2'],
-      };;
+      };
       sandbox.stub(adb, 'getRunningAVDWithRetry').withArgs('foobar').throws();
-      sandbox.stub(adb, 'launchAVD')
+      sandbox
+        .stub(adb, 'launchAVD')
         .withArgs('foobar', {
           args: ['--arg1', 'value 1', '--arg2', 'value 2'],
           env: undefined,
@@ -127,7 +129,7 @@ describe('Device Helpers', function () {
       await prepareEmulator.bind(driver)(adb);
     });
     it('should kill emulator if avdArgs contains -wipe-data', async function () {
-      driver.opts = {avd: 'foo@bar', avdArgs: '-wipe-data'};;
+      driver.opts = {avd: 'foo@bar', avdArgs: '-wipe-data'};
       sandbox.stub(adb, 'getRunningAVDWithRetry').withArgs('foobar').returns('foo');
       sandbox.stub(adb, 'killEmulator').withArgs('foobar').onFirstCall();
       sandbox.stub(adb, 'launchAVD').onFirstCall();
@@ -326,7 +328,7 @@ describe('Device Helpers', function () {
       ADB.createADB.restore();
     });
     it('should create adb and set device id and emulator port', async function () {
-      await driver.createADB({
+      driver.opts = {
         udid: '111222',
         emPort: '111',
         adbPort: '222',
@@ -342,7 +344,8 @@ describe('Device Helpers', function () {
         remoteAppsCacheLimit: 5,
         buildToolsVersion: '1.2.3',
         allowOfflineDevices: true,
-      });
+      };
+      await driver.createADB();
       ADB.createADB.calledWithExactly({
         adbPort: '222',
         suppressKillServer: true,
@@ -376,10 +379,14 @@ describe('Device Helpers', function () {
       sandbox.stub(driver.adb, 'waitForDevice').throws();
       sandbox.stub(driver.adb, 'startLogcat').onFirstCall();
       sandbox.stub(deviceUtils, 'pushSettingsApp').onFirstCall();
-      sandbox.stub(driver, 'ensureDeviceLocale')
+      sandbox
+        .stub(driver, 'ensureDeviceLocale')
         .withArgs(driver.opts.language, driver.opts.locale, driver.opts.localeScript)
         .onFirstCall();
-      sandbox.stub(geolocationHelpers, 'setMockLocationApp').withArgs('io.appium.settings').onFirstCall();
+      sandbox
+        .stub(geolocationHelpers, 'setMockLocationApp')
+        .withArgs('io.appium.settings')
+        .onFirstCall();
       await driver.initDevice();
     });
     it('should init device without locale and language', async function () {
@@ -390,7 +397,10 @@ describe('Device Helpers', function () {
       sandbox.stub(driver.adb, 'startLogcat').onFirstCall();
       sandbox.stub(deviceUtils, 'pushSettingsApp').onFirstCall();
       sandbox.stub(driver, 'ensureDeviceLocale').throws();
-      sandbox.stub(geolocationHelpers, 'setMockLocationApp').withArgs('io.appium.settings').onFirstCall();
+      sandbox
+        .stub(geolocationHelpers, 'setMockLocationApp')
+        .withArgs('io.appium.settings')
+        .onFirstCall();
       await driver.initDevice();
     });
     it('should init device with either locale or language', async function () {
@@ -400,10 +410,14 @@ describe('Device Helpers', function () {
       sandbox.stub(driver.adb, 'waitForDevice').throws();
       sandbox.stub(driver.adb, 'startLogcat').onFirstCall();
       sandbox.stub(deviceUtils, 'pushSettingsApp').onFirstCall();
-      sandbox.stub(driver, 'ensureDeviceLocale')
+      sandbox
+        .stub(driver, 'ensureDeviceLocale')
         .withArgs(driver.opts.language, driver.opts.locale, driver.opts.localeScript)
         .onFirstCall();
-      sandbox.stub(geolocationHelpers, 'setMockLocationApp').withArgs('io.appium.settings').onFirstCall();
+      sandbox
+        .stub(geolocationHelpers, 'setMockLocationApp')
+        .withArgs('io.appium.settings')
+        .onFirstCall();
       await driver.initDevice();
     });
     it('should not install mock location on emulator', async function () {
@@ -437,9 +451,11 @@ describe('Device Helpers', function () {
       sandbox.stub(driver.adb, 'startLogcat').throws();
       sandbox.stub(deviceUtils, 'pushSettingsApp').onFirstCall();
       sandbox.stub(driver, 'ensureDeviceLocale').throws();
-      sandbox.stub(geolocationHelpers, 'setMockLocationApp').withArgs('io.appium.settings').onFirstCall();
+      sandbox
+        .stub(geolocationHelpers, 'setMockLocationApp')
+        .withArgs('io.appium.settings')
+        .onFirstCall();
       await driver.initDevice();
     });
   });
-
 });


### PR DESCRIPTION
As https://github.com/appium/appium-android-driver/blob/884c0bcdc0661a315954c46fe98acfd3e9f9d69b/lib/commands/device/common.js#L22 ?

https://github.com/appium/appium/issues/19713


Actually, when I saw logs in the ruby_lib_core's test Appium log, it had:

```
2024-01-25 09:30:47:019 - [ADB] Running '/Users/runner/Library/Android/sdk/platform-tools/adb -P 5037 start-server'
2024-01-25 09:30:47:041 - [ADB] Setting device id to 
2024-01-25 09:30:47:042 - [ADB] Running '/Users/runner/Library/Android/sdk/platform-tools/adb -P 5037 -s  shell getprop ro.build.version.sdk'
2024-01-25 09:30:47:194 - [ADB] Current device property 'ro.build.version.sdk': 29
2024-01-25 09:30:47:195 - [ADB] Getting device platform version
2024-01-25 09:30:47:195 - [ADB] Running '/Users/runner/Library/Android/sdk/platform-tools/adb -P 5037 -s  shell getprop ro.build.version.release'
2024-01-25 09:30:47:337 - [ADB] Current device property 'ro.build.version.release': 10
2024-01-25 09:30:47:337 - [ADB] Device API level: 29
```
but tests worked.

Testing in https://github.com/appium/ruby_lib_core/pull/520

---

hm, I used GitHub Codespase, then auto linter was applied...