### PR TITLE
fix: add backgroundApp

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -413,6 +413,7 @@ class AndroidDriver
   activateApp = activateApp;
   queryAppState = queryAppState;
   isAppInstalled = isAppInstalled;
+  mobileBackgroundApp = background;
 
   mobileGetUiMode = mobileGetUiMode;
   mobileSetUiMode = mobileSetUiMode;

--- a/lib/execute-method-map.ts
+++ b/lib/execute-method-map.ts
@@ -174,7 +174,12 @@ export const executeMethodMap = {
       required: ['appId'],
     },
   },
-
+  'mobile: backgroundApp': {
+    command: 'mobileBackgroundApp',
+    params: {
+      optional: ['seconds'],
+    }
+  },
   'mobile: startService': {
     command: 'mobileStartService',
     params: {


### PR DESCRIPTION
Espresso driver missed this background app right now.

https://github.com/appium/appium-espresso-driver?tab=readme-ov-file#mobile-backgroundapp

Past implementation in espresso driver is the same as uia2's one, so this android driver can have it and both drivers refer to this.