### PR TITLE
feat: extend mobile: setGeoLocation

### DIFF
--- a/lib/commands/geolocation.js
+++ b/lib/commands/geolocation.js
@@ -36,16 +36,30 @@ export async function setGeoLocation(location) {
 }
 
 /**
+ * Set the device geolocation.
+ *
  * @this {import('../driver').AndroidDriver}
- * @param {number} latitude
- * @param {number} longitude
- * @param {number} [altitude]
+ * @param {number} latitude Valid latitude value.
+ * @param {number} longitude Valid longitude value.
+ * @param {number} [altitude] Valid altitude value.
+ * @param {number} [satellites] Number of satellites being tracked (1-12).
+ * @param {number} [speed] Valid speed value.
+ * https://developer.android.com/reference/android/location/Location#setSpeed(float)
+ * @param {number} [bearing] Valid bearing value.
+ * https://developer.android.com/reference/android/location/Location#setBearing(float)
+ * @param {number} [accuracy] Valid accuracy value.
+ * https://developer.android.com/reference/android/location/Location#setAccuracy(float),
+ * https://developer.android.com/reference/android/location/Criteria
  */
-export async function mobileSetGeolocation(latitude, longitude, altitude) {
+export async function mobileSetGeolocation(latitude, longitude, altitude, satellites, speed, bearing, accuracy) {
   await this.settingsApp.setGeoLocation({
     latitude,
     longitude,
     altitude,
+    satellites,
+    speed,
+    bearing,
+    accuracy
   }, this.isEmulator());
 }
 

--- a/lib/commands/geolocation.js
+++ b/lib/commands/geolocation.js
@@ -51,7 +51,15 @@ export async function setGeoLocation(location) {
  * https://developer.android.com/reference/android/location/Location#setAccuracy(float),
  * https://developer.android.com/reference/android/location/Criteria
  */
-export async function mobileSetGeolocation(latitude, longitude, altitude, satellites, speed, bearing, accuracy) {
+export async function mobileSetGeolocation(
+  latitude,
+  longitude,
+  altitude,
+  satellites,
+  speed,
+  bearing,
+  accuracy
+) {
   await this.settingsApp.setGeoLocation({
     latitude,
     longitude,

--- a/lib/commands/geolocation.js
+++ b/lib/commands/geolocation.js
@@ -42,12 +42,12 @@ export async function setGeoLocation(location) {
  * @param {number} latitude Valid latitude value.
  * @param {number} longitude Valid longitude value.
  * @param {number} [altitude] Valid altitude value.
- * @param {number} [satellites] Number of satellites being tracked (1-12).
+ * @param {number} [satellites] Number of satellites being tracked (1-12). Available for emulators.
  * @param {number} [speed] Valid speed value.
  * https://developer.android.com/reference/android/location/Location#setSpeed(float)
- * @param {number} [bearing] Valid bearing value.
+ * @param {number} [bearing] Valid bearing value. Available for real devices.
  * https://developer.android.com/reference/android/location/Location#setBearing(float)
- * @param {number} [accuracy] Valid accuracy value.
+ * @param {number} [accuracy] Valid accuracy value. Available for real devices.
  * https://developer.android.com/reference/android/location/Location#setAccuracy(float),
  * https://developer.android.com/reference/android/location/Criteria
  */

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -452,7 +452,7 @@ export const executeMethodMap = {
     command: 'mobileSetGeolocation',
     params: {
       required: ['latitude', 'longitude'],
-      optional: ['altitude'],
+      optional: ['altitude', 'satellites', 'speed', 'bearing', 'accuracy'],
     }
   },
   'mobile: getGeolocation': {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "asyncbox": "^3.0.0",
     "axios": "^1.x",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^5.12.24",
+    "io.appium.settings": "^5.14.0",
     "lodash": "^4.17.4",
     "lru-cache": "^10.0.1",
     "moment": "^2.24.0",


### PR DESCRIPTION
Ad'satellites', 'speed', 'bearing', 'accuracy' for the mobile command.
Validation will be done in the `this.settingsApp.setGeoLocation`