### PR TITLE
chore: remove unused XML test dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@types/semver": "^7.5.0",
     "@types/sinon": "^21.0.1",
     "@types/ws": "^8.5.4",
-    "@xmldom/xmldom": "^0.x",
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
@@ -87,8 +86,7 @@
     "semantic-release": "^25.0.2",
     "sinon": "^22.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^6.0.2",
-    "xpath": "^0.x"
+    "typescript": "^6.0.2"
   },
   "peerDependencies": {
     "appium": "^3.0.0-rc.2"


### PR DESCRIPTION
  Remove unused dev dependencies:

  - `@xmldom/xmldom`
  - `xpath`

  These dependencies were originally added in bc67705 for the old source e2e test, where page source XML was parsed with `DOMParser` and queried with `xpath.select`.

  The last direct usage was removed in 042c2fe when the package was transformed into a library and the functional source e2e test was deleted. The dependencies remained in
  `package.json`, but there are no current direct imports or requires for either package.