### PR TITLE
Bump appium settings due to set location issue on Android 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [10.1.2](https://github.com/appium/appium-android-driver/compare/v10.1.1...v10.1.2) (2025-02-21)
+
+### Miscellaneous Chores
+
+* Bump appium-settings ([#210](https://github.com/appium/appium-android-driver/issues/210))
+
 ## [10.1.1](https://github.com/appium/appium-android-driver/compare/v10.1.0...v10.1.1) (2025-02-18)
 
 ### Miscellaneous Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-android-driver",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "description": "Android UiAutomator and Chrome support for Appium",
   "keywords": [
     "appium",
@@ -55,7 +55,7 @@
     "asyncbox": "^3.0.0",
     "axios": "^1.x",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^5.12.22",
+    "io.appium.settings": "^5.12.24",
     "lodash": "^4.17.4",
     "lru-cache": "^10.0.1",
     "moment": "^2.24.0",


### PR DESCRIPTION
There is a set location issue on Android 10 which becomes blocker when running mobile automation. Fix for the issue made on the appium-settings on this MR https://github.com/appium/io.appium.settings/pull/211. 
