### PR TITLE
fix: fix isBoolean to true for recreateChromeDriverSessions

### DIFF
--- a/lib/constraints.ts
+++ b/lib/constraints.ts
@@ -143,7 +143,7 @@ export const ANDROID_DRIVER_CONSTRAINTS = {
     isBoolean: true,
   },
   recreateChromeDriverSessions: {
-    isBoolean: false,
+    isBoolean: true,
   },
   autoLaunch: {
     isBoolean: true,


### PR DESCRIPTION
Not sure why, but it looks like only this param set as `false` in long past refactoring.

Fixes https://github.com/appium/appium-uiautomator2-driver/issues/918


With this caps:

```
[04dc3dbd][ADB] Removing forwarded port socket connection: 10900
[04dc3dbd][ADB] Running '/Users/kazu/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 forward --remove tcp:10900'
[04dc3dbd][AndroidUiautomator2Driver@2a95] CDP data collection completed
[04dc3dbd][AndroidUiautomator2Driver@2a95] Available contexts: ["NATIVE_APP","CHROMIUM"]
[04dc3dbd][AndroidUiautomator2Driver@2a95] recreateChromeDriverSessions set to true; killing existing chromedrivers
[04dc3dbd][AndroidUiautomator2Driver@2a95] Stopping chromedriver for context CHROMIUM
[04dc3dbd][Chromedriver@dff7] Changed state to 'stopping'
```