### PR TITLE
fix: Add a workaround for wrong adb exit code on service stop

### DIFF
--- a/lib/commands/intent.js
+++ b/lib/commands/intent.js
@@ -162,7 +162,15 @@ export async function mobileStopService(opts = {}) {
     cmd.push('--user', String(user));
   }
   cmd.push(...parseIntentSpec(opts));
-  return await this.adb.shell(cmd);
+  try {
+    return await this.adb.shell(cmd);
+  } catch (e) {
+    // https://github.com/appium/appium-uiautomator2-driver/issues/792
+    if (e.code === 255 && e.stderr?.includes('Service stopped')) {
+      return e.stderr;
+    }
+    throw e;
+  }
 }
 
 // #region Internal helpers


### PR DESCRIPTION
Addresses https://github.com/appium/appium-uiautomator2-driver/issues/792