### PR TITLE
feat: add /window/new endpoint call for chrome

### DIFF
--- a/lib/commands/context/exports.js
+++ b/lib/commands/context/exports.js
@@ -199,6 +199,18 @@ export async function setWindow(handle) {
 }
 
 /**
+ * Open a new tab/window in web view context (chrome)
+ * @param {string} type
+ * @returns {Promise<import('../types').CreateNewWindow>}
+ */
+export async function createNewWindow(type) {
+  if (!this.isWebContext()) {
+    throw new errors.NotImplementedError('Not implemented');
+  }
+  return await this.chromedriver.jwproxy.command('/window/new', 'POST', {type});
+}
+
+/**
  * Turn on proxying to an existing Chromedriver session or a new one
  *
  * @this {AndroidDriver}

--- a/lib/commands/types.ts
+++ b/lib/commands/types.ts
@@ -618,3 +618,8 @@ export interface InjectedImageProperties {
   position?: InjectedImagePosition;
   rotation?: InjectedImageRotation;
 }
+
+export interface CreateNewWindow {
+  handle: string;
+  type: string;
+}


### PR DESCRIPTION
Android Chrome can work with this. (chrome accept this endpoint for both, w3c and mjsonwp modes)

e.g:
selenium clients set the newly opened window as focused window after this response as part of their new window command (e.g. `driver.switch_to.new_window :tab` in ruby)

```
[4168ced8][HTTP] --> POST /session/4168ced8-3db2-4162-a55c-918ff0763cf8/window/new {"type":"tab"}
[4168ced8][AndroidUiautomator2Driver@32fa] Driver proxy active, passing request on via HTTP proxy
[4168ced8][Chromedriver@7a7e] Matched '/session/4168ced8-3db2-4162-a55c-918ff0763cf8/window/new' to command name 'createNewWindow'
[4168ced8][Chromedriver@7a7e] Proxying [POST /session/4168ced8-3db2-4162-a55c-918ff0763cf8/window/new] to [POST http://127.0.0.1:57902/session/ab2da835ac1b99fa67e42168244b33b2/window/new] with body: {"type":"tab"}
[4168ced8][Chromedriver@7a7e] Got response with status 200: {"value":{"handle":"F5F2FC602F2023378E24349D28D98E9E","type":"tab"}}
[4168ced8][HTTP] <-- POST /session/4168ced8-3db2-4162-a55c-918ff0763cf8/window/new 200 2282 ms - 68
[4168ced8][HTTP] --> POST /session/4168ced8-3db2-4162-a55c-918ff0763cf8/window {"handle":"F5F2FC602F2023378E24349D28D98E9E"}
[4168ced8][AndroidUiautomator2Driver@32fa] Driver proxy active, passing request on via HTTP proxy
[4168ced8][Chromedriver@7a7e] Matched '/session/4168ced8-3db2-4162-a55c-918ff0763cf8/window' to command name 'setWindow'
[4168ced8][Chromedriver@7a7e] Proxying [POST /session/4168ced8-3db2-4162-a55c-918ff0763cf8/window] to [POST http://127.0.0.1:57902/session/ab2da835ac1b99fa67e42168244b33b2/window] with body: {"handle":"F5F2FC602F2023378E24349D28D98E9E"}
[4168ced8][Chromedriver@7a7e] Got response with status 200: {"value":null}
[4168ced8][HTTP] <-- POST /session/4168ced8-3db2-4162-a55c-918ff0763cf8/window 200 357 ms - 14
```