### PR TITLE
chore: drop rimraf deps from dev deps as no references

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.0.1",
     "prettier": "^3.0.1",
-    "rimraf": "^5.0.0",
     "semantic-release": "^24.0.0",
     "sinon": "^21.0.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
```
kazu $ git grep 'rimraf'
CHANGELOG.md:* **deps-dev:** bump rimraf from 4.4.1 to 5.0.0 ([#794](https://github.com/appium/appium-android-driver/issues/794)) ([7ab3933](https://github.com/appium/appium-android-driver/commit/7ab39337b1190803d8bb064255570aa6b50d6c48))
CHANGELOG.md:* **deps-dev:** bump rimraf from 3.0.2 to 4.0.4 ([#783](https://github.com/appium/appium-android-driver/issues/783)) ([8f89741](https://github.com/appium/appium-android-driver/commit/8f89741d2cbba912b68ae533372dd8503db9eef1))
lib/commands/file-actions.js:    await fs.rimraf(tmpRoot);
lib/commands/geolocation.js:      await fs.rimraf(tmpRoot);
lib/commands/media-projection.js:    await fs.rimraf(path.dirname(recentRecordingPath));
lib/commands/recordscreen.js:      await this.adb.rimraf(record);
lib/commands/recordscreen.js:      await this.adb.rimraf(pathOnDevice);
lib/commands/recordscreen.js:    await fs.rimraf(tmpRoot);
lib/commands/resources.js:      await fs.rimraf(tmpRoot);
package.json:    "rimraf": "^5.0.0",
test/unit/commands/app-management-specs.js:      sandbox.stub(fs, 'rimraf').returns();
test/unit/commands/app-management-specs.js:      fs.rimraf.notCalled.should.be.true;
```

instead of https://github.com/appium/appium-android-driver/pull/950