### PR TITLE
feat: support 'goog:loggingPrefs' value when creating a session

### DIFF
--- a/lib/commands/context/helpers.js
+++ b/lib/commands/context/helpers.js
@@ -739,12 +739,12 @@ export async function setupNewChromedriver(opts, curDeviceId, context) {
   }
 
   // Ensure there are logging preferences
-  opts.chromeLoggingPrefs = opts.chromeLoggingPrefs || {};
+  opts.chromeLoggingPrefs = opts.chromeLoggingPrefs ?? {};
 
   // Strip the prefix and store it
   for (const opt of _.keys(opts)) {
     if (opt.endsWith(':loggingPrefs')) {
-      this?.log?.warn(`Merging '${opt}' into 'chromeLoggingPrefs'. This may cause unexpected behavior`);
+      this.log.warn(`Merging '${opt}' into 'chromeLoggingPrefs'. This may cause unexpected behavior`);
       _.merge(opts.chromeLoggingPrefs, opts[opt]);
     }
   }

--- a/lib/commands/context/helpers.js
+++ b/lib/commands/context/helpers.js
@@ -738,6 +738,17 @@ export async function setupNewChromedriver(opts, curDeviceId, context) {
     }
   }
 
+  // Ensure there are logging preferences
+  opts.chromeLoggingPrefs = opts.chromeLoggingPrefs || {};
+
+  // Strip the prefix and store it
+  for (const opt of _.keys(opts)) {
+    if (opt.endsWith(':loggingPrefs')) {
+      this?.log?.warn(`Merging '${opt}' into 'chromeLoggingPrefs'. This may cause unexpected behavior`);
+      _.merge(opts.chromeLoggingPrefs, opts[opt]);
+    }
+  }
+
   const caps = /** @type {any} */ (createChromedriverCaps.bind(this)(opts, curDeviceId, details));
   this.log.debug(
     `Before starting chromedriver, androidPackage is '${caps.chromeOptions.androidPackage}'`,

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -319,6 +319,10 @@ describe('Context', function () {
       let chromedriver = await setupNewChromedriver.bind(driver)({enablePerformanceLogging: true});
       chromedriver.start.getCall(0).args[0].loggingPrefs.should.deep.equal({performance: 'ALL'});
     });
+    it('should use prefixed logging preferences', async function () {
+      let chromedriver = await setupNewChromedriver.bind(driver)({'goog:loggingPrefs': { 'performance': 'ALL', 'browser': 'INFO' }});
+      chromedriver.start.getCall(0).args[0].loggingPrefs.should.deep.equal({performance: 'ALL', 'browser': 'INFO'});
+    });
     it('should set androidActivity to appActivity if browser name is chromium-webview', async function () {
       let chromedriver = await setupNewChromedriver.bind(driver)({
         browserName: 'chromium-webview',
@@ -328,7 +332,7 @@ describe('Context', function () {
         .getCall(0)
         .args[0].chromeOptions.androidActivity.should.be.equal('app_act');
     });
-    it('should be able to set loggingPrefs capability', async function () {
+    it('should be able to set pageLoad strategy', async function () {
       let chromedriver = await setupNewChromedriver.bind(driver)({pageLoadStrategy: 'strategy'});
       chromedriver.start.getCall(0).args[0].pageLoadStrategy.should.be.equal('strategy');
     });

--- a/test/unit/commands/context-specs.js
+++ b/test/unit/commands/context-specs.js
@@ -320,8 +320,8 @@ describe('Context', function () {
       chromedriver.start.getCall(0).args[0].loggingPrefs.should.deep.equal({performance: 'ALL'});
     });
     it('should use prefixed logging preferences', async function () {
-      let chromedriver = await setupNewChromedriver.bind(driver)({'goog:loggingPrefs': { 'performance': 'ALL', 'browser': 'INFO' }});
-      chromedriver.start.getCall(0).args[0].loggingPrefs.should.deep.equal({performance: 'ALL', 'browser': 'INFO'});
+      let chromedriver = await setupNewChromedriver.bind(driver)({'goog:loggingPrefs': { performance: 'ALL', browser: 'INFO' }});
+      chromedriver.start.getCall(0).args[0].loggingPrefs.should.deep.equal({performance: 'ALL', browser: 'INFO'});
     });
     it('should set androidActivity to appActivity if browser name is chromium-webview', async function () {
       let chromedriver = await setupNewChromedriver.bind(driver)({


### PR DESCRIPTION
Problem: Able to receive performance log types and get performance logs when using Mobile JSON Wire protocol but unable to do the same when using W3C. 

Reason: The logging preferences are set using "goog:LoggingPrefs" in Selenium capability. "`[enablePerformanceLogging](https://github.com/appium/appium-android-driver/blob/92b51340cd976a73cb60530d6cdd6d43414b939a/lib/commands/context/helpers.js#L208)`" is deprecated and Selenium 4 does not allow passing it. However, the Appium Android driver did not account for it and set it correctly to pass it to the Appium Chromedriver. Thus, the ChromeDriver would not receive it and then create a default session with the default logging preferences i.e. `{browser: ALL}`.

Logs (when trying to use the Appium server):

Capabilities sent: 

`22024-08-28 14:12:36:753 - [HTTP] {"capabilities":{"firstMatch":[{"goog:chromeOptions":{"args":["--proxy-bypass-list=<-loopback>","test-type","--proxy-server=http://[REDACTED]","--disable-features=Translate"]},"newCommandTimeout":0,"goog:loggingPrefs":{"performance":"ALL"},"appium:skipServerInstallation":"true","platformName":"Android","deviceName":"android","browserName":"chrome"}]}}`

Capabilities when creating a ChromeDriver session capabilities: 

```
2024-08-28 14:12:40:644 - [AndroidDriver] Merging 'goog:chromeOptions' into 'chromeOptions'. This may cause unexpected behavior
2024-08-28 14:12:40:644 - [debug] [AndroidDriver] Before starting chromedriver, androidPackage is 'com.android.chrome'
2024-08-28 14:12:40:645 - [debug] [Chromedriver] Changed state to 'starting'
2024-08-28 14:12:40:645 - [Chromedriver] Set chromedriver binary as: /usr/local/.browserstack/deps/chromedriver/v123.0.6312.86/chromedriver
2024-08-28 14:12:40:645 - [debug] [Chromedriver] Killing any old chromedrivers, running: pkill -15 -f "/usr/local/.browserstack/deps/chromedriver/v123.0.6312.86/chromedriver.*--port=18086"
2024-08-28 14:12:40:663 - [Chromedriver] No old chromedrivers seem to exist
2024-08-28 14:12:40:663 - [debug] [Chromedriver] Cleaning any old adb forwarded port socket connections
2024-08-28 14:12:40:664 - [debug] [ADB] List forwarding ports
2024-08-28 14:12:40:664 - [debug] [ADB] Running '/usr/local/.browserstack/android-sdk/platform-tools/adb -P 5037 -s R5CT21L7E6E forward --list'
2024-08-28 14:12:40:671 - [Chromedriver] Spawning chromedriver with: /usr/local/.browserstack/deps/chromedriver/v123.0.6312.86/chromedriver --url-base=wd/hub --port=18086 --adb-port=5037 --verbose
2024-08-28 14:12:40:681 - [debug] [Chromedriver] Chromedriver version: '123.0.6312.86'
2024-08-28 14:12:40:682 - [debug] [WD Proxy] Matched '/status' to command name 'getStatus'
2024-08-28 14:12:40:682 - [debug] [WD Proxy] Proxying [GET /status] to [GET http://127.0.0.1:18086/wd/hub/status] with no body
2024-08-28 14:12:40:684 - [debug] [WD Proxy] Got response with status 200: {"value":{"build":{"version":"123.0.6312.86 (9b72c47a053648d405376c5cf07999ed626728da-refs/branch-heads/6312@{#698})"},"message":"ChromeDriver ready for new sessions.","os":{"arch":"x86_64","name":"Linux","version":"5.16.12-200.fc35.x86_64"},"ready":true}}
2024-08-28 14:12:40:684 - [Chromedriver] Starting W3C Chromedriver session with capabilities: {
2024-08-28 14:12:40:684 - [Chromedriver]   "capabilities": {
2024-08-28 14:12:40:684 - [Chromedriver]     "alwaysMatch": {
2024-08-28 14:12:40:684 - [Chromedriver]       "goog:chromeOptions": {
2024-08-28 14:12:40:684 - [Chromedriver]         "androidPackage": "com.android.chrome",
2024-08-28 14:12:40:684 - [Chromedriver]         "args": [
2024-08-28 14:12:40:684 - [Chromedriver]           "--proxy-bypass-list=<-loopback>",
2024-08-28 14:12:40:684 - [Chromedriver]           "test-type",
2024-08-28 14:12:40:684 - [Chromedriver]           "--proxy-server=http://[REDACTED]",
2024-08-28 14:12:40:684 - [Chromedriver]           "--disable-features=Translate"
2024-08-28 14:12:40:685 - [Chromedriver]         ],
2024-08-28 14:12:40:685 - [Chromedriver]         "androidDeviceSerial": "R5CT21L7E6E"
2024-08-28 14:12:40:685 - [Chromedriver]       },
2024-08-28 14:12:40:685 - [Chromedriver]       "goog:loggingPrefs": {
2024-08-28 14:12:40:685 - [Chromedriver]         "browser": "ALL"
2024-08-28 14:12:40:685 - [Chromedriver]       }
2024-08-28 14:12:40:685 - [Chromedriver]     }
2024-08-28 14:12:40:685 - [Chromedriver]   }
2024-08-28 14:12:40:685 - [Chromedriver] }
```

Note that the capabilities sent while creating a ChromeDriver session do not contain the logging preferences: `"performance": "ALL”` but only the default value `"browser": "ALL"`. This change fixes it in the Android appium driver. 

