### PR TITLE
fix: get connectivity return value

### DIFF
--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -1,4 +1,4 @@
-import _, { result } from 'lodash';
+import _ from 'lodash';
 import {errors} from 'appium/driver';
 import {util} from 'appium/support';
 import B from 'bluebird';
@@ -120,7 +120,6 @@ export async function mobileGetConnectivity(services = SUPPORTED_SERVICE_NAMES) 
     ),
   };
   await B.all(_.values(statePromises));
-
   return _.reduce(
     statePromises,
     (state, v, k) => _.isUndefined(v.value()) ? state : {...state, [k]: Boolean(v.value())},

--- a/lib/commands/network.js
+++ b/lib/commands/network.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { result } from 'lodash';
 import {errors} from 'appium/driver';
 import {util} from 'appium/support';
 import B from 'bluebird';
@@ -97,7 +97,7 @@ export async function mobileSetConnectivity(wifi, data, airplaneMode) {
  */
 export async function mobileGetConnectivity(services = SUPPORTED_SERVICE_NAMES) {
   const svcs = _.castArray(services);
-  const unsupportedServices = _.difference(services, SUPPORTED_SERVICE_NAMES);
+  const unsupportedServices = _.difference(svcs, SUPPORTED_SERVICE_NAMES);
   if (!_.isEmpty(unsupportedServices)) {
     throw new errors.InvalidArgumentError(
       `${util.pluralize(
@@ -120,11 +120,12 @@ export async function mobileGetConnectivity(services = SUPPORTED_SERVICE_NAMES) 
     ),
   };
   await B.all(_.values(statePromises));
-  return {
-    wifi: Boolean(statePromises.wifi.value()),
-    data: Boolean(statePromises.data.value()),
-    airplaneMode: Boolean(statePromises.airplaneMode.value()),
-  };
+
+  return _.reduce(
+    statePromises,
+    (state, v, k) => _.isUndefined(v.value()) ? state : {...state, [k]: Boolean(v.value())},
+    {}
+  );
 }
 
 /**

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -245,15 +245,15 @@ export interface GetConnectivityResult {
   /**
    * True if wifi is enabled
    */
-  wifi: boolean;
+  wifi?: boolean;
   /**
    * True if mobile data connection is enabled
    */
-  data: boolean;
+  data?: boolean;
   /**
    * True if Airplane Mode is enabled
    */
-  airplaneMode: boolean;
+  airplaneMode?: boolean;
 }
 
 export type ServiceType = 'wifi' | 'data' | 'airplaneMode';

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -245,15 +245,15 @@ export interface GetConnectivityResult {
   /**
    * True if wifi is enabled
    */
-  wifi?: boolean;
+  wifi: boolean;
   /**
    * True if mobile data connection is enabled
    */
-  data?: boolean;
+  data: boolean;
   /**
    * True if Airplane Mode is enabled
    */
-  airplaneMode?: boolean;
+  airplaneMode: boolean;
 }
 
 export type ServiceType = 'wifi' | 'data' | 'airplaneMode';

--- a/test/unit/commands/network-specs.js
+++ b/test/unit/commands/network-specs.js
@@ -156,7 +156,7 @@ describe('Network', function () {
       await driver.mobileGetConnectivity(['data', 'airplaneMode'])
         .should.eventually.eql({ data: true, airplaneMode: false});
     });
-  })
+  });
   describe('toggleData', function () {
     it('should toggle data', async function () {
       adb.isDataOn.returns(false);

--- a/test/unit/commands/network-specs.js
+++ b/test/unit/commands/network-specs.js
@@ -3,6 +3,7 @@ import {ADB} from 'appium-adb';
 import {AndroidDriver} from '../../../lib/driver';
 import B from 'bluebird';
 import { SettingsApp } from 'io.appium.settings';
+import { errors } from 'appium/driver';
 
 /** @type {AndroidDriver} */
 let driver;
@@ -118,6 +119,44 @@ describe('Network', function () {
       driver.setDataState.calledWithExactly(true).should.be.true;
     });
   });
+  describe('mobileGetConnectivity', function () {
+    it('should raise unsupported services in string', async function () {
+      await driver.mobileGetConnectivity('bad')
+        .should.eventually.rejectedWith(errors.InvalidArgumentError);
+    });
+    it('should raise unsupported services in array', async function () {
+      await driver.mobileGetConnectivity(['bad', 'array'])
+        .should.eventually.rejectedWith(errors.InvalidArgumentError);
+    });
+    it('should return all supported services', async function () {
+      adb.isWifiOn.returns(true);
+      adb.isDataOn.returns(true);
+      adb.isAirplaneModeOn.returns(true);
+      await driver.mobileGetConnectivity()
+        .should.eventually.eql({ wifi: true, data: true, airplaneMode: true });
+    });
+    it('should return only wifi', async function () {
+      adb.isWifiOn.returns(true);
+      adb.isDataOn.returns(true);
+      adb.isAirplaneModeOn.returns(true);
+      await driver.mobileGetConnectivity('wifi')
+        .should.eventually.eql({ wifi: true });
+    });
+    it('should return only data', async function () {
+      adb.isWifiOn.returns(true);
+      adb.isDataOn.returns(true);
+      adb.isAirplaneModeOn.returns(true);
+      await driver.mobileGetConnectivity(['data'])
+        .should.eventually.eql({ data: true });
+    });
+    it('should return only data and airplaneMode', async function () {
+      adb.isWifiOn.returns(true);
+      adb.isDataOn.returns(true);
+      adb.isAirplaneModeOn.returns(false);
+      await driver.mobileGetConnectivity(['data', 'airplaneMode'])
+        .should.eventually.eql({ data: true, airplaneMode: false});
+    });
+  })
   describe('toggleData', function () {
     it('should toggle data', async function () {
       adb.isDataOn.returns(false);

--- a/test/unit/commands/network-specs.js
+++ b/test/unit/commands/network-specs.js
@@ -128,6 +128,9 @@ describe('Network', function () {
       await driver.mobileGetConnectivity(['bad', 'array'])
         .should.eventually.rejectedWith(errors.InvalidArgumentError);
     });
+    it('should raise unsupported services with an empty array', async function () {
+      await driver.mobileGetConnectivity().should.eventually.eql({});
+    });
     it('should return all supported services', async function () {
       adb.isWifiOn.returns(true);
       adb.isDataOn.returns(true);


### PR DESCRIPTION
Fixes https://github.com/appium/appium-uiautomator2-driver/issues/866

- mobile:getConnectivity accepts `string`
- mobile:getConnectivity wants to return only specified service/s

https://github.com/appium/appium-uiautomator2-driver?tab=readme-ov-file#mobile-getconnectivity