### PR TITLE
chore: add deprecated: true for network_connection

### DIFF
--- a/lib/method-map.js
+++ b/lib/method-map.js
@@ -279,7 +279,10 @@ export const newMethodMap = /** @type {const} */ ({
     },
   },
   '/session/:sessionId/network_connection': {
-    GET: {command: 'getNetworkConnection'},
+    GET: {
+      command: 'getNetworkConnection',
+      deprecated: true
+    },
     POST: {
       command: 'setNetworkConnection',
       payloadParams: {unwrap: 'parameters', required: ['type']},


### PR DESCRIPTION
- `/session/:sessionId/network_connection`
    - `mobile: getConnectivity`


missed from https://github.com/appium/appium-android-driver/pull/995