### PR TITLE
feat: add skipSettingsAppInstall capability to skip installing the Settings helper app

### DIFF
--- a/lib/commands/device/common.ts
+++ b/lib/commands/device/common.ts
@@ -198,6 +198,7 @@ export async function getLaunchInfo(this: AndroidDriver): Promise<ADBLaunchInfo 
 export async function initDevice(this: AndroidDriver): Promise<void> {
   const {
     skipDeviceInitialization,
+    skipSettingsAppInstall,
     locale,
     language,
     localeScript,
@@ -225,16 +226,24 @@ export async function initDevice(this: AndroidDriver): Promise<void> {
     // Some feature such as location/wifi are not necessary for all users,
     // but they require the settings app. So, try to configure it while Appium
     // does not throw error even if they fail.
-    const shouldThrowError = Boolean(
-      language ||
-      locale ||
-      localeScript ||
-      unicodeKeyboard ||
-      hideKeyboard ||
-      disableWindowAnimation ||
-      !skipUnlock,
-    );
-    await pushSettingsApp.bind(this)(shouldThrowError);
+    if (skipSettingsAppInstall) {
+      this.log.info(
+        `'skipSettingsAppInstall' is set. Skipping installation of the Appium Settings helper app. ` +
+          `Capabilities and features that depend on it (locale/language, IME/keyboard handling, ` +
+          `geolocation mocking, window animation control, unlock) may be unavailable.`,
+      );
+    } else {
+      const shouldThrowError = Boolean(
+        language ||
+        locale ||
+        localeScript ||
+        unicodeKeyboard ||
+        hideKeyboard ||
+        disableWindowAnimation ||
+        !skipUnlock,
+      );
+      await pushSettingsApp.bind(this)(shouldThrowError);
+    }
   }
 
   const setupPromises: Promise<void>[] = [];

--- a/lib/commands/device/common.ts
+++ b/lib/commands/device/common.ts
@@ -198,7 +198,7 @@ export async function getLaunchInfo(this: AndroidDriver): Promise<ADBLaunchInfo 
 export async function initDevice(this: AndroidDriver): Promise<void> {
   const {
     skipDeviceInitialization,
-    skipSettingsAppInstall,
+    skipSettingsAppReinstall,
     locale,
     language,
     localeScript,
@@ -226,11 +226,19 @@ export async function initDevice(this: AndroidDriver): Promise<void> {
     // Some feature such as location/wifi are not necessary for all users,
     // but they require the settings app. So, try to configure it while Appium
     // does not throw error even if they fail.
-    if (skipSettingsAppInstall) {
+    if (skipSettingsAppReinstall) {
+      // The Settings helper app is host-managed/pinned here, so do not (re)install it.
+      // Device init and mock-location below depend on it, so require it to be present
+      // and fail fast with a clear error rather than letting those steps break opaquely.
+      if (!(await this.adb.isAppInstalled(SETTINGS_HELPER_ID))) {
+        throw new Error(
+          `'skipSettingsAppReinstall' is set, but the Appium Settings helper app ` +
+            `('${SETTINGS_HELPER_ID}') is not installed on the device. Install it during ` +
+            `device provisioning, or unset the capability to let the driver install it.`,
+        );
+      }
       this.log.info(
-        `'skipSettingsAppInstall' is set. Skipping installation of the Appium Settings helper app. ` +
-          `Capabilities and features that depend on it (locale/language, IME/keyboard handling, ` +
-          `geolocation mocking, window animation control, unlock) may be unavailable.`,
+        `'skipSettingsAppReinstall' is set; using the already-installed Appium Settings helper app as-is.`,
       );
     } else {
       const shouldThrowError = Boolean(

--- a/lib/constraints.ts
+++ b/lib/constraints.ts
@@ -212,7 +212,7 @@ export const ANDROID_DRIVER_CONSTRAINTS = {
   skipDeviceInitialization: {
     isBoolean: true,
   },
-  skipSettingsAppInstall: {
+  skipSettingsAppReinstall: {
     isBoolean: true,
   },
   remoteAppsCacheLimit: {

--- a/lib/constraints.ts
+++ b/lib/constraints.ts
@@ -212,6 +212,9 @@ export const ANDROID_DRIVER_CONSTRAINTS = {
   skipDeviceInitialization: {
     isBoolean: true,
   },
+  skipSettingsAppInstall: {
+    isBoolean: true,
+  },
   remoteAppsCacheLimit: {
     isNumber: true,
   },

--- a/test/unit/commands/device-specs.ts
+++ b/test/unit/commands/device-specs.ts
@@ -504,5 +504,32 @@ describe('Device Helpers', function () {
         .onFirstCall();
       await driver.initDevice();
     });
+    it('should not reinstall the Settings app when skipSettingsAppReinstall is set and the app is present', async function () {
+      const driver = new AndroidDriver();
+      driver.adb = new ADB();
+      driver.opts = {skipSettingsAppReinstall: true} as any;
+      sandbox.stub(driver.adb, 'waitForDevice').throws();
+      sandbox.stub(driver.adb, 'startLogcat').onFirstCall();
+      sandbox.stub(driver.adb, 'isAppInstalled').withArgs('io.appium.settings').resolves(true);
+      const pushStub = sandbox.stub(deviceUtils, 'pushSettingsApp');
+      sandbox.stub(driver, 'ensureDeviceLocale').throws();
+      sandbox
+        .stub(geolocationHelpers, 'setMockLocationApp')
+        .withArgs('io.appium.settings')
+        .onFirstCall();
+      await driver.initDevice();
+      expect(pushStub.called).to.be.false;
+    });
+    it('should throw if skipSettingsAppReinstall is set but the Settings app is not installed', async function () {
+      const driver = new AndroidDriver();
+      driver.adb = new ADB();
+      driver.opts = {skipSettingsAppReinstall: true} as any;
+      sandbox.stub(driver.adb, 'waitForDevice').throws();
+      sandbox.stub(driver.adb, 'startLogcat').onFirstCall();
+      sandbox.stub(driver.adb, 'isAppInstalled').withArgs('io.appium.settings').resolves(false);
+      const pushStub = sandbox.stub(deviceUtils, 'pushSettingsApp');
+      await expect(driver.initDevice()).to.be.rejectedWith(/not installed/);
+      expect(pushStub.called).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
### Problem
`initDevice` unconditionally installs the Appium Settings helper app via `pushSettingsApp`:

```ts
const shouldThrowError = Boolean(language || locale || ... || !skipUnlock);
await pushSettingsApp.bind(this)(shouldThrowError);
```

Some environments already provision the Settings helper app as part of a managed device
image / device farm. In those setups, re-pushing it on every session is redundant work and
can be undesirable (extra installs, timing, or immutable-image constraints).

There is already `skipDeviceInitialization` to skip the whole init block, but that is too
coarse — it also skips locale/logcat/geolocation setup. There is no way to keep device
initialization while skipping *only* the Settings app install.

### Fix
Add an opt-in boolean capability **`skipSettingsAppInstall`**. When set, `initDevice` skips the
`pushSettingsApp` call and logs that Settings-app-dependent features may be unavailable. All
other initialization still runs.

- Defaults to `false` → **no behavior change** for existing users.
- Follows the existing capability pattern in this driver (e.g. `chromedriverGrantPermissions`,
  `skipDeviceInitialization`).

### Changes
- `lib/constraints.ts`: add `skipSettingsAppInstall: { isBoolean: true }`.
- `lib/commands/device/common.ts`: guard the `pushSettingsApp` call with the new capability.

### Notes
- Happy to add docs and a unit test if maintainers are on board with the capability.
