### PR TITLE
fix: Tune retrieval of package launch info

### DIFF
--- a/lib/commands/device/common.js
+++ b/lib/commands/device/common.js
@@ -1,13 +1,13 @@
 import semver from 'semver';
 import _ from 'lodash';
 import B from 'bluebird';
+import path from 'node:path';
 import {setMockLocationApp} from '../geolocation';
 import {SETTINGS_HELPER_ID} from 'io.appium.settings';
 import {hideKeyboardCompletely, initUnicodeKeyboard} from '../keyboard';
 import {
   createBaseADB,
   prepareEmulator,
-  validatePackageActivityNames,
   pushSettingsApp,
 } from './utils';
 import {adjustTimeZone} from '../time';
@@ -151,34 +151,34 @@ export async function createADB() {
  * @returns {Promise<import('../types').ADBLaunchInfo | undefined>}
  */
 export async function getLaunchInfo() {
-  if (!this.opts.app) {
-    this.log.warn('No app sent in, not parsing package/activity');
-    return;
-  }
-  let {appPackage, appActivity, appWaitPackage, appWaitActivity} = this.opts;
-  const {app} = this.opts;
-
-  validatePackageActivityNames.bind(this)();
-
-  if (appPackage && appActivity) {
+  let {appPackage, appActivity, appWaitPackage, appWaitActivity, app} = this.opts;
+  if (appPackage && appActivity || (!app && !appPackage)) {
     return;
   }
 
-  this.log.debug('Parsing package and activity from app manifest');
-  const {apkPackage, apkActivity} = await this.adb.packageAndLaunchActivityFromManifest(app);
+  let apkPackage;
+  let apkActivity;
+  if (app) {
+    this.log.debug(`Parsing package and activity from the '${path.basename(app)}' file manifest`);
+    ({apkPackage, apkActivity} = await this.adb.packageAndLaunchActivityFromManifest(app));
+  } else if (appPackage) {
+    this.log.debug(`Parsing activity from the installed '${appPackage}' package manifest`);
+    apkActivity = await this.adb.resolveLaunchableActivity(appPackage);
+  }
   if (apkPackage && !appPackage) {
     appPackage = apkPackage;
   }
   if (!appWaitPackage) {
     appWaitPackage = appPackage;
   }
+  this.log.debug(`Resolved launch package/activity: ${apkPackage}/${apkActivity}`);
   if (apkActivity && !appActivity) {
     appActivity = apkActivity;
   }
   if (!appWaitActivity) {
     appWaitActivity = appActivity;
   }
-  this.log.debug(`Parsed package and activity are: ${apkPackage}/${apkActivity}`);
+  this.log.debug(`Resolved wait package/activity: ${appWaitPackage}/${appWaitActivity}`);
   return {appPackage, appWaitPackage, appActivity, appWaitActivity};
 }
 

--- a/lib/commands/device/utils.js
+++ b/lib/commands/device/utils.js
@@ -26,33 +26,6 @@ export function requireEmulator(errMsg) {
 
 /**
  * @this {import('../../driver').AndroidDriver}
- * @returns {void}
- */
-export function validatePackageActivityNames() {
-  for (const key of ['appPackage', 'appActivity', 'appWaitPackage', 'appWaitActivity']) {
-    const name = this.opts[key];
-    if (!name) {
-      continue;
-    }
-
-    const match = /([^\w.*,])+/.exec(String(name));
-    if (!match) {
-      continue;
-    }
-
-    this.log.warn(
-      `Capability '${key}' is expected to only include latin letters, digits, underscore, dot, comma and asterisk characters.`,
-    );
-    this.log.warn(
-      `Current value '${name}' has non-matching character at index ${match.index}: '${String(
-        name,
-      ).substring(0, match.index + 1)}'`,
-    );
-  }
-}
-
-/**
- * @this {import('../../driver').AndroidDriver}
  * @param {string} networkSpeed
  * @returns {string}
  */


### PR DESCRIPTION
Currently a situation is possible when a session with noReset=true cap is started, where only appPackage is set and no appActivity. In such case the driver still tries to start the app like: `[8387f77e][AndroidUiautomator2Driver@17e6] Starting 'com.package/undefined and waiting for 'com.package/undefined'`, which obviously results into an error