### PR TITLE
ci: use shared PR title workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,14 +3,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-
 jobs:
   lint:
-    name: https://www.conventionalcommits.org
-    runs-on: ubuntu-latest
-    steps:
-      - uses: beemojs/conventional-pr-action@v3
-        with:
-          config-preset: angular
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: appium/appium-workflows/.github/workflows/pr-title.yml@main
+    with:
+      config-preset: angular


### PR DESCRIPTION
  ## Summary

  Use Appium's shared PR title workflow instead of invoking `beemojs/conventional-pr-action` directly.

  ## Details

  The current `pr-title` workflow uses `beemojs/conventional-pr-action@v3`, but it is failing due to the issue reported in
  https://github.com/beemojs/conventional-pr-action/issues/40.

  This updates the workflow to match the one used in `appium/appium`:

  https://github.com/appium/appium/blob/master/.github/workflows/pr-title.yml