### PR TITLE
feat: Add /session/:sessionId/network_connection to the method map

### DIFF
--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -164,4 +164,11 @@ export const newMethodMap = /** @type {const} */ ({
       payloadParams: {required: ['text']},
     },
   },
+  '/session/:sessionId/network_connection': {
+    GET: {command: 'getNetworkConnection'},
+    POST: {
+      command: 'setNetworkConnection',
+      payloadParams: {unwrap: 'parameters', required: ['type']},
+    },
+  },
 });


### PR DESCRIPTION
I'd like to deprecate this endpoint in the base driver as it is anyway only used in Android