### PR TITLE
fix: prefer chromedriverPorts pool over single chromedriverPort when both are set

### DIFF
--- a/lib/commands/context/helpers.ts
+++ b/lib/commands/context/helpers.ts
@@ -248,7 +248,17 @@ export async function setupNewChromedriver(
     opts.chromedriverPort = (opts as any).chromeDriverPort;
   }
 
-  if (opts.chromedriverPort) {
+  if (opts.chromedriverPort && opts.chromedriverPorts) {
+    // If both the single 'chromedriverPort' and the 'chromedriverPorts' pool are provided, prefer
+    // the pool. Otherwise the explicitly configured range would be silently bypassed by the single
+    // port, which is surprising and makes it impossible to guarantee a per-session port is picked
+    // from the pool (e.g. when several parallel sessions share the same host).
+    this.log.info(
+      `Both 'chromedriverPort' (${opts.chromedriverPort}) and 'chromedriverPorts' were provided; ` +
+        `preferring a free port from the 'chromedriverPorts' pool and ignoring 'chromedriverPort'`,
+    );
+    opts.chromedriverPort = await getChromedriverPort.bind(this)(opts.chromedriverPorts);
+  } else if (opts.chromedriverPort) {
     this.log.debug(`Using user-specified port ${opts.chromedriverPort} for chromedriver`);
   } else {
     // if a single port wasn't given, we'll look for a free one


### PR DESCRIPTION
### Problem
`setupNewChromedriver` resolves the chromedriver port like this:

```ts
if (opts.chromedriverPort) {
  // use the single port
} else {
  opts.chromedriverPort = await getChromedriverPort(opts.chromedriverPorts);
}
```

If a caller provides **both** the single `chromedriverPort` and the `chromedriverPorts`
pool/range, the single port wins and the configured pool is silently ignored. There is then
no way to guarantee that a session picks a free port from the pool — which matters when
several parallel sessions run against the same host and rely on the pool to avoid collisions.

### Fix
When both are provided, prefer a free port from the `chromedriverPorts` pool and log that the
single `chromedriverPort` is being ignored. Behavior is unchanged when only one of the two is set:
- only `chromedriverPort` → use it (as before)
- only `chromedriverPorts` → pick from the pool (as before)
- neither → pick any free port (as before)

### Notes
- Small, self-contained change in `setupNewChromedriver`; no capability/schema changes.
- Happy to add a unit test for the precedence if maintainers prefer.
