### PR TITLE
feat: add checkVersion option for mobile:installApp

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -222,8 +222,7 @@ export async function installApp(appPath, opts) {
  * @returns {Promise<void>}
  */
 export async function mobileInstallApp(opts) {
-  const {appPath} = requireArgs('appPath', opts);
-  const {checkVersion} = opts;
+  const {appPath, checkVersion} = requireArgs('appPath', opts);
   if (checkVersion) {
     const localPath = await this.helpers.configureApp(appPath, APP_EXTENSIONS);
     await this.adb.installOrUpgrade(localPath, null, Object.assign({}, opts, {enforceCurrentBuild: false}));

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -223,9 +223,10 @@ export async function installApp(appPath, opts) {
  */
 export async function mobileInstallApp(opts) {
   const {appPath} = requireArgs('appPath', opts);
-  const {versionCheck} = opts;
-  if (versionCheck) {
-    await this.adb.installOrUpgrade(appPath, null, opts);
+  const {checkVersion} = opts;
+  if (checkVersion) {
+    const localPath = await this.helpers.configureApp(appPath, APP_EXTENSIONS);
+    await this.adb.installOrUpgrade(localPath, null, Object.assign({}, opts, {enforceCurrentBuild: false}));
     return;
   }
 

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -223,6 +223,12 @@ export async function installApp(appPath, opts) {
  */
 export async function mobileInstallApp(opts) {
   const {appPath} = requireArgs('appPath', opts);
+  const {versionCheck} = opts;
+  if (versionCheck) {
+    await this.adb.installOrUpgrade(appPath, null, opts);
+    return;
+  }
+
   return await this.installApp(appPath, opts);
 }
 

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -174,7 +174,7 @@ export interface RemoveAppOpts extends UninstallOptions {
 
 export interface InstallAppOpts extends InstallOptions {
   appPath: string;
-  versionCheck: boolean;
+  checkVersion: boolean;
 }
 
 export interface WebviewsMapping {

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -174,6 +174,7 @@ export interface RemoveAppOpts extends UninstallOptions {
 
 export interface InstallAppOpts extends InstallOptions {
   appPath: string;
+  versionCheck: boolean;
 }
 
 export interface WebviewsMapping {


### PR DESCRIPTION
As same as https://github.com/appium/appium-xcuitest-driver/pull/2322 , so app installation will be skipped if the installed app is equal or greater than the installed app

https://github.com/appium/appium/issues/19754


e.g. with uia2


- `driver.execute_script "mobile: installApp", {appPath: "https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip", checkVersion: false}`
- `driver.execute_script "mobile: installApp", {appPath: "https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip", checkVersion: true}`


```
[HTTP] --> POST /session/f8146e45-e10b-4e8e-abe4-6eb9d8f927ef/execute/sync
[HTTP] {"script":"mobile: installApp","args":[{"appPath":"https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip"}]}
[debug] [AndroidUiautomator2Driver@719d (f8146e45)] Calling AppiumDriver.execute() with args: ["mobile: installApp",[{"appPath":"https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip"}],"f8146e45-e10b-4e8e-abe4-6eb9d8f927ef"]
[AndroidUiautomator2Driver@719d (f8146e45)] Executing method 'mobile: installApp'
[debug] [BaseDriver] Cached app data: {
[debug] [BaseDriver]   "lastModified": null,
[debug] [BaseDriver]   "immutable": false,
[debug] [BaseDriver]   "maxAge": 300,
[debug] [BaseDriver]   "etag": "W/\"d8f6c539b8657abd111a46ea257f9240b353b09c95eaed74fb322dd1b4898482\"",
[debug] [BaseDriver]   "timestamp": 1707376209263,
[debug] [BaseDriver]   "packageHash": "01b778aa2e0e3c91e6a5219de9cfd8fea1757805",
[debug] [BaseDriver]   "integrity": {
[debug] [BaseDriver]     "file": "e5d5451e0d5300e78bff059460313425fb344b5c"
[debug] [BaseDriver]   },
[debug] [BaseDriver]   "fullPath": "/var/folders/xt/hbb7vf_d2_g6ks5b765c890c0000gn/T/202417-40758-iek5w2.42nf/api.apk"
[debug] [BaseDriver] }
[BaseDriver] Using downloadable app 'https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip'
[debug] [BaseDriver] Etag: W/"d8f6c539b8657abd111a46ea257f9240b353b09c95eaed74fb322dd1b4898482"
[debug] [BaseDriver] Last-Modified: undefined
[debug] [BaseDriver] Cache-Control: max-age=300
[BaseDriver] Reusing previously downloaded application at '/var/folders/xt/hbb7vf_d2_g6ks5b765c890c0000gn/T/202417-40758-iek5w2.42nf/api.apk'
[ADB] The application at '/var/folders/xt/hbb7vf_d2_g6ks5b765c890c0000gn/T/202417-40758-iek5w2.42nf/api.apk' will not be cached, because the device under test has confirmed the support of streamed installs
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 install -r /var/folders/xt/hbb7vf_d2_g6ks5b765c890c0000gn/T/202417-40758-iek5w2.42nf/api.apk'
[ADB] The installation of 'api.apk' took 201ms
[debug] [ADB] Install command stdout: Performing Streamed Install
[debug] [ADB] Success
[debug] [AndroidUiautomator2Driver@719d (f8146e45)] Responding to client with driver.execute() result: null
[HTTP] <-- POST /session/f8146e45-e10b-4e8e-abe4-6eb9d8f927ef/execute/sync 200 435 ms - 14
[HTTP]
[HTTP] --> POST /session/f8146e45-e10b-4e8e-abe4-6eb9d8f927ef/execute/sync
[HTTP] {"script":"mobile: installApp","args":[{"appPath":"https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip","checkVersion":true}]}
[debug] [AndroidUiautomator2Driver@719d (f8146e45)] Calling AppiumDriver.execute() with args: ["mobile: installApp",[{"appPath":"https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip","checkVersion":true}],"f8146e45-e10b-4e8e-abe4-6eb9d8f927ef"]
[AndroidUiautomator2Driver@719d (f8146e45)] Executing method 'mobile: installApp'
[debug] [BaseDriver] Cached app data: {
[debug] [BaseDriver]   "lastModified": null,
[debug] [BaseDriver]   "immutable": false,
[debug] [BaseDriver]   "maxAge": 300,
[debug] [BaseDriver]   "etag": "W/\"d8f6c539b8657abd111a46ea257f9240b353b09c95eaed74fb322dd1b4898482\"",
[debug] [BaseDriver]   "timestamp": 1707376209263,
[debug] [BaseDriver]   "packageHash": "01b778aa2e0e3c91e6a5219de9cfd8fea1757805",
[debug] [BaseDriver]   "integrity": {
[debug] [BaseDriver]     "file": "e5d5451e0d5300e78bff059460313425fb344b5c"
[debug] [BaseDriver]   },
[debug] [BaseDriver]   "fullPath": "/var/folders/xt/hbb7vf_d2_g6ks5b765c890c0000gn/T/202417-40758-iek5w2.42nf/api.apk"
[debug] [BaseDriver] }
[BaseDriver] Using downloadable app 'https://github.com/appium/ruby_lib_core/raw/master/test/functional/app/api.apk.zip'
[debug] [BaseDriver] Etag: W/"d8f6c539b8657abd111a46ea257f9240b353b09c95eaed74fb322dd1b4898482"
[debug] [BaseDriver] Last-Modified: undefined
[debug] [BaseDriver] Cache-Control: max-age=300
[BaseDriver] Reusing previously downloaded application at '/var/folders/xt/hbb7vf_d2_g6ks5b765c890c0000gn/T/202417-40758-iek5w2.42nf/api.apk'
[debug] [ADB] Getting package info for 'io.appium.android.apis'
[debug] [ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell dumpsys package io.appium.android.apis'
[debug] [ADB] The version name of the installed 'io.appium.android.apis' is greater or equal to the application version name ('4.1.1' >= '4.1.1')
[debug] [ADB] There is no need to install/upgrade '/var/folders/xt/hbb7vf_d2_g6ks5b765c890c0000gn/T/202417-40758-iek5w2.42nf/api.apk'
[debug] [AndroidUiautomator2Driver@719d (f8146e45)] Responding to client with driver.execute() result: null
[HTTP] <-- POST /session/f8146e45-e10b-4e8e-abe4-6eb9d8f927ef/execute/sync 200 340 ms - 14
```