### PR TITLE
chore: use activateApp from adb

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -6,7 +6,6 @@ import {EOL} from 'node:os';
 import B from 'bluebird';
 
 const APP_EXTENSIONS = ['.apk', '.apks'];
-const RESOLVER_ACTIVITY_NAME = 'android/com.android.internal.app.ResolverActivity';
 const PACKAGE_INSTALL_TIMEOUT_MS = 90000;
 // These constants are in sync with
 // https://developer.apple.com/documentation/xctest/xcuiapplicationstate/xcuiapplicationstaterunningbackground?language=objc

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -80,6 +80,15 @@ export async function mobileQueryAppState(opts) {
 
 /**
  * @this {AndroidDriver}
+ * @param {string} appId
+ * @returns {Promise<void>}
+ */
+export async function activateApp(appId) {
+  return await this.adb.activateApp(appId);
+}
+
+/**
+ * @this {AndroidDriver}
  * @param {import('./types').ActivateAppOpts} opts
  * @returns {Promise<void>}
  */

--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -80,71 +80,12 @@ export async function mobileQueryAppState(opts) {
 
 /**
  * @this {AndroidDriver}
- * @param {string} appId
- * @returns {Promise<void>}
- */
-export async function activateApp(appId) {
-  this.log.debug(`Activating '${appId}'`);
-  const apiLevel = await this.adb.getApiLevel();
-  // Fallback to Monkey in older APIs
-  if (apiLevel < 24) {
-    // The monkey command could raise an issue as https://stackoverflow.com/questions/44860475/how-to-use-the-monkey-command-with-an-android-system-that-doesnt-have-physical
-    // but '--pct-syskeys 0' could cause another background process issue. https://github.com/appium/appium/issues/16941#issuecomment-1129837285
-    const cmd = ['monkey', '-p', appId, '-c', 'android.intent.category.LAUNCHER', '1'];
-    let output = '';
-    try {
-      output = await this.adb.shell(cmd);
-      this.log.debug(`Command stdout: ${output}`);
-    } catch (e) {
-      this.log.errorAndThrow(
-        `Cannot activate '${appId}'. Original error: ${/** @type {Error} */ (e).message}`,
-      );
-    }
-    if (output.includes('monkey aborted')) {
-      this.log.errorAndThrow(`Cannot activate '${appId}'. Are you sure it is installed?`);
-    }
-    return;
-  }
-
-  let activityName = await this.adb.resolveLaunchableActivity(appId);
-  if (activityName === RESOLVER_ACTIVITY_NAME) {
-    // https://github.com/appium/appium/issues/17128
-    this.log.debug(
-      `The launchable activity name of '${appId}' was resolved to '${activityName}'. ` +
-        `Switching the resolver to not use cmd`,
-    );
-    activityName = await this.adb.resolveLaunchableActivity(appId, {preferCmd: false});
-  }
-
-  const stdout = await this.adb.shell([
-    'am',
-    apiLevel < 26 ? 'start' : 'start-activity',
-    '-a',
-    'android.intent.action.MAIN',
-    '-c',
-    'android.intent.category.LAUNCHER',
-    // FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
-    // https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_NEW_TASK
-    // https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
-    '-f',
-    '0x10200000',
-    '-n',
-    activityName,
-  ]);
-  this.log.debug(stdout);
-  if (/^error:/im.test(stdout)) {
-    throw new Error(`Cannot activate '${appId}'. Original error: ${stdout}`);
-  }
-}
-
-/**
- * @this {AndroidDriver}
  * @param {import('./types').ActivateAppOpts} opts
  * @returns {Promise<void>}
  */
 export async function mobileActivateApp(opts) {
   const {appId} = requireArgs('appId', opts);
-  return await this.activateApp(appId);
+  return await this.adb.activateApp(appId);
 }
 
 /**
@@ -332,7 +273,7 @@ export async function background(seconds) {
   } else {
     try {
       this.log.debug(`Activating app '${appPackage}' in order to restore it`);
-      await this.activateApp(/** @type {string} */ (appPackage));
+      await this.adb.activateApp(/** @type {string} */ (appPackage));
       return true;
     } catch (ign) {}
     args =

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -81,7 +81,6 @@ import {
   mobileTerminateApp,
   terminateApp,
   removeApp,
-  activateApp,
   queryAppState,
   isAppInstalled,
 } from './commands/app-management';
@@ -409,7 +408,6 @@ class AndroidDriver
   mobileTerminateApp = mobileTerminateApp;
   terminateApp = terminateApp;
   removeApp = removeApp;
-  activateApp = activateApp;
   queryAppState = queryAppState;
   isAppInstalled = isAppInstalled;
 

--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -81,6 +81,7 @@ import {
   mobileTerminateApp,
   terminateApp,
   removeApp,
+  activateApp,
   queryAppState,
   isAppInstalled,
 } from './commands/app-management';
@@ -408,6 +409,7 @@ class AndroidDriver
   mobileTerminateApp = mobileTerminateApp;
   terminateApp = terminateApp;
   removeApp = removeApp;
+  activateApp = activateApp;
   queryAppState = queryAppState;
   isAppInstalled = isAppInstalled;
 

--- a/test/unit/commands/app-management-specs.js
+++ b/test/unit/commands/app-management-specs.js
@@ -119,12 +119,12 @@ describe('App Management', function () {
       sandbox.stub(driver.adb, 'getFocusedPackageAndActivity').returns({appPackage, appActivity});
       sandbox.stub(B, 'delay');
       sandbox.stub(driver.adb, 'startApp');
-      sandbox.stub(driver, 'activateApp');
+      sandbox.stub(driver.adb, 'activateApp');
       await driver.background(10);
       driver.adb.getFocusedPackageAndActivity.calledOnce.should.be.true;
       driver.adb.goToHome.calledOnce.should.be.true;
       B.delay.calledWithExactly(10000).should.be.true;
-      driver.activateApp.calledWithExactly(appPackage).should.be.true;
+      driver.adb.activateApp.calledWithExactly(appPackage).should.be.true;
       driver.adb.startApp.notCalled.should.be.true;
     });
     it('should bring app to background and back if started after session init', async function () {
@@ -154,13 +154,13 @@ describe('App Management', function () {
       sandbox.stub(driver.adb, 'getFocusedPackageAndActivity').returns({appPackage, appActivity});
       sandbox.stub(B, 'delay');
       sandbox.stub(driver.adb, 'startApp');
-      sandbox.stub(driver, 'activateApp');
+      sandbox.stub(driver.adb, 'activateApp');
       await driver.background(10);
       driver.adb.getFocusedPackageAndActivity.calledOnce.should.be.true;
       driver.adb.goToHome.calledOnce.should.be.true;
       B.delay.calledWithExactly(10000).should.be.true;
       driver.adb.startApp.calledWithExactly(params).should.be.true;
-      driver.activateApp.notCalled.should.be.true;
+      driver.adb.activateApp.notCalled.should.be.true;
     });
     it('should bring app to background and back if waiting for other pkg / activity', async function () {
       //eslint-disable-line
@@ -185,12 +185,12 @@ describe('App Management', function () {
         .returns({appPackage: appWaitPackage, appActivity: appWaitActivity});
       sandbox.stub(B, 'delay');
       sandbox.stub(driver.adb, 'startApp');
-      sandbox.stub(driver, 'activateApp');
+      sandbox.stub(driver.adb, 'activateApp');
       await driver.background(10);
       driver.adb.getFocusedPackageAndActivity.calledOnce.should.be.true;
       driver.adb.goToHome.calledOnce.should.be.true;
       B.delay.calledWithExactly(10000).should.be.true;
-      driver.activateApp.calledWithExactly(appWaitPackage).should.be.true;
+      driver.adb.activateApp.calledWithExactly(appWaitPackage).should.be.true;
       driver.adb.startApp.notCalled.should.be.true;
     });
     it('should not bring app back if seconds are negative', async function () {


### PR DESCRIPTION
It looks like... the same activateApp exists in https://github.com/appium/appium-adb/blob/74fb4f0a15f8e1c1db610aa633acf856877de209/lib/tools/apk-utils.js#L1180 so we can call the adb's one instead.