### PR TITLE
fix: Tune application termination condition

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -205,7 +205,7 @@ export async function terminateApp(appId, options = {}) {
         this.log.info(
           `The application '${appId}' was reported running, ` +
           `although its process ids have been changed: ` +
-          `(${JSON.stringify(pids)} -> ${JSON.stringify(remainingPids)}). ` +
+          `(${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
           `Assuming the termination was succesull.`
         );
         return true;

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -205,7 +205,7 @@ export async function terminateApp(appId, options = {}) {
       if (_.isEmpty(currentPids) || _.isEmpty(_.intersection(pids, currentPids))) {
         this.log.info(
           `The application '${appId}' was reported running, ` +
-          `although process ids of all processes belonging to it have been changed: ` +
+          `although all process ids belonging to it have been changed: ` +
           `(${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
           `Assuming the termination was succesull.`
         );
@@ -220,10 +220,8 @@ export async function terminateApp(appId, options = {}) {
     if (!_.isEmpty(currentPids) && !_.isEmpty(_.difference(pids, currentPids))) {
       this.log.warn(
         `Some of processes belonging to the '${appId}' applcation are still running ` +
-        `after ${timeout}ms (${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
-        `Assuming the termination was succesull.`
+        `after ${timeout}ms (${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)})`
       );
-      return true;
     }
     throw this.log.errorWithException(`'${appId}' is still running after ${timeout}ms timeout`);
   }

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -175,7 +175,8 @@ export async function mobileRemoveApp(opts) {
  */
 export async function terminateApp(appId, options = {}) {
   this.log.info(`Terminating '${appId}'`);
-  if (!(await this.adb.processExists(appId))) {
+  const pids = await this.adb.getPIDsByName(appId);
+  if (_.isEmpty(pids)) {
     this.log.info(`The app '${appId}' is not running`);
     return false;
   }
@@ -187,19 +188,42 @@ export async function terminateApp(appId, options = {}) {
 
   if (timeout <= 0) {
     this.log.info(
-      `'${appId}' has been terminated. Skip checking the application process state ` +
-        `since the timeout was set as ${timeout}ms`,
+      `'${appId}' has been terminated. Skipping checking of the application process state ` +
+      `since the timeout was set to ${timeout}ms`,
     );
     return true;
   }
 
   try {
-    await waitForCondition(async () => (await this.queryAppState(appId)) <= APP_STATE.NOT_RUNNING, {
+    await waitForCondition(async () => {
+      if (await this.queryAppState(appId) <= APP_STATE.NOT_RUNNING) {
+        return true;
+      }
+      const currentPids = await this.adb.getPIDsByName(appId);
+      const remainingPids = _.intersection(pids, currentPids);
+      if (_.isEmpty(currentPids) || _.isEmpty(remainingPids)) {
+        this.log.info(
+          `The application '${appId}' was reported running, ` +
+          `although its process ids have been changed: ` +
+          `(${JSON.stringify(pids)} -> ${JSON.stringify(remainingPids)}). ` +
+          `Assuming the termination was succesull.`
+        );
+        return true;
+      } else if (_.isEqual(currentPids, remainingPids)) {
+        return false;
+      }
+      this.log.warn(
+        `Some of processes belonging to the '${appId}' applcation are still running ` +
+        `(${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
+        `Assuming the termination was succesull.`
+      );
+      return true;
+    }, {
       waitMs: timeout,
       intervalMs: 100,
     });
   } catch (e) {
-    this.log.errorAndThrow(`'${appId}' is still running after ${timeout}ms timeout`);
+    throw this.log.errorWithException(`'${appId}' is still running after ${timeout}ms timeout`);
   }
   this.log.info(`'${appId}' has been successfully terminated`);
   return true;

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -209,7 +209,7 @@ export async function terminateApp(appId, options = {}) {
           `Assuming the termination was succesull.`
         );
         return true;
-      } else if (_.isEqual(currentPids, remainingPids)) {
+      } else if (_.isEmpty(_.difference(currentPids, remainingPids))) {
         return false;
       }
       this.log.warn(

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -194,35 +194,37 @@ export async function terminateApp(appId, options = {}) {
     return true;
   }
 
+  /** @type {number[]} */
+  let currentPids = [];
   try {
     await waitForCondition(async () => {
       if (await this.queryAppState(appId) <= APP_STATE.NOT_RUNNING) {
         return true;
       }
-      const currentPids = await this.adb.getPIDsByName(appId);
-      const remainingPids = _.intersection(pids, currentPids);
-      if (_.isEmpty(currentPids) || _.isEmpty(remainingPids)) {
+      currentPids = await this.adb.getPIDsByName(appId);
+      if (_.isEmpty(currentPids) || _.isEmpty(_.intersection(pids, currentPids))) {
         this.log.info(
           `The application '${appId}' was reported running, ` +
-          `although its process ids have been changed: ` +
+          `although process ids of all processes belonging to it have been changed: ` +
           `(${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
           `Assuming the termination was succesull.`
         );
         return true;
-      } else if (_.isEmpty(_.difference(currentPids, remainingPids))) {
-        return false;
       }
-      this.log.warn(
-        `Some of processes belonging to the '${appId}' applcation are still running ` +
-        `(${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
-        `Assuming the termination was succesull.`
-      );
-      return true;
+      return false;
     }, {
       waitMs: timeout,
       intervalMs: 100,
     });
   } catch (e) {
+    if (!_.isEmpty(currentPids) && !_.isEmpty(_.difference(pids, currentPids))) {
+      this.log.warn(
+        `Some of processes belonging to the '${appId}' applcation are still running ` +
+        `after ${timeout}ms (${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
+        `Assuming the termination was succesull.`
+      );
+      return true;
+    }
     throw this.log.errorWithException(`'${appId}' is still running after ${timeout}ms timeout`);
   }
   this.log.info(`'${appId}' has been successfully terminated`);

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -207,7 +207,7 @@ export async function terminateApp(appId, options = {}) {
           `The application '${appId}' was reported running, ` +
           `although all process ids belonging to it have been changed: ` +
           `(${JSON.stringify(pids)} -> ${JSON.stringify(currentPids)}). ` +
-          `Assuming the termination was succesull.`
+          `Assuming the termination was successful.`
         );
         return true;
       }


### PR DESCRIPTION
Sometimes an app might be terminated and then immediately restored by the system. If that happens then its processes becoming different PIDs. This PR handles such situation and marks app termination as successful if all application PIDs have been changed within the given timeout