### PR TITLE
chore: Remove apkanalyzer from doctor checks

### DIFF
--- a/lib/doctor/checks.js
+++ b/lib/doctor/checks.js
@@ -123,7 +123,7 @@ export class AndroidSdkCheck {
   /** @type {import('@appium/types').AppiumLogger} */
   log;
 
-  TOOL_NAMES = ['adb', 'emulator', `apkanalyzer${system.isWindows() ? '.bat' : ''}`];
+  TOOL_NAMES = ['adb', 'emulator'];
 
   async diagnose() {
     const listOfTools = this.TOOL_NAMES.join(', ');


### PR DESCRIPTION
This script is not used by drivers anymore. It was needed in way older versions, but nowadays we just execute necessary jars directly without using additional wrappers