### PR TITLE
chore: Add stubs for legacy APIs

### DIFF
--- a/lib/commands/legacy.js
+++ b/lib/commands/legacy.js
@@ -1,0 +1,31 @@
+import { errors } from 'appium/driver';
+
+const ISSUE_URL = 'https://github.com/appium/appium/issues/15807';
+
+/**
+ * @this {AndroidDriver}
+ */
+// eslint-disable-next-line require-await
+export async function launchApp () {
+  throw new errors.UnsupportedOperationError(`This API is not supported anymore. See ${ISSUE_URL}`);
+}
+
+/**
+ * @this {AndroidDriver}
+ */
+// eslint-disable-next-line require-await
+export async function closeApp () {
+  throw new errors.UnsupportedOperationError(`This API is not supported anymore. See ${ISSUE_URL}`);
+}
+
+/**
+ * @this {AndroidDriver}
+ */
+// eslint-disable-next-line require-await
+export async function reset () {
+  throw new errors.UnsupportedOperationError(`This API is not supported anymore. See ${ISSUE_URL}`);
+}
+
+/**
+ * @typedef {import('../driver').AndroidDriver} AndroidDriver
+ */

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -188,6 +188,11 @@ import {
   getPerformanceDataTypes,
   mobileGetPerformanceData,
 } from './commands/performance';
+import {
+  reset,
+  closeApp,
+  launchApp,
+} from './commands/legacy';
 import {mobileChangePermissions, mobileGetPermissions} from './commands/permissions';
 import {startRecordingScreen, stopRecordingScreen} from './commands/recordscreen';
 import {getStrings, ensureDeviceLocale} from './commands/resources';
@@ -516,6 +521,10 @@ class AndroidDriver
 
   getDeviceTime = getDeviceTime;
   mobileGetDeviceTime = mobileGetDeviceTime;
+
+  reset = reset;
+  closeApp = closeApp;
+  launchApp = launchApp;
 }
 
 export {AndroidDriver};


### PR DESCRIPTION
These handlers are still present in the base driver, but we don't want to have them to be available here. So throw a proper error message instead.

This should also allow to remove some extra code from the espresso driver afterwards