### PR TITLE
feat: grant runtime permissions to the Chrome package (chromedriverGrantPermissions)

### DIFF
--- a/lib/commands/context/helpers.ts
+++ b/lib/commands/context/helpers.ts
@@ -320,7 +320,6 @@ export async function setupNewChromedriver(
           `resolved from the chromedriver capabilities, so runtime permissions cannot be granted`,
       );
     }
-    this.log.info(`Granting all runtime permissions to '${chromePkg}'`);
     await this.adb.grantAllPermissions(chromePkg);
   }
   const sessionCaps = await chromedriver.start(caps);

--- a/lib/commands/context/helpers.ts
+++ b/lib/commands/context/helpers.ts
@@ -274,10 +274,6 @@ export async function setupNewChromedriver(
     bundleId: (opts as any).chromeBundleId,
     useSystemExecutable: opts.chromedriverUseSystemExecutable,
     disableBuildCheck: opts.chromedriverDisableBuildCheck,
-    // Pre-grant Android runtime permissions to Chrome so the session is not blocked by a
-    // native permission dialog. Requires appium-chromedriver with the `grantPermissions`
-    // option (https://github.com/appium/appium-chromedriver/pull/587).
-    grantPermissions: opts.chromedriverGrantPermissions,
     details: details as any,
     isAutodownloadEnabled: isChromedriverAutodownloadEnabled.bind(this)(),
   };
@@ -313,6 +309,21 @@ export async function setupNewChromedriver(
   this.log.debug(
     `Before starting chromedriver, androidPackage is '${caps.chromeOptions.androidPackage}'`,
   );
+  // Optionally pre-grant all runtime permissions to the resolved Chrome package before Chrome
+  // is launched, so the session is not interrupted by a native permission dialog (geolocation,
+  // camera, file access, ...). Because the grant is requested explicitly, failures propagate.
+  if (opts.chromedriverGrantPermissions) {
+    const chromePkg = caps.chromeOptions?.androidPackage;
+    if (chromePkg) {
+      this.log.info(`Granting all runtime permissions to '${chromePkg}'`);
+      await this.adb.grantAllPermissions(chromePkg);
+    } else {
+      this.log.warn(
+        `'chromedriverGrantPermissions' is set but the Chrome package could not be resolved; ` +
+          `skipping the permission grant`,
+      );
+    }
+  }
   const sessionCaps = await chromedriver.start(caps);
   cacheChromedriverCaps.bind(this)(sessionCaps, context);
   return chromedriver;

--- a/lib/commands/context/helpers.ts
+++ b/lib/commands/context/helpers.ts
@@ -274,6 +274,10 @@ export async function setupNewChromedriver(
     bundleId: (opts as any).chromeBundleId,
     useSystemExecutable: opts.chromedriverUseSystemExecutable,
     disableBuildCheck: opts.chromedriverDisableBuildCheck,
+    // Pre-grant Android runtime permissions to Chrome so the session is not blocked by a
+    // native permission dialog. Requires appium-chromedriver with the `grantPermissions`
+    // option (https://github.com/appium/appium-chromedriver/pull/587).
+    grantPermissions: opts.chromedriverGrantPermissions,
     details: details as any,
     isAutodownloadEnabled: isChromedriverAutodownloadEnabled.bind(this)(),
   };

--- a/lib/commands/context/helpers.ts
+++ b/lib/commands/context/helpers.ts
@@ -314,15 +314,14 @@ export async function setupNewChromedriver(
   // camera, file access, ...). Because the grant is requested explicitly, failures propagate.
   if (opts.chromedriverGrantPermissions) {
     const chromePkg = caps.chromeOptions?.androidPackage;
-    if (chromePkg) {
-      this.log.info(`Granting all runtime permissions to '${chromePkg}'`);
-      await this.adb.grantAllPermissions(chromePkg);
-    } else {
-      this.log.warn(
-        `'chromedriverGrantPermissions' is set but the Chrome package could not be resolved; ` +
-          `skipping the permission grant`,
+    if (!chromePkg) {
+      throw new Error(
+        `'chromedriverGrantPermissions' is enabled but the Chrome package name could not be ` +
+          `resolved from the chromedriver capabilities, so runtime permissions cannot be granted`,
       );
     }
+    this.log.info(`Granting all runtime permissions to '${chromePkg}'`);
+    await this.adb.grantAllPermissions(chromePkg);
   }
   const sessionCaps = await chromedriver.start(caps);
   cacheChromedriverCaps.bind(this)(sessionCaps, context);

--- a/lib/constraints.ts
+++ b/lib/constraints.ts
@@ -111,6 +111,9 @@ export const ANDROID_DRIVER_CONSTRAINTS = {
   chromedriverDisableBuildCheck: {
     isBoolean: true,
   },
+  chromedriverGrantPermissions: {
+    // boolean (grant a default set) or an array of `android.permission.*` names
+  },
   chromeLoggingPrefs: {
     isObject: true,
   },

--- a/lib/constraints.ts
+++ b/lib/constraints.ts
@@ -112,7 +112,7 @@ export const ANDROID_DRIVER_CONSTRAINTS = {
     isBoolean: true,
   },
   chromedriverGrantPermissions: {
-    // boolean (grant a default set) or an array of `android.permission.*` names
+    isBoolean: true,
   },
   chromeLoggingPrefs: {
     isObject: true,

--- a/test/unit/commands/context-specs.ts
+++ b/test/unit/commands/context-specs.ts
@@ -224,6 +224,14 @@ describe('Context', function () {
       await driver.startChromedriverProxy('WEBVIEW_1', []);
       expect(grantStub.called).to.be.false;
     });
+    it('should throw when chromedriverGrantPermissions is set but the Chrome package cannot be resolved', async function () {
+      driver.opts.chromedriverGrantPermissions = true;
+      const grantStub = sandbox.stub(driver.adb, 'grantAllPermissions').resolves();
+      await expect(driver.startChromedriverProxy('WEBVIEW_1', [])).to.be.rejectedWith(
+        /could not be resolved/,
+      );
+      expect(grantStub.called).to.be.false;
+    });
     it('should handle chromedriver event with STATE_STOPPED state', async function () {
       await driver.startChromedriverProxy('WEBVIEW_1', []);
       driver.chromedriver!.emit(Chromedriver.EVENT_CHANGED, {

--- a/test/unit/commands/context-specs.ts
+++ b/test/unit/commands/context-specs.ts
@@ -211,6 +211,19 @@ describe('Context', function () {
         (driver.chromedriver?.start as sinon.SinonStub).getCall(0).args[0].chromeOptions,
       ).to.deep.include({androidPackage: 'pkg'});
     });
+    it('should grant all runtime permissions to the Chrome package when chromedriverGrantPermissions is set', async function () {
+      driver.opts.appPackage = 'com.pkg';
+      driver.opts.chromedriverGrantPermissions = true;
+      const grantStub = sandbox.stub(driver.adb, 'grantAllPermissions').resolves();
+      await driver.startChromedriverProxy('WEBVIEW_1', []);
+      expect(grantStub.calledOnceWithExactly('com.pkg')).to.be.true;
+    });
+    it('should not grant permissions when chromedriverGrantPermissions is not set', async function () {
+      driver.opts.appPackage = 'com.pkg';
+      const grantStub = sandbox.stub(driver.adb, 'grantAllPermissions').resolves();
+      await driver.startChromedriverProxy('WEBVIEW_1', []);
+      expect(grantStub.called).to.be.false;
+    });
     it('should handle chromedriver event with STATE_STOPPED state', async function () {
       await driver.startChromedriverProxy('WEBVIEW_1', []);
       driver.chromedriver!.emit(Chromedriver.EVENT_CHANGED, {


### PR DESCRIPTION
## Problem

On Android, Chrome interrupts an automated web session with a **native runtime-permission dialog** the first time a page uses geolocation, the camera (`getUserMedia`), or file download/upload. That dialog is a native OS prompt, not web content, so it can't be dismissed via the automation session and the session stalls.

## Fix

Add a `chromedriverGrantPermissions` capability. When set, `setupNewChromedriver` grants **all** runtime permissions to the **resolved** Chrome package (via `adb.grantAllPermissions`) **before** Chrome is launched, so they take effect for the session without a restart. Because the package is resolved by the driver, it covers the beta/dev/canary variants in `KNOWN_CHROME_PACKAGE_NAMES`, not just `com.android.chrome`.

The grant lives in appium-android-driver (which already owns app-permission handling and resolves the Chrome package) rather than in appium-chromedriver — per the review discussion on appium/appium-chromedriver#587, keeping chromedriver focused on browser interactions and Android-specific setup here. That chromedriver PR is now closed in favour of this approach; this PR has **no dependency** on it.

Since the grant is opt-in/explicit, a failure propagates rather than being swallowed.

## How tested

- New unit tests in `test/unit/commands/context-specs.ts`: grants to the resolved package when the cap is set; no grant when it isn't.
- `npm run build`, `npm run lint` pass; the context unit specs pass (44 passing).

## How it fixes the issue

With the permissions pre-granted before Chrome launches, the native permission dialog never appears, so geolocation/camera/file-access web tests run without manual interaction.
