### PR TITLE
feat: Update server compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@appium/support": "^6.0.0",
+    "@appium/support": "^7.0.0-rc.1",
     "@colors/colors": "^1.6.0",
-    "appium-adb": "^12.12.6",
-    "appium-chromedriver": "^7.0.6",
+    "appium-adb": "^13.0.0",
+    "appium-chromedriver": "^8.0.0",
     "asyncbox": "^3.0.0",
     "axios": "^1.x",
     "bluebird": "^3.4.7",
-    "io.appium.settings": "^5.14.8",
+    "io.appium.settings": "^6.0.0",
     "lodash": "^4.17.4",
     "lru-cache": "^10.0.1",
     "moment": "^2.24.0",
@@ -63,15 +63,15 @@
     "portscanner": "^2.2.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.x",
-    "teen_process": "^2.0.0",
+    "teen_process": "^3.0.0",
     "type-fest": "^4.4.0",
     "ws": "^8.0.0"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
-    "@appium/test-support": "^3.0.20",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/test-support": "^4.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.38",
@@ -81,10 +81,9 @@
     "@types/portscanner": "^2.1.1",
     "@types/semver": "^7.5.0",
     "@types/source-map-support": "^0.5.6",
-    "@types/teen_process": "^2.0.0",
     "@types/ws": "^8.5.4",
     "@xmldom/xmldom": "^0.x",
-    "android-apidemos": "^4.1.0",
+    "android-apidemos": "^5.0.0",
     "chai": "^5.1.1",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
@@ -97,11 +96,11 @@
     "xpath": "^0.x"
   },
   "peerDependencies": {
-    "appium": "^2.0.0 || ^3.0.0-beta.0"
+    "appium": "^3.0.0-rc.2"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   },
   "types": "./build/lib/index.d.ts"
 }


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10
BREAKING CHANGE: Required Appium server version has been bumped to >=3.0.0-rc.2