### PR TITLE
refactor: use an object spread instead of Object.assign

### DIFF
--- a/lib/commands/app-management.js
+++ b/lib/commands/app-management.js
@@ -231,11 +231,10 @@ export async function mobileInstallApp(
   };
   if (checkVersion) {
     const localPath = await this.helpers.configureApp(appPath, APP_EXTENSIONS);
-    await this.adb.installOrUpgrade(localPath, null, Object.assign({}, {
-      appPath,
-      checkVersion,
+    await this.adb.installOrUpgrade(localPath, null, {
       ...opts,
-    }, {enforceCurrentBuild: false}));
+      enforceCurrentBuild: false,
+    });
     return;
   }
 

--- a/lib/commands/context/exports.js
+++ b/lib/commands/context/exports.js
@@ -93,7 +93,7 @@ export async function mobileGetContexts(waitForWebviewMs) {
  * @returns {string[]}
  */
 export function assignContexts(webviewsMapping) {
-  const opts = Object.assign({isChromeSession: this.isChromeSession}, this.opts);
+  const opts = { isChromeSession: this.isChromeSession, ...this.opts };
   const webviews = parseWebviewNames.bind(this)(webviewsMapping, opts);
   this.contexts = [NATIVE_WIN, ...webviews];
   this.log.debug(`Available contexts: ${JSON.stringify(this.contexts)}`);

--- a/lib/commands/context/helpers.js
+++ b/lib/commands/context/helpers.js
@@ -213,7 +213,7 @@ function createChromedriverCaps(opts, deviceId, webViewDetails) {
     );
     const newPref = {performance: 'ALL'};
     // don't overwrite other logging prefs that have been sent in if they exist
-    caps.loggingPrefs = caps.loggingPrefs ? Object.assign({}, caps.loggingPrefs, newPref) : newPref;
+    caps.loggingPrefs = caps.loggingPrefs ? { ...caps.loggingPrefs, ...newPref } : newPref;
   }
 
   if (opts.chromeOptions?.Arguments) {

--- a/test/unit/commands/app-management-specs.js
+++ b/test/unit/commands/app-management-specs.js
@@ -293,12 +293,12 @@ describe('App Management', function () {
         .onFirstCall()
         .returns({wasUninstalled: false, appState: 'sameVersionInstalled'});
       sandbox.stub(driver, 'resetAUT').onFirstCall();
-      await driver.installAUT(Object.assign({}, opts, {fastReset: true}));
+      await driver.installAUT({ ...opts, fastReset: true });
     });
     it('should reinstall app if full reset is set to true', async function () {
       sandbox.stub(driver.adb, 'installOrUpgrade').throws();
       sandbox.stub(driver, 'resetAUT').onFirstCall();
-      await driver.installAUT(Object.assign({}, opts, {fastReset: true, fullReset: true}));
+      await driver.installAUT({ ...opts, fastReset: true, fullReset: true });
     });
     it('should not run reset if the corresponding option is not set', async function () {
       sandbox.stub(driver.adb, 'installOrUpgrade')
@@ -314,7 +314,7 @@ describe('App Management', function () {
         .onFirstCall()
         .returns({wasUninstalled: false, appState: 'notInstalled'});
       sandbox.stub(driver, 'resetAUT').throws();
-      await driver.installAUT(Object.assign({}, opts, {fastReset: true}));
+      await driver.installAUT({ ...opts, fastReset: true });
     });
   });
   describe('installOtherApks', function () {


### PR DESCRIPTION
use an object spread instead of Object.assign to make it more concise and readable