### PR TITLE
chore: Add timeout option to adb.pull() in stopRecordingScreen function

### DIFF
--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -134,7 +134,7 @@ export async function stopRecordingScreen(options = {}) {
     for (const pathOnDevice of this._screenRecordingProperties.records) {
       const relativePath = path.resolve(tmpRoot, path.posix.basename(pathOnDevice));
       localRecords.push(relativePath);
-      await this.adb.pull(pathOnDevice, relativePath);
+      await this.adb.pull(pathOnDevice, relativePath, { timeout: 5 * 60 * 1000 });
       await this.adb.rimraf(pathOnDevice);
     }
     let resultFilePath = /** @type {string} */ (_.last(localRecords));

--- a/lib/commands/recordscreen.js
+++ b/lib/commands/recordscreen.js
@@ -14,6 +14,7 @@ const SCREENRECORD_BINARY = 'screenrecord';
 const DEFAULT_EXT = '.mp4';
 const MIN_EMULATOR_API_LEVEL = 27;
 const FFMPEG_BINARY = `ffmpeg${system.isWindows() ? '.exe' : ''}`;
+const ADB_PULL_TIMEOUT = 5 * 60 * 1000;
 
 /**
  *
@@ -134,7 +135,7 @@ export async function stopRecordingScreen(options = {}) {
     for (const pathOnDevice of this._screenRecordingProperties.records) {
       const relativePath = path.resolve(tmpRoot, path.posix.basename(pathOnDevice));
       localRecords.push(relativePath);
-      await this.adb.pull(pathOnDevice, relativePath, { timeout: 5 * 60 * 1000 });
+      await this.adb.pull(pathOnDevice, relativePath, { timeout: ADB_PULL_TIMEOUT });
       await this.adb.rimraf(pathOnDevice);
     }
     let resultFilePath = /** @type {string} */ (_.last(localRecords));


### PR DESCRIPTION
There was set not enough long timeout: 1-min (default value)
- https://github.com/appium/appium/issues/19785