### PR TITLE
fix: Add retry for keyboard hide

### DIFF
--- a/lib/commands/device/common.js
+++ b/lib/commands/device/common.js
@@ -11,6 +11,7 @@ import {
   pushSettingsApp,
 } from './utils';
 import {adjustTimeZone} from '../time';
+import { retryInterval } from 'asyncbox';
 
 /**
  * @this {AndroidDriver}
@@ -247,7 +248,10 @@ export async function initDevice() {
   }
   setupPromises.push((async () => {
     if (hideKeyboard) {
-      await hideKeyboardCompletely.bind(this)();
+      // Sometimes we have a race condition when Android
+      // does not register input services soon enough
+      // after Settings app is installed
+      await retryInterval(3, 500, async () => await hideKeyboardCompletely.bind(this)());
     } else if (hideKeyboard === false) {
       await this.adb.shell(['ime', 'reset']);
     }


### PR DESCRIPTION
Sometimes we have a race condition when Android does not register input services soon enough after Settings app is installed. Then the following error is thrown: 
> {"tag":"InputMethodManagerService","message":"InputMethodManagerService : \"ime enable io.appium.settings/.EmptyIME\" for user #0 failed due to its unrecognized IME ID.","processId":2389,"level":"ERROR","timestamp":"2024-07-01 10:53:34.565"}
