### PR TITLE
feat: Add mobile wrappers to geolocation APIs

### DIFF
--- a/lib/commands/device/common.js
+++ b/lib/commands/device/common.js
@@ -1,7 +1,7 @@
 import semver from 'semver';
 import _ from 'lodash';
 import B from 'bluebird';
-import {resetMockLocation, setMockLocationApp} from '../geolocation';
+import {setMockLocationApp} from '../geolocation';
 import {SETTINGS_HELPER_ID} from 'io.appium.settings';
 import {hideKeyboardCompletely, initUnicodeKeyboard} from '../keyboard';
 import {
@@ -235,7 +235,7 @@ export async function initDevice() {
       if (mockLocationApp || _.isUndefined(mockLocationApp)) {
         await setMockLocationApp.bind(this)(mockLocationApp || SETTINGS_HELPER_ID);
       } else {
-        await resetMockLocation.bind(this)();
+        await this.mobileResetGeolocation();
       }
     })());
   }

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -99,6 +99,10 @@ export function mobileCommandsMapping() {
 
     getCurrentActivity: 'getCurrentActivity',
     getCurrentPackage: 'getCurrentPackage',
+
+    setGeolocation: 'mobileSetGeolocation',
+    getGeolocation: 'mobileGetGeolocation',
+    resetGeolocation: 'mobileResetGeolocation',
   };
 }
 

--- a/lib/commands/geolocation.js
+++ b/lib/commands/geolocation.js
@@ -36,6 +36,14 @@ export async function setGeoLocation(location) {
 }
 
 /**
+ * @this {import('../driver').AndroidDriver}
+ * @param {import('@appium/types').Location} opts
+ */
+export async function mobileSetGeolocation(opts) {
+  await this.settingsApp.setGeoLocation(opts, this.isEmulator());
+}
+
+/**
  * Sends an async request to refresh the GPS cache.
  *
  * This feature only works if the device under test has Google Play Services
@@ -66,6 +74,14 @@ export async function getGeoLocation() {
 
 /**
  * @this {import('../driver').AndroidDriver}
+ * @returns {Promise<import('@appium/types').Location>}
+ */
+export async function mobileGetGeolocation() {
+  return await this.getGeoLocation();
+}
+
+/**
+ * @this {import('../driver').AndroidDriver}
  * @returns {Promise<boolean>}
  */
 export async function isLocationServicesEnabled() {
@@ -84,6 +100,17 @@ export async function toggleLocationServices() {
       `The service is going to be ${isGpsEnabled ? 'disabled' : 'enabled'}`,
   );
   await this.adb.toggleGPSLocationProvider(!isGpsEnabled);
+}
+
+/**
+ * @this {import('../driver').AndroidDriver}
+ * @returns {Promise<void>}
+ */
+export async function mobileResetGeolocation() {
+  if (this.isEmulator()) {
+    throw new Error('Geolocation reset does not work on emulators');
+  }
+  await resetMockLocation.bind(this);
 }
 
 // #region Internal helpers
@@ -133,7 +160,7 @@ export async function setMockLocationApp(appId) {
  * @this {import('../driver').AndroidDriver}
  * @returns {Promise<void>}
  */
-export async function resetMockLocation() {
+async function resetMockLocation() {
   try {
     if ((await this.adb.getApiLevel()) < 23) {
       await this.adb.shell(['settings', 'put', 'secure', 'mock_location', '0']);

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -126,6 +126,9 @@ import {
   mobileRefreshGpsCache,
   toggleLocationServices,
   isLocationServicesEnabled,
+  mobileGetGeolocation,
+  mobileSetGeolocation,
+  mobileResetGeolocation,
 } from './commands/geolocation';
 import {
   performActions,
@@ -453,6 +456,9 @@ class AndroidDriver
   mobileRefreshGpsCache = mobileRefreshGpsCache;
   toggleLocationServices = toggleLocationServices;
   isLocationServicesEnabled = isLocationServicesEnabled;
+  mobileGetGeolocation = mobileGetGeolocation;
+  mobileSetGeolocation = mobileSetGeolocation;
+  mobileResetGeolocation = mobileResetGeolocation;
 
   performActions = performActions;
 


### PR DESCRIPTION
Geolocation methods are not part of the W3C API, so it makes sense to have mobile wrappers over them to let updated clients call these APIs